### PR TITLE
Implemented $not and $nor filter helpers

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -50,19 +50,8 @@ public final class Filters {
     }
 
     /**
-     * Creates a bson document for the $eq operator that matches the specified value.
-     *
-     * @param value     the value
-     * @param <TItem>  the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/eq $eq
-     */
-    public static <TItem> Bson eq(final TItem value) {
-        return new SimpleEncodingFilter<TItem>("$eq", value);
-    }
-
-    /**
-     * Creates a filter that matches all documents where the value of the field name equals the specified value.
+     * Creates a filter that matches all documents where the value of the field name equals the specified value. Note that this does
+     * actually generate a $eq operator, as the query language doesn't require it.
      *
      * @param fieldName the field name
      * @param value     the value
@@ -75,18 +64,6 @@ public final class Filters {
     }
 
     /**
-     * Creates a bson documents for the $ne operator.
-     *
-     * @param value     the value
-     * @param <TItem>  the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/ne $ne
-     */
-    public static <TItem> Bson ne(final TItem value) {
-        return new SimpleEncodingFilter<TItem>("$ne", value);
-    }
-
-    /**
      * Creates a filter that matches all documents where the value of the field name does not equal the specified value.
      *
      * @param fieldName the field name
@@ -96,19 +73,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/ne $ne
      */
     public static <TItem> Bson ne(final String fieldName, final TItem value) {
-        return new SimpleEncodingFilter<Bson>(fieldName, ne(value));
-    }
-
-    /**
-     * Creates a bson document for the $gt operator
-     *
-     * @param value the value
-     * @param <TItem> the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/gt $gt
-     */
-    public static <TItem> Bson gt(final TItem value) {
-        return new SimpleEncodingFilter<TItem>("$gt", value);
+        return new OperatorFilter<TItem>("$ne", fieldName, value);
     }
 
     /**
@@ -121,19 +86,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/gt $gt
      */
     public static <TItem> Bson gt(final String fieldName, final TItem value) {
-        return new SimpleEncodingFilter<Bson>(fieldName, gt(value));
-    }
-
-    /**
-     * Creates a bson document for the $lt operator
-     *
-     * @param value the value
-     * @param <TItem> the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/lt $lt
-     */
-    public static <TItem> Bson lt(final TItem value) {
-        return new SimpleEncodingFilter<TItem>("$lt", value);
+        return new OperatorFilter<TItem>("$gt", fieldName, value);
     }
 
     /**
@@ -146,19 +99,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/lt $lt
      */
     public static <TItem> Bson lt(final String fieldName, final TItem value) {
-        return new SimpleEncodingFilter<Bson>(fieldName, lt(value));
-    }
-
-    /**
-     * Creates a bson document for the $gte operator
-     *
-     * @param value the value
-     * @param <TItem> the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/gte $gte
-     */
-    public static <TItem> Bson gte(final TItem value) {
-        return new SimpleEncodingFilter<TItem>("$gte", value);
+        return new OperatorFilter<TItem>("$lt", fieldName, value);
     }
 
     /**
@@ -171,19 +112,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/gte $gte
      */
     public static <TItem> Bson gte(final String fieldName, final TItem value) {
-        return new SimpleEncodingFilter<Bson>(fieldName, gte(value));
-    }
-
-    /**
-     * Creates a bson document for the $lte operator
-     *
-     * @param value the value
-     * @param <TItem> the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/lte $lte
-     */
-    public static <TItem> Bson lte(final TItem value) {
-        return new SimpleEncodingFilter<TItem>("$lte", value);
+        return new OperatorFilter<TItem>("$gte", fieldName, value);
     }
 
     /**
@@ -196,31 +125,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/lte $lte
      */
     public static <TItem> Bson lte(final String fieldName, final TItem value) {
-        return new SimpleEncodingFilter<Bson>(fieldName, lte(value));
-    }
-
-    /**
-     * Creates a bson document for the $in operator
-     *
-     * @param values    the list of values
-     * @param <TItem>   the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/in $in
-     */
-    public static <TItem> Bson in(final TItem... values) {
-        return in(asList(values));
-    }
-
-    /**
-     * Creates a bson document for the $in operator
-     *
-     * @param values    the list of values
-     * @param <TItem>   the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/in $in
-     */
-    public static <TItem> Bson in(final Iterable<TItem> values) {
-        return new IterableEncodingFilter<TItem>("$in", values);
+        return new OperatorFilter<TItem>("$lte", fieldName, value);
     }
 
     /**
@@ -246,33 +151,8 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/in $in
      */
     public static <TItem> Bson in(final String fieldName, final Iterable<TItem> values) {
-        return new SimpleEncodingFilter<Bson>(fieldName, in(values));
+        return new SimpleEncodingFilter<Bson>(fieldName , new IterableOperatorFilter<TItem>("$in", values));
     }
-
-    /**
-     * Creates a bson document for the $nin operator
-     *
-     * @param values    the list of values
-     * @param <TItem>   the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/nin $nin
-     */
-    public static <TItem> Bson nin(final TItem... values) {
-        return nin(asList(values));
-    }
-
-    /**
-     * Creates a bson document for the $nin operator
-     *
-     * @param values    the list of values
-     * @param <TItem>   the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/nin $nin
-     */
-    public static <TItem> Bson nin(final Iterable<TItem> values) {
-        return new IterableEncodingFilter<TItem>("$nin", values);
-    }
-
 
     /**
      * Creates a filter that matches all documents where the value of a field does not equal any of the specified values or does not exist.
@@ -297,7 +177,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/nin $nin
      */
     public static <TItem> Bson nin(final String fieldName, final Iterable<TItem> values) {
-        return new SimpleEncodingFilter<Bson>(fieldName, nin(values));
+        return new SimpleEncodingFilter<Bson>(fieldName, new IterableOperatorFilter<TItem>("$nin", values));
     }
 
     /**
@@ -370,25 +250,12 @@ public final class Filters {
     /**
      * Creates a filter that matches all documents where the value of the field name does not match the specified value.
      *
-     * @param fieldName the field name
      * @param value     the value
      * @return the filter
      * @mongodb.driver.manual reference/operator/query/not $not
      */
-    public static Bson not(final String fieldName, final Bson value) {
-        return new OperatorFilter<Bson>("$not", fieldName, value);
-    }
-
-    /**
-     * Creates a filter that matches all documents where the value of the field name does not match the specified value.
-     *
-     * @param fieldName the field name
-     * @param value     the value
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/not $not
-     */
-    public static Bson not(final String fieldName, final Pattern value) {
-        return new OperatorFilter<String>("$not", fieldName, value.pattern());
+    public static Bson not(final Bson value) {
+        return new NotFilter(value);
     }
 
     /**
@@ -410,7 +277,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/nor $nor
      */
     public static Bson nor(final Iterable<Bson> values) {
-        return new IterableEncodingFilter<Bson>("$nor", values);
+        return new IterableOperatorFilter<Bson>("$nor", values);
     }
 
     /**
@@ -553,30 +420,6 @@ public final class Filters {
     }
 
     /**
-     * Creates a bson document for the $all operator
-     *
-     * @param values    the list of values
-     * @param <TItem>   the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/all $all
-     */
-    public static <TItem> Bson all(final TItem... values) {
-        return all(asList(values));
-    }
-
-    /**
-     * Creates a bson document for the $all operator
-     *
-     * @param values    the list of values
-     * @param <TItem>   the value type
-     * @return the filter
-     * @mongodb.driver.manual reference/operator/query/all $all
-     */
-    public static <TItem> Bson all(final Iterable<TItem> values) {
-        return new IterableEncodingFilter<TItem>("$all", values);
-    }
-
-    /**
      * Creates a filter that matches all documents where the value of a field is an array that contains all the specified values.
      *
      * @param fieldName the field name
@@ -599,7 +442,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/all $all
      */
     public static <TItem> Bson all(final String fieldName, final Iterable<TItem> values) {
-        return new SimpleEncodingFilter<Bson>(fieldName, all(values));
+        return new SimpleEncodingFilter<Bson>(fieldName, new IterableOperatorFilter<TItem>("$all", values));
     }
 
     /**
@@ -768,11 +611,11 @@ public final class Filters {
         }
     }
 
-    private static class IterableEncodingFilter<TItem> implements Bson {
+    private static class IterableOperatorFilter<TItem> implements Bson {
         private final String operatorName;
         private final Iterable<TItem> values;
 
-        IterableEncodingFilter(final String operatorName, final Iterable<TItem> values) {
+        IterableOperatorFilter(final String operatorName, final Iterable<TItem> values) {
             this.operatorName = notNull("operatorName", operatorName);
             this.values = notNull("values", values);
         }
@@ -824,6 +667,76 @@ public final class Filters {
                     ((Bson) value).toBsonDocument(BsonDocument.class, codecRegistry), EncoderContext.builder().build());
         } else {
             ((Encoder) codecRegistry.get(value.getClass())).encode(writer, value, EncoderContext.builder().build());
+        }
+    }
+
+    private static class NotFilter implements Bson {
+        private final Bson filter;
+
+        public NotFilter(final Bson filter) {
+            this.filter = notNull("filter", filter);
+        }
+
+        @Override
+        public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+            return toFilter(filter.toBsonDocument(documentClass, codecRegistry));
+        }
+
+        public BsonDocument toFilter(final BsonDocument filterDocument) {
+            BsonDocument combinedDocument = new BsonDocument();
+            for (Map.Entry<String, BsonValue> docs : filterDocument.entrySet()) {
+                combinedDocument = combineDocuments(combinedDocument, createFilter(docs.getKey(), docs.getValue()));
+            }
+            return combinedDocument;
+        }
+
+        private BsonDocument createFilter(final String fieldName, final BsonValue value) {
+            if (fieldName.equals("$and")) {
+                return toFilter(flattenBsonArray(value.asArray()));
+            } else if (value.isDocument() && ((BsonDocument) value).keySet().iterator().next().startsWith("$")) {
+                return new BsonDocument(fieldName, new BsonDocument("$not", value));
+            } else if (value.isRegularExpression()) {
+                return new BsonDocument(fieldName, new BsonDocument("$not", value));
+            }
+            return new BsonDocument(fieldName, new BsonDocument("$not", new BsonDocument("$eq", value)));
+        }
+
+        private BsonDocument combineDocuments(final BsonDocument document1, final BsonDocument document2) {
+            BsonDocument combinedDocument = document1;
+            for (Map.Entry<String, BsonValue> entry : document2.entrySet()) {
+                String key = entry.getKey();
+                BsonValue val = entry.getValue();
+                BsonDocument document = combinedDocument.getDocument(key, new BsonDocument());
+                if (!val.isDocument()) {
+                    if (document.containsKey("$in")) {
+                        BsonArray inArray = document.getArray("$in");
+                        inArray.add(val);
+                        document.put("$in", inArray);
+                    } else if (document.containsKey("$eq")) {
+                        BsonArray inArray = document.getArray("$in", new BsonArray());
+                        inArray.add(document.remove("$eq"));
+                        inArray.add(val);
+                        document.put("$in", inArray);
+                    } else {
+                        document.put("$eq", val);
+                    }
+                } else {
+                    document = val.asDocument();
+                }
+                combinedDocument.put(key, document);
+            }
+            return combinedDocument;
+        }
+
+        private BsonDocument flattenBsonArray(final BsonArray bsonArray) {
+            BsonDocument combinedDocument = new BsonDocument();
+            for (BsonValue bsonValue : bsonArray) {
+                if (!bsonValue.isDocument()) {
+                    throw new IllegalArgumentException("Invalid $not document " + bsonValue);
+                }
+                combinedDocument = combineDocuments(combinedDocument, bsonValue.asDocument());
+            }
+            return combinedDocument;
         }
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -248,7 +248,7 @@ public final class Filters {
     }
 
     /**
-     * Creates a filter that matches all documents where the value of the field name does not match the specified value.
+     * Creates a filter that matches all documents that do not match the passed in filter.
      * Requires the field name to passed as part of the value passed in and lifts it to create a valid "$not" query:
      *
      * <blockquote><pre>
@@ -260,34 +260,34 @@ public final class Filters {
      *    {x : $not: {$eq : 1}}
      * </pre></blockquote>
      *
-     * @param value     the value
+     * @param filter     the value
      * @return the filter
      * @mongodb.driver.manual reference/operator/query/not $not
      */
-    public static Bson not(final Bson value) {
-        return new NotFilter(value);
+    public static Bson not(final Bson filter) {
+        return new NotFilter(filter);
     }
 
     /**
      * Creates a filter that performs a logical NOR operation on all the specified filters.
      *
-     * @param values    the list of values
+     * @param filters    the list of values
      * @return the filter
      * @mongodb.driver.manual reference/operator/query/nor $nor
      */
-    public static Bson nor(final Bson... values) {
-        return nor(asList(values));
+    public static Bson nor(final Bson... filters) {
+        return nor(asList(filters));
     }
 
     /**
      * Creates a filter that performs a logical NOR operation on all the specified filters.
      *
-     * @param values    the list of values
+     * @param filters    the list of values
      * @return the filter
      * @mongodb.driver.manual reference/operator/query/nor $nor
      */
-    public static Bson nor(final Iterable<Bson> values) {
-        return new IterableOperatorFilter<Bson>("$nor", values);
+    public static Bson nor(final Iterable<Bson> filters) {
+        return new IterableOperatorFilter<Bson>("$nor", filters);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -50,8 +50,19 @@ public final class Filters {
     }
 
     /**
-     * Creates a filter that matches all documents where the value of the field name equals the specified value. Note that this does
-     * actually generate a $eq operator, as the query language doesn't require it.
+     * Creates a bson document for the $eq operator that matches the specified value.
+     *
+     * @param value     the value
+     * @param <TItem>  the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/eq $eq
+     */
+    public static <TItem> Bson eq(final TItem value) {
+        return new SimpleEncodingFilter<TItem>("$eq", value);
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the field name equals the specified value.
      *
      * @param fieldName the field name
      * @param value     the value
@@ -64,6 +75,18 @@ public final class Filters {
     }
 
     /**
+     * Creates a bson documents for the $ne operator.
+     *
+     * @param value     the value
+     * @param <TItem>  the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/ne $ne
+     */
+    public static <TItem> Bson ne(final TItem value) {
+        return new SimpleEncodingFilter<TItem>("$ne", value);
+    }
+
+    /**
      * Creates a filter that matches all documents where the value of the field name does not equal the specified value.
      *
      * @param fieldName the field name
@@ -73,7 +96,19 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/ne $ne
      */
     public static <TItem> Bson ne(final String fieldName, final TItem value) {
-        return new OperatorFilter<TItem>("$ne", fieldName, value);
+        return new SimpleEncodingFilter<Bson>(fieldName, ne(value));
+    }
+
+    /**
+     * Creates a bson document for the $gt operator
+     *
+     * @param value the value
+     * @param <TItem> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TItem> Bson gt(final TItem value) {
+        return new SimpleEncodingFilter<TItem>("$gt", value);
     }
 
     /**
@@ -86,7 +121,19 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/gt $gt
      */
     public static <TItem> Bson gt(final String fieldName, final TItem value) {
-        return new OperatorFilter<TItem>("$gt", fieldName, value);
+        return new SimpleEncodingFilter<Bson>(fieldName, gt(value));
+    }
+
+    /**
+     * Creates a bson document for the $lt operator
+     *
+     * @param value the value
+     * @param <TItem> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/lt $lt
+     */
+    public static <TItem> Bson lt(final TItem value) {
+        return new SimpleEncodingFilter<TItem>("$lt", value);
     }
 
     /**
@@ -99,7 +146,19 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/lt $lt
      */
     public static <TItem> Bson lt(final String fieldName, final TItem value) {
-        return new OperatorFilter<TItem>("$lt", fieldName, value);
+        return new SimpleEncodingFilter<Bson>(fieldName, lt(value));
+    }
+
+    /**
+     * Creates a bson document for the $gte operator
+     *
+     * @param value the value
+     * @param <TItem> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gte $gte
+     */
+    public static <TItem> Bson gte(final TItem value) {
+        return new SimpleEncodingFilter<TItem>("$gte", value);
     }
 
     /**
@@ -112,7 +171,19 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/gte $gte
      */
     public static <TItem> Bson gte(final String fieldName, final TItem value) {
-        return new OperatorFilter<TItem>("$gte", fieldName, value);
+        return new SimpleEncodingFilter<Bson>(fieldName, gte(value));
+    }
+
+    /**
+     * Creates a bson document for the $lte operator
+     *
+     * @param value the value
+     * @param <TItem> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/lte $lte
+     */
+    public static <TItem> Bson lte(final TItem value) {
+        return new SimpleEncodingFilter<TItem>("$lte", value);
     }
 
     /**
@@ -125,7 +196,31 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/lte $lte
      */
     public static <TItem> Bson lte(final String fieldName, final TItem value) {
-        return new OperatorFilter<TItem>("$lte", fieldName, value);
+        return new SimpleEncodingFilter<Bson>(fieldName, lte(value));
+    }
+
+    /**
+     * Creates a bson document for the $in operator
+     *
+     * @param values    the list of values
+     * @param <TItem>   the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/in $in
+     */
+    public static <TItem> Bson in(final TItem... values) {
+        return in(asList(values));
+    }
+
+    /**
+     * Creates a bson document for the $in operator
+     *
+     * @param values    the list of values
+     * @param <TItem>   the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/in $in
+     */
+    public static <TItem> Bson in(final Iterable<TItem> values) {
+        return new IterableEncodingFilter<TItem>("$in", values);
     }
 
     /**
@@ -151,8 +246,33 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/in $in
      */
     public static <TItem> Bson in(final String fieldName, final Iterable<TItem> values) {
-        return new ArrayOperatorFilter<TItem>("$in", fieldName, values);
+        return new SimpleEncodingFilter<Bson>(fieldName, in(values));
     }
+
+    /**
+     * Creates a bson document for the $nin operator
+     *
+     * @param values    the list of values
+     * @param <TItem>   the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/nin $nin
+     */
+    public static <TItem> Bson nin(final TItem... values) {
+        return nin(asList(values));
+    }
+
+    /**
+     * Creates a bson document for the $nin operator
+     *
+     * @param values    the list of values
+     * @param <TItem>   the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/nin $nin
+     */
+    public static <TItem> Bson nin(final Iterable<TItem> values) {
+        return new IterableEncodingFilter<TItem>("$nin", values);
+    }
+
 
     /**
      * Creates a filter that matches all documents where the value of a field does not equal any of the specified values or does not exist.
@@ -177,7 +297,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/nin $nin
      */
     public static <TItem> Bson nin(final String fieldName, final Iterable<TItem> values) {
-        return new ArrayOperatorFilter<TItem>("$nin", fieldName, values);
+        return new SimpleEncodingFilter<Bson>(fieldName, nin(values));
     }
 
     /**
@@ -247,8 +367,51 @@ public final class Filters {
         return or(asList(filters));
     }
 
-    // TODO: $not
-    // TODO: $nor
+    /**
+     * Creates a filter that matches all documents where the value of the field name does not match the specified value.
+     *
+     * @param fieldName the field name
+     * @param value     the value
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/not $not
+     */
+    public static Bson not(final String fieldName, final Bson value) {
+        return new OperatorFilter<Bson>("$not", fieldName, value);
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the field name does not match the specified value.
+     *
+     * @param fieldName the field name
+     * @param value     the value
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/not $not
+     */
+    public static Bson not(final String fieldName, final Pattern value) {
+        return new OperatorFilter<String>("$not", fieldName, value.pattern());
+    }
+
+    /**
+     * Creates a filter that performs a logical NOR operation on all the specified filters.
+     *
+     * @param values    the list of values
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/nor $nor
+     */
+    public static Bson nor(final Bson... values) {
+        return nor(asList(values));
+    }
+
+    /**
+     * Creates a filter that performs a logical NOR operation on all the specified filters.
+     *
+     * @param values    the list of values
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/nor $nor
+     */
+    public static Bson nor(final Iterable<Bson> values) {
+        return new IterableEncodingFilter<Bson>("$nor", values);
+    }
 
     /**
      * Creates a filter that matches all documents that contain the given field.
@@ -390,6 +553,30 @@ public final class Filters {
     }
 
     /**
+     * Creates a bson document for the $all operator
+     *
+     * @param values    the list of values
+     * @param <TItem>   the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/all $all
+     */
+    public static <TItem> Bson all(final TItem... values) {
+        return all(asList(values));
+    }
+
+    /**
+     * Creates a bson document for the $all operator
+     *
+     * @param values    the list of values
+     * @param <TItem>   the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/all $all
+     */
+    public static <TItem> Bson all(final Iterable<TItem> values) {
+        return new IterableEncodingFilter<TItem>("$all", values);
+    }
+
+    /**
      * Creates a filter that matches all documents where the value of a field is an array that contains all the specified values.
      *
      * @param fieldName the field name
@@ -412,7 +599,7 @@ public final class Filters {
      * @mongodb.driver.manual reference/operator/query/all $all
      */
     public static <TItem> Bson all(final String fieldName, final Iterable<TItem> values) {
-        return new ArrayOperatorFilter<TItem>("$all", fieldName, values);
+        return new SimpleEncodingFilter<Bson>(fieldName, all(values));
     }
 
     /**
@@ -581,14 +768,12 @@ public final class Filters {
         }
     }
 
-    private static class ArrayOperatorFilter<TItem> implements Bson {
+    private static class IterableEncodingFilter<TItem> implements Bson {
         private final String operatorName;
-        private final String fieldName;
         private final Iterable<TItem> values;
 
-        ArrayOperatorFilter(final String operatorName, final String fieldName, final Iterable<TItem> values) {
+        IterableEncodingFilter(final String operatorName, final Iterable<TItem> values) {
             this.operatorName = notNull("operatorName", operatorName);
-            this.fieldName = notNull("fieldName", fieldName);
             this.values = notNull("values", values);
         }
 
@@ -596,15 +781,12 @@ public final class Filters {
         public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
             BsonDocumentWriter writer = new BsonDocumentWriter(new BsonDocument());
             writer.writeStartDocument();
-            writer.writeName(fieldName);
-            writer.writeStartDocument();
             writer.writeName(operatorName);
             writer.writeStartArray();
             for (TItem value : values) {
                 encodeValue(writer, value, codecRegistry);
             }
             writer.writeEndArray();
-            writer.writeEndDocument();
             writer.writeEndDocument();
 
             return writer.getDocument();
@@ -637,63 +819,11 @@ public final class Filters {
     private static <TItem> void encodeValue(final BsonDocumentWriter writer, final TItem value, final CodecRegistry codecRegistry) {
         if (value == null) {
             writer.writeNull();
+        } else if (value instanceof Bson) {
+            ((Encoder) codecRegistry.get(BsonDocument.class)).encode(writer,
+                    ((Bson) value).toBsonDocument(BsonDocument.class, codecRegistry), EncoderContext.builder().build());
         } else {
             ((Encoder) codecRegistry.get(value.getClass())).encode(writer, value, EncoderContext.builder().build());
         }
-    }
-
-    // WIP, to be used later by not/nor methods
-    private static class NotFilter implements Bson {
-        private final Bson filter;
-
-        public NotFilter(final Bson filter) {
-            this.filter = notNull("filter", filter);
-        }
-
-        @Override
-        public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
-            BsonDocument filterDocument = filter.toBsonDocument(documentClass, codecRegistry);
-            if (filterDocument.size() == 1) {
-                return negateSingleElementFilter(filterDocument);
-            } else {
-                return negateArbitraryFilter(filterDocument);
-            }
-        }
-
-        private BsonDocument negateSingleElementFilter(final BsonDocument filterDocument) {
-            String name = filterDocument.keySet().iterator().next();
-            BsonValue value = filterDocument.get(name);
-
-            if (name.equals("$")) {
-                return negateSingleElementTopLevelOperatorFilter(filterDocument, name, value);
-            }
-
-            if (value.isDocument()) {
-                // TODO: figure out what to do here
-            }
-
-            if (value.isRegularExpression()) {
-                return new BsonDocument(name, new BsonDocument("$not", value));
-            }
-
-            return new BsonDocument(name, new BsonDocument("$ne", value));
-        }
-
-        private BsonDocument negateArbitraryFilter(final BsonDocument filterDocument) {
-            // $not only works as a meta operator on a single operator so simulate using $nor
-            return new BsonDocument("$nor", new BsonArray(asList(filterDocument)));
-        }
-
-        BsonDocument negateSingleElementTopLevelOperatorFilter(final BsonDocument filterDocument, final String name,
-                                                               final BsonValue value) {
-            if (name.equals("$or")) {
-                return new BsonDocument("$nor", value);
-            } else if (name.equals("$nor")) {
-                return new BsonDocument("$or", value);
-            } else {
-                return negateArbitraryFilter(filterDocument);
-            }
-        }
-
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -68,8 +68,12 @@ class FiltersSpecification extends Specification {
 
     def 'should render $not'() {
         expect:
-        toBson(not('x', eq(1))) == parse('{x : {$not: {$eq: 1}}}')
-        toBson(not('x', Pattern.compile('/^p.*/'))) == parse('{x : {$not: "/^p.*/"}}')
+        toBson(not(eq('x', 1))) == parse('{x : {$not: {$eq: 1}}}')
+        toBson(not(gt('x', 1))) == parse('{x : {$not: {$gt: 1}}}')
+        toBson(not(regex('x', '^p.*'))) == parse('{x : {$not: /^p.*/}}')
+        toBson(not(and(gt('x', 1), eq('y', 20)))) == parse('{x : {$not: {$gt: 1}}, y : {$not: {$eq: 20}}}')
+        toBson(not(and(eq('x', 1), eq('x', 2)))) == parse('{x : {$not: {$in: [1, 2]}}}')
+        toBson(not(and(Filters.in('x', 1, 2), eq('x', 3)))) == parse('{x : {$not: {$in: [1, 2, 3]}}}')
     }
 
     def 'should render $nor'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -15,7 +15,6 @@
  */
 
 package com.mongodb.client.model
-
 import org.bson.BsonArray
 import org.bson.BsonDocument
 import org.bson.BsonInt32
@@ -41,13 +40,14 @@ import static com.mongodb.client.model.Filters.elemMatch
 import static com.mongodb.client.model.Filters.mod
 import static com.mongodb.client.model.Filters.ne
 import static com.mongodb.client.model.Filters.nin
+import static com.mongodb.client.model.Filters.nor
+import static com.mongodb.client.model.Filters.not
 import static com.mongodb.client.model.Filters.regex
 import static com.mongodb.client.model.Filters.size
 import static com.mongodb.client.model.Filters.text
 import static com.mongodb.client.model.Filters.type
 import static com.mongodb.client.model.Filters.where
-import static com.mongodb.client.model.Filters.not
-import static com.mongodb.client.model.Filters.nor
+import static java.util.Arrays.asList
 import static org.bson.BsonDocument.parse
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 
@@ -74,6 +74,12 @@ class FiltersSpecification extends Specification {
         toBson(not(and(gt('x', 1), eq('y', 20)))) == parse('{x : {$not: {$gt: 1}}, y : {$not: {$eq: 20}}}')
         toBson(not(and(eq('x', 1), eq('x', 2)))) == parse('{x : {$not: {$in: [1, 2]}}}')
         toBson(not(and(Filters.in('x', 1, 2), eq('x', 3)))) == parse('{x : {$not: {$in: [1, 2, 3]}}}')
+
+        when: 'Missing a field name it should error'
+        toBson(not(new BsonDocument('$in', new BsonArray(asList(new BsonInt32(1))))))
+
+        then:
+        thrown(IllegalArgumentException)
     }
 
     def 'should render $nor'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -46,6 +46,8 @@ import static com.mongodb.client.model.Filters.size
 import static com.mongodb.client.model.Filters.text
 import static com.mongodb.client.model.Filters.type
 import static com.mongodb.client.model.Filters.where
+import static com.mongodb.client.model.Filters.not
+import static com.mongodb.client.model.Filters.nor
 import static org.bson.BsonDocument.parse
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 
@@ -62,6 +64,18 @@ class FiltersSpecification extends Specification {
         expect:
         toBson(ne('x', 1)) == parse('{x : {$ne : 1} }')
         toBson(ne('x', null)) == parse('{x : {$ne : null} }')
+    }
+
+    def 'should render $not'() {
+        expect:
+        toBson(not('x', eq(1))) == parse('{x : {$not: {$eq: 1}}}')
+        toBson(not('x', Pattern.compile('/^p.*/'))) == parse('{x : {$not: "/^p.*/"}}')
+    }
+
+    def 'should render $nor'() {
+        expect:
+        toBson(nor(eq('price', 1))) == parse('{$nor : [{price: 1}]}')
+        toBson(nor(eq('price', 1), eq('sale', true))) == parse('{$nor : [{price: 1}, {sale: true}]}')
     }
 
     def 'should render $gt'() {


### PR DESCRIPTION
I'm not sure @jyemin if this is what you had in mind for $not, but the `NotFilter` didn't do the same as a `$not` operation.  Now $not is composible inline with other operations eg: `not("myField", eq(1))`.

$nor is just a simple collection of bson filters - so is simple enough.

JAVA-1663

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rozza/mongo-java-driver/71)
<!-- Reviewable:end -->
