### PR TITLE
Fix regression in ObjectId.compareTo

### DIFF
--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -405,22 +405,14 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
             throw new NullPointerException();
         }
 
-        int x = timestamp - other.timestamp;
-        if (x != 0) {
-            return x;
+        byte[] byteArray = toByteArray();
+        byte[] otherByteArray = other.toByteArray();
+        for (int i = 0; i < 12; i++) {
+            if (byteArray[i] != otherByteArray[i]) {
+                return Integer.compare(byteArray[i] + Integer.MIN_VALUE, otherByteArray[i] + Integer.MIN_VALUE);
+            }
         }
-
-        x = machineIdentifier - other.machineIdentifier;
-        if (x != 0) {
-            return x;
-        }
-
-        x = processIdentifier - other.processIdentifier;
-        if (x != 0) {
-            return x;
-        }
-
-        return counter - other.counter;
+        return 0;
     }
 
     @Override

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -409,7 +409,7 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         byte[] otherByteArray = other.toByteArray();
         for (int i = 0; i < 12; i++) {
             if (byteArray[i] != otherByteArray[i]) {
-                return Integer.compare(byteArray[i] + Integer.MIN_VALUE, otherByteArray[i] + Integer.MIN_VALUE);
+                return Integer.compare(byteArray[i] & 0xff, otherByteArray[i] & 0xff);
             }
         }
         return 0;

--- a/bson/src/test/unit/org/bson/types/ObjectIdTest.java
+++ b/bson/src/test/unit/org/bson/types/ObjectIdTest.java
@@ -113,11 +113,13 @@ public class ObjectIdTest {
         assertEquals(-1, new ObjectId(0, 0, (short) 0, 0).compareTo(new ObjectId(1, 0, (short) 0, 0)));
         assertEquals(-1, new ObjectId(0, 0, (short) 0, 0).compareTo(new ObjectId(0, 1, (short) 0, 0)));
         assertEquals(-1, new ObjectId(0, 0, (short) 0, 0).compareTo(new ObjectId(0, 0, (short) 1, 0)));
+        assertEquals(-1, new ObjectId(0, 0, (short) 1, 0).compareTo(new ObjectId(0, 0, (short) -1, 0)));
         assertEquals(-1, new ObjectId(0, 0, (short) 0, 0).compareTo(new ObjectId(0, 0, (short) 0, 1)));
         assertEquals(0, new ObjectId(0, 0, (short) 0, 0).compareTo(new ObjectId(0, 0, (short) 0, 0)));
         assertEquals(1, new ObjectId(1, 0, (short) 0, 0).compareTo(new ObjectId(0, 0, (short) 0, 0)));
         assertEquals(1, new ObjectId(0, 1, (short) 0, 0).compareTo(new ObjectId(0, 0, (short) 0, 0)));
         assertEquals(1, new ObjectId(0, 0, (short) 1, 0).compareTo(new ObjectId(0, 0, (short) 0, 0)));
+        assertEquals(1, new ObjectId(0, 0, (short) -1, 0).compareTo(new ObjectId(0, 0, (short) 1, 0)));
         assertEquals(1, new ObjectId(0, 0, (short) 0, 1).compareTo(new ObjectId(0, 0, (short) 0, 0)));
     }
 

--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -8,6 +8,12 @@
     </Match>
 
     <Match>
+        <Class name="org.bson.types.ObjectId">
+            <Bug pattern="BIT_ADD_OF_SIGNED_BYTE"/>  <!-- Integer.compare implementation is copied from Integer.compareUnsigned  -->
+        </Class>
+    </Match>
+
+    <Match>
         <Package name="com.mongodb">
             <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS"/>  <!-- Deliberately ignoring this, as many BSONObject subclasses don't do it -->
         </Package>

--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -8,12 +8,6 @@
     </Match>
 
     <Match>
-        <Class name="org.bson.types.ObjectId">
-            <Bug pattern="BIT_ADD_OF_SIGNED_BYTE"/>  <!-- Integer.compare implementation is copied from Integer.compareUnsigned  -->
-        </Class>
-    </Match>
-
-    <Match>
         <Package name="com.mongodb">
             <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS"/>  <!-- Deliberately ignoring this, as many BSONObject subclasses don't do it -->
         </Package>


### PR DESCRIPTION
Now checks the byte array unsigned int values
JAVA-1785

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rozza/mongo-java-driver/90)
<!-- Reviewable:end -->
