### PR TITLE
Updated the MapReduceIterable API docs

### DIFF
--- a/driver/src/main/com/mongodb/client/MapReduceIterable.java
+++ b/driver/src/main/com/mongodb/client/MapReduceIterable.java
@@ -22,7 +22,10 @@ import org.bson.conversions.Bson;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Iterable for map reduce.
+ * Iterable for map-reduce.
+ *
+ * <p>By default the {@code MapReduceIterable} returns the results inline. You can write map-reduce output to a collection by using the
+ * {@link MapReduceIterable#collectionName(String)} method.</p>
  *
  * @param <TResult> The type of the result.
  * @since 3.0


### PR DESCRIPTION
Clarified that by default map reduces are inline
JAVA-1932

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rozza/mongo-java-driver/103)
<!-- Reviewable:end -->
