### PR TITLE
Fix DBCursor#tryNext support for curr() and numSeen()

### DIFF
--- a/driver/src/main/com/mongodb/DBCursor.java
+++ b/driver/src/main/com/mongodb/DBCursor.java
@@ -186,8 +186,7 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
             }
             cursor = executor.execute(operation, getReadPreferenceForCursor());
         }
-
-        return cursor.tryNext();
+        return currentObject(cursor.tryNext());
     }
 
 
@@ -817,14 +816,19 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
             checkCursorType(CursorType.ITERATOR);
         }
 
-        currentObject = cursor.next();
-        numSeen++;
+        return currentObject(cursor.next());
+    }
 
-        if (findOptions.getProjection() != null && !((BsonDocument) findOptions.getProjection()).isEmpty()) {
-            currentObject.markAsPartialObject();
+    private DBObject currentObject(final DBObject newCurrentObject){
+        if (newCurrentObject != null) {
+            currentObject = newCurrentObject;
+            numSeen++;
+
+            if (findOptions.getProjection() != null && !((BsonDocument) findOptions.getProjection()).isEmpty()) {
+                currentObject.markAsPartialObject();
+            }
         }
-
-        return currentObject;
+        return newCurrentObject;
     }
 
     private static DBObject lookupSuitableHints(final DBObject query, final List<DBObject> hints) {

--- a/driver/src/test/legacy/com/mongodb/DBCursorOldTest.java
+++ b/driver/src/test/legacy/com/mongodb/DBCursorOldTest.java
@@ -120,12 +120,21 @@ public class DBCursorOldTest extends DatabaseTestCase {
         c.save(firstDBObject, WriteConcern.SAFE);
 
         assertEquals(firstDBObject, cur.tryNext());
+        assertEquals(firstDBObject, cur.curr());
+        assertEquals(1, cur.numSeen());
+
         assertEquals(null, cur.tryNext());
-        assertEquals(null, cur.tryNext());
+        assertEquals(firstDBObject, cur.curr());
+        assertEquals(1, cur.numSeen());
 
         c.save(secondDBObject, WriteConcern.SAFE);
         assertEquals(secondDBObject, cur.tryNext());
+        assertEquals(secondDBObject, cur.curr());
+        assertEquals(2, cur.numSeen());
+
         assertEquals(null, cur.tryNext());
+        assertEquals(secondDBObject, cur.curr());
+        assertEquals(2, cur.numSeen());
     }
 
     @Test
@@ -342,6 +351,22 @@ public class DBCursorOldTest extends DatabaseTestCase {
         cur = collection.find(q).batchSize(-20).limit(100);
         assertEquals(0, cur.getCursorId());
         assertEquals(20, cur.itcount());
+    }
+
+    @Test
+    public void testCurrentObjectAndNumSeen() {
+        for (int i = 1; i < 100; i++) {
+            collection.save(new BasicDBObject("x", i));
+        }
+
+        DBCursor cur = collection.find().sort(new BasicDBObject("x", 1));
+        while (cur.hasNext()) {
+            DBObject current = cur.next();
+            int num = (Integer) current.get("x");
+
+            assertEquals(current, cur.curr());
+            assertEquals(num, cur.numSeen());
+        }
     }
 
     @Test


### PR DESCRIPTION
Missed in JAVA-1255
