### PR TITLE
Added batchCursor method to the async MongoIterable

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/AwaitingWriteOperationIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/AwaitingWriteOperationIterable.java
@@ -3,6 +3,7 @@ package com.mongodb.async.client;
 import com.mongodb.Block;
 import com.mongodb.Function;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.operation.AsyncBatchCursor;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.AsyncWriteOperation;
 
@@ -121,5 +122,33 @@ class AwaitingWriteOperationIterable<T, W> implements MongoIterable<T> {
     @Override
     public <U> MongoIterable<U> map(final Function<T, U> mapper) {
         return new MappingIterable<T, U>(this, mapper);
+    }
+
+    @Override
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+        boolean localWriteCompleted;
+
+        synchronized (this) {
+            localWriteCompleted = writeCompleted;
+            if (!localWriteCompleted) {
+                callbacks.add(new SingleResultCallback<Void>() {
+                    @Override
+                    public void onResult(final Void result, final Throwable t) {
+                        if (t != null) {
+                            callback.onResult(null, t);
+                        } else {
+                            delegated.batchCursor(callback);
+                        }
+                    }
+                });
+            }
+        }
+        if (localWriteCompleted) {
+            if (thrown != null) {
+                callback.onResult(null, thrown);
+            } else {
+                delegated.batchCursor(callback);
+            }
+        }
     }
 }

--- a/driver-async/src/main/com/mongodb/async/client/FindFluentImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/FindFluentImpl.java
@@ -23,6 +23,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.client.model.FindOptions;
+import com.mongodb.operation.AsyncBatchCursor;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.FindOperation;
 import org.bson.BsonDocument;
@@ -148,6 +149,11 @@ class FindFluentImpl<T> implements FindFluent<T> {
     @Override
     public <U> MongoIterable<U> map(final Function<T, U> mapper) {
         return execute().map(mapper);
+    }
+
+    @Override
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+        execute().batchCursor(callback);
     }
 
     private MongoIterable<T> execute() {

--- a/driver-async/src/main/com/mongodb/async/client/ListCollectionsFluentImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListCollectionsFluentImpl.java
@@ -20,6 +20,7 @@ import com.mongodb.Block;
 import com.mongodb.Function;
 import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.operation.AsyncBatchCursor;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.ListCollectionsOperation;
 import org.bson.BsonDocument;
@@ -91,6 +92,11 @@ final class ListCollectionsFluentImpl<T> implements ListCollectionsFluent<T> {
     @Override
     public <U> MongoIterable<U> map(final Function<T, U> mapper) {
         return execute().map(mapper);
+    }
+
+    @Override
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+        execute().batchCursor(callback);
     }
 
     private MongoIterable<T> execute() {

--- a/driver-async/src/main/com/mongodb/async/client/ListDatabasesFluentImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListDatabasesFluentImpl.java
@@ -20,6 +20,7 @@ import com.mongodb.Block;
 import com.mongodb.Function;
 import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.operation.AsyncBatchCursor;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.ListDatabasesOperation;
 import org.bson.codecs.Codec;
@@ -72,6 +73,11 @@ final class ListDatabasesFluentImpl<T> implements ListDatabasesFluent<T> {
     @Override
     public <U> MongoIterable<U> map(final Function<T, U> mapper) {
         return execute().map(mapper);
+    }
+
+    @Override
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+        execute().batchCursor(callback);
     }
 
     private MongoIterable<T> execute() {

--- a/driver-async/src/main/com/mongodb/async/client/ListIndexesFluentImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListIndexesFluentImpl.java
@@ -21,6 +21,7 @@ import com.mongodb.Function;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.operation.AsyncBatchCursor;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.ListIndexesOperation;
 import org.bson.codecs.Codec;
@@ -82,6 +83,11 @@ final class ListIndexesFluentImpl<T> implements ListIndexesFluent<T> {
     @Override
     public <U> MongoIterable<U> map(final Function<T, U> mapper) {
         return execute().map(mapper);
+    }
+
+    @Override
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+        execute().batchCursor(callback);
     }
 
     private MongoIterable<T> execute() {

--- a/driver-async/src/main/com/mongodb/async/client/MappingAsyncBatchCursor.java
+++ b/driver-async/src/main/com/mongodb/async/client/MappingAsyncBatchCursor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.async.client;
+
+import com.mongodb.Function;
+import com.mongodb.async.SingleResultCallback;
+import com.mongodb.operation.AsyncBatchCursor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class MappingAsyncBatchCursor<T, U> implements AsyncBatchCursor<U> {
+
+    private final AsyncBatchCursor<T> batchCursor;
+    private final Function<T, U> mapper;
+
+    MappingAsyncBatchCursor(final AsyncBatchCursor<T> batchCursor, final Function<T, U> mapper) {
+        this.batchCursor = batchCursor;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void next(final SingleResultCallback<List<U>> callback) {
+        batchCursor.next(new SingleResultCallback<List<T>>() {
+            @Override
+            public void onResult(final List<T> results, final Throwable t) {
+                if (t != null) {
+                    callback.onResult(null, t);
+                } else {
+                    try {
+                        List<U> mappedResults = new ArrayList<U>();
+                        for (T result : results) {
+                            mappedResults.add(mapper.apply(result));
+                        }
+                        callback.onResult(mappedResults, null);
+                    } catch (Throwable t1) {
+                        callback.onResult(null, t1);
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
+    public void setBatchSize(final int batchSize) {
+        batchCursor.setBatchSize(batchSize);
+    }
+
+    @Override
+    public int getBatchSize() {
+        return batchCursor.getBatchSize();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return batchCursor.isClosed();
+    }
+
+    @Override
+    public void close() {
+        batchCursor.close();
+    }
+}

--- a/driver-async/src/main/com/mongodb/async/client/MappingIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MappingIterable.java
@@ -19,6 +19,7 @@ package com.mongodb.async.client;
 import com.mongodb.Block;
 import com.mongodb.Function;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.operation.AsyncBatchCursor;
 
 import java.util.Collection;
 
@@ -86,5 +87,19 @@ class MappingIterable<T, U> implements MongoIterable<U> {
     @Override
     public <V> MongoIterable<V> map(final Function<U, V> mapper) {
         return new MappingIterable<U, V>(this, mapper);
+    }
+
+    @Override
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<U>> callback) {
+        iterable.batchCursor(new SingleResultCallback<AsyncBatchCursor<T>>() {
+            @Override
+            public void onResult(final AsyncBatchCursor<T> batchCursor, final Throwable t) {
+                if (t != null) {
+                    callback.onResult(null, t);
+                } else {
+                    callback.onResult(new MappingAsyncBatchCursor<T, U>(batchCursor, mapper), null);
+                }
+            }
+        });
     }
 }

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
@@ -19,6 +19,7 @@ package com.mongodb.async.client;
 import com.mongodb.Block;
 import com.mongodb.Function;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.operation.AsyncBatchCursor;
 
 import java.util.Collection;
 
@@ -63,4 +64,11 @@ public interface MongoIterable<T> {
      * @return an iterable which maps T to U
      */
     <U> MongoIterable<U> map(Function<T, U> mapper);
+
+    /**
+     * Provide the underlying {@link com.mongodb.operation.AsyncBatchCursor} allowing fine grained control of the cursor.
+     *
+     * @param callback a callback that will be passed the AsyncBatchCursor
+     */
+    void batchCursor(SingleResultCallback<AsyncBatchCursor<T>> callback);
 }

--- a/driver-async/src/main/com/mongodb/async/client/OperationIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/OperationIterable.java
@@ -45,7 +45,7 @@ class OperationIterable<T> implements MongoIterable<T> {
 
     @Override
     public void forEach(final Block<? super T> block, final SingleResultCallback<Void> callback) {
-        execute(new SingleResultCallback<AsyncBatchCursor<T>>() {
+        batchCursor(new SingleResultCallback<AsyncBatchCursor<T>>() {
             @Override
             public void onResult(final AsyncBatchCursor<T> batchCursor, final Throwable t) {
                 if (t != null) {
@@ -59,7 +59,7 @@ class OperationIterable<T> implements MongoIterable<T> {
 
     @Override
     public <A extends Collection<? super T>> void into(final A target, final SingleResultCallback<A> callback) {
-        execute(new SingleResultCallback<AsyncBatchCursor<T>>() {
+        batchCursor(new SingleResultCallback<AsyncBatchCursor<T>>() {
             @Override
             public void onResult(final AsyncBatchCursor<T> batchCursor, final Throwable t) {
                 if (t != null) {
@@ -87,7 +87,7 @@ class OperationIterable<T> implements MongoIterable<T> {
 
     @Override
     public void first(final SingleResultCallback<T> callback) {
-        execute(new SingleResultCallback<AsyncBatchCursor<T>>() {
+        batchCursor(new SingleResultCallback<AsyncBatchCursor<T>>() {
             @Override
             public void onResult(final AsyncBatchCursor<T> batchCursor, final Throwable t) {
                 if (t != null) {
@@ -118,7 +118,8 @@ class OperationIterable<T> implements MongoIterable<T> {
     }
 
     @SuppressWarnings("unchecked")
-    private void execute(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+    @Override
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
         executor.execute((AsyncReadOperation<AsyncBatchCursor<T>>) operation, readPreference, callback);
     }
 

--- a/driver-async/src/test/unit/com/mongodb/async/client/FindFluentSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/FindFluentSpecification.groovy
@@ -170,10 +170,10 @@ class FindFluentSpecification extends Specification {
                 next(_) >> {
                     it[0].onResult(getResult(), null)
                 }
-
+                isClosed() >> { count >= 1 }
             }
         }
-        def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
+        def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
         def findOptions = new FindOptions()
         def mongoIterable = new FindFluentImpl<Document>(new MongoNamespace('db', 'coll'),  Document, codecRegistry, readPreference,
                 executor, new Document(), findOptions)
@@ -218,6 +218,22 @@ class FindFluentSpecification extends Specification {
         }).into(target, results)
         then:
         results.get() == [1, 1, 1]
+
+        when:
+        results = new FutureResultCallback()
+        mongoIterable.batchCursor(results)
+        def batchCursor = results.get()
+
+        then:
+        !batchCursor.isClosed()
+
+        when:
+        results = new FutureResultCallback()
+        batchCursor.next(results)
+
+        then:
+        results.get() == cannedResults
+        batchCursor.isClosed()
     }
 
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/ListDatabasesFluentSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ListDatabasesFluentSpecification.groovy
@@ -86,10 +86,10 @@ class ListDatabasesFluentSpecification extends Specification {
                 next(_) >> {
                     it[0].onResult(getResult(), null)
                 }
-
+                isClosed() >> { count >= 1 }
             }
         }
-        def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
+        def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
         def mongoIterable = new ListDatabasesFluentImpl<Document>(Document, codecRegistry, readPreference, executor)
 
         when:
@@ -132,6 +132,22 @@ class ListDatabasesFluentSpecification extends Specification {
         }).into(target, results)
         then:
         results.get() == [1, 1, 1]
+
+        when:
+        results = new FutureResultCallback()
+        mongoIterable.batchCursor(results)
+        def batchCursor = results.get()
+
+        then:
+        !batchCursor.isClosed()
+
+        when:
+        results = new FutureResultCallback()
+        batchCursor.next(results)
+
+        then:
+        results.get() == cannedResults
+        batchCursor.isClosed()
     }
 
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/ListIndexesFluentSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ListIndexesFluentSpecification.groovy
@@ -92,10 +92,10 @@ class ListIndexesFluentSpecification extends Specification {
                 next(_) >> {
                     it[0].onResult(getResult(), null)
                 }
-
+                isClosed() >> { count >= 1 }
             }
         }
-        def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
+        def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
         def mongoIterable = new ListIndexesFluentImpl<Document>(namespace, Document, codecRegistry, readPreference, executor)
 
         when:
@@ -138,6 +138,22 @@ class ListIndexesFluentSpecification extends Specification {
         }).into(target, results)
         then:
         results.get() == [1, 1, 1]
+
+        when:
+        results = new FutureResultCallback()
+        mongoIterable.batchCursor(results)
+        def batchCursor = results.get()
+
+        then:
+        !batchCursor.isClosed()
+
+        when:
+        results = new FutureResultCallback()
+        batchCursor.next(results)
+
+        then:
+        results.get() == cannedResults
+        batchCursor.isClosed()
     }
 
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/MappingAsyncBatchCursorSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MappingAsyncBatchCursorSpecification.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.async.client
+
+import com.mongodb.Function
+import com.mongodb.MongoException
+import com.mongodb.async.FutureResultCallback
+import com.mongodb.operation.AsyncBatchCursor
+import org.bson.Document
+import spock.lang.Specification
+
+class MappingAsyncBatchCursorSpecification extends Specification {
+    def cannedResults = [new Document('name', 'a'), new Document('name', 'b'), new Document('name', 'c')]
+    def asyncBatchCursor = {
+        Stub(AsyncBatchCursor) {
+            def count = 0
+            def results;
+            def getResult = {
+                count++
+                results = count == 1 ? cannedResults : null
+                results
+            }
+            next(_) >> {
+                it[0].onResult(getResult(), null)
+            }
+            isClosed() >> { count >= 1 }
+        }
+    }
+
+    def 'should map types from the cursor'() {
+        given:
+        def mapper = new Function<Document, String>() {
+            @Override
+            String apply(final Document document) {
+                document.getString('name')
+            }
+        }
+        def mappingAsyncBatchCursor = new MappingAsyncBatchCursor(asyncBatchCursor(), mapper)
+
+        when:
+        def results = new FutureResultCallback()
+        mappingAsyncBatchCursor.next(results)
+
+        then:
+        results.get() == cannedResults*.name
+    }
+
+    def 'should capture mapping errors'() {
+        given:
+        def mapper = new Function<Document, String>() {
+            @Override
+            String apply(final Document document) {
+                throw new MongoException('Something went wrong')
+            }
+        }
+        def mappingAsyncBatchCursor = new MappingAsyncBatchCursor(asyncBatchCursor(), mapper)
+
+        when:
+        def results = new FutureResultCallback()
+        mappingAsyncBatchCursor.next(results)
+        results.get()
+
+        then:
+        thrown MongoException
+    }
+
+    def 'should proxy the underlying asyncBatchCursor'() {
+        given:
+        def asyncBatchCursor = Mock(AsyncBatchCursor)
+        def mapper = Stub(Function)
+        def mappingAsyncBatchCursor = new MappingAsyncBatchCursor(asyncBatchCursor, mapper)
+
+        when:
+        mappingAsyncBatchCursor.setBatchSize(10)
+
+        then:
+        1 * asyncBatchCursor.setBatchSize(10)
+
+        when:
+        mappingAsyncBatchCursor.getBatchSize()
+
+        then:
+        1 * asyncBatchCursor.getBatchSize()
+
+        when:
+        mappingAsyncBatchCursor.isClosed()
+
+        then:
+        1 * asyncBatchCursor.isClosed()
+
+        when:
+        mappingAsyncBatchCursor.close()
+
+        then:
+
+        1 * asyncBatchCursor.close()
+    }
+
+}

--- a/driver-core/src/main/com/mongodb/operation/AsyncBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncBatchCursor.java
@@ -22,7 +22,7 @@ import java.io.Closeable;
 import java.util.List;
 
 /**
- * MongoDB returns query results as batches, and this interface provideds an asynchronous iterator over those batches.  The first call to
+ * MongoDB returns query results as batches, and this interface provides an asynchronous iterator over those batches.  The first call to
  * the {@code next} method will return the first batch, and subsequent calls will trigger an asynchronous request to get the next batch
  * of results.  Clients can control the batch size by setting the {@code batchSize} property between calls to {@code next}.
  *


### PR DESCRIPTION
Allows users fine grained control over the cursor.  They can
implement their own backpressure logic and cancel the cursor
as they need.

JAVA-1259 JAVA-1268