### PR TITLE
Fix MongoClientURI wtimeoutMS support

### DIFF
--- a/src/main/com/mongodb/MongoClientURI.java
+++ b/src/main/com/mongodb/MongoClientURI.java
@@ -284,7 +284,7 @@ public class MongoClientURI {
 
         writeConcernKeys.add("safe");
         writeConcernKeys.add("w");
-        writeConcernKeys.add("wtimeout");
+        writeConcernKeys.add("wtimeoutms");
         writeConcernKeys.add("fsync");
         writeConcernKeys.add("j");
 
@@ -370,7 +370,7 @@ public class MongoClientURI {
                 safe = _parseBoolean(value);
             } else if (key.equals("w")) {
                 w = value;
-            } else if (key.equals("wtimeout")) {
+            } else if (key.equals("wtimeoutms")) {
                 wTimeout = Integer.parseInt(value);
             } else if (key.equals("fsync")) {
                 fsync = _parseBoolean(value);
@@ -488,6 +488,11 @@ public class MongoClientURI {
                 valueList.add(value);
                 optionsMap.put(key, valueList);
             }
+        }
+
+        // JAVA-943 handle legacy wtimeout settings
+        if (optionsMap.containsKey("wtimeout") && !optionsMap.containsKey("wtimeoutms")) {
+            optionsMap.put("wtimeoutms", optionsMap.remove("wtimeout"));
         }
 
         return optionsMap;

--- a/src/test/com/mongodb/MongoClientURITest.java
+++ b/src/test/com/mongodb/MongoClientURITest.java
@@ -168,7 +168,7 @@ public class MongoClientURITest {
         MongoClientURI uri = new MongoClientURI("mongodb://localhost");
         assertEquals(WriteConcern.ACKNOWLEDGED, uri.getOptions().getWriteConcern());
 
-        uri = new MongoClientURI("mongodb://localhost/?wTimeout=5");
+        uri = new MongoClientURI("mongodb://localhost/?wtimeoutMS=5");
         assertEquals(new WriteConcern(1, 5, false, false), uri.getOptions().getWriteConcern());
 
         uri = new MongoClientURI("mongodb://localhost/?fsync=true");
@@ -177,10 +177,10 @@ public class MongoClientURITest {
         uri = new MongoClientURI("mongodb://localhost/?j=true");
         assertEquals(new WriteConcern(1, 0, false, true), uri.getOptions().getWriteConcern());
 
-        uri = new MongoClientURI("mongodb://localhost/?w=2&wtimeout=5&fsync=true&j=true");
+        uri = new MongoClientURI("mongodb://localhost/?w=2&wtimeoutMS=5&fsync=true&j=true");
         assertEquals(new WriteConcern(2, 5, true, true), uri.getOptions().getWriteConcern());
 
-        uri = new MongoClientURI("mongodb://localhost/?w=majority&wtimeout=5&fsync=true&j=true");
+        uri = new MongoClientURI("mongodb://localhost/?w=majority&wtimeoutMS=5&fsync=true&j=true");
         assertEquals(new WriteConcern("majority", 5, true, true), uri.getOptions().getWriteConcern());
 
         uri = new MongoClientURI("mongodb://localhost/?safe=true");
@@ -188,7 +188,24 @@ public class MongoClientURITest {
 
         uri = new MongoClientURI("mongodb://localhost/?safe=false");
         assertEquals(WriteConcern.UNACKNOWLEDGED, uri.getOptions().getWriteConcern());
+    }
 
+    @Test()
+    public void testWriteConcernLegacyWtimeout() {
+        MongoClientURI uri = new MongoClientURI("mongodb://localhost");
+        assertEquals(WriteConcern.ACKNOWLEDGED, uri.getOptions().getWriteConcern());
+
+        uri = new MongoClientURI("mongodb://localhost/?wtimeout=5");
+        assertEquals(new WriteConcern(1, 5, false, false), uri.getOptions().getWriteConcern());
+
+        uri = new MongoClientURI("mongodb://localhost/?wtimeout=1&wtimeoutms=5");
+        assertEquals(new WriteConcern(1, 5, false, false), uri.getOptions().getWriteConcern());
+
+        uri = new MongoClientURI("mongodb://localhost/?w=2&wtimeout=5&fsync=true&j=true");
+        assertEquals(new WriteConcern(2, 5, true, true), uri.getOptions().getWriteConcern());
+
+        uri = new MongoClientURI("mongodb://localhost/?w=majority&wtimeout=5&fsync=true&j=true");
+        assertEquals(new WriteConcern("majority", 5, true, true), uri.getOptions().getWriteConcern());
     }
 
     @Test


### PR DESCRIPTION
Still handles `wtimeout` in the URI
If both `wtimeout` and `wtimeoutMS` in the URI `wtimeoutMS` is used.

JAVA-943
