### PR TITLE
Netty fixed readTimeout

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -68,3 +68,20 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+6) The following files: ReadTimeoutHandler.java
+
+    Copyright 2015 MongoDB, Inc.
+    Copyright 2012 The Netty Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/driver-core/src/main/com/mongodb/connection/FutureAsyncCompletionHandler.java
+++ b/driver-core/src/main/com/mongodb/connection/FutureAsyncCompletionHandler.java
@@ -64,10 +64,8 @@ class FutureAsyncCompletionHandler<T> implements AsyncCompletionHandler<T> {
         if (error != null) {
             if (error instanceof IOException) {
                 throw (IOException) error;
-            } else if (error instanceof MongoSocketReadTimeoutException) {
-                throw (MongoSocketReadTimeoutException) error;
-            } else if (error instanceof MongoSocketOpenException) {
-                throw (MongoSocketOpenException) error;
+            } else if (error instanceof MongoException) {
+                throw (MongoException) error;
             } else {
                 throw new MongoInternalException(prefix + " the AsynchronousSocketChannelStream failed", error);
             }

--- a/driver-core/src/main/com/mongodb/connection/FutureAsyncCompletionHandler.java
+++ b/driver-core/src/main/com/mongodb/connection/FutureAsyncCompletionHandler.java
@@ -16,8 +16,11 @@
 
 package com.mongodb.connection;
 
+import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
 import com.mongodb.MongoInterruptedException;
+import com.mongodb.MongoSocketOpenException;
+import com.mongodb.MongoSocketReadTimeoutException;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
@@ -61,6 +64,10 @@ class FutureAsyncCompletionHandler<T> implements AsyncCompletionHandler<T> {
         if (error != null) {
             if (error instanceof IOException) {
                 throw (IOException) error;
+            } else if (error instanceof MongoSocketReadTimeoutException) {
+                throw (MongoSocketReadTimeoutException) error;
+            } else if (error instanceof MongoSocketOpenException) {
+                throw (MongoSocketOpenException) error;
             } else {
                 throw new MongoInternalException(prefix + " the AsynchronousSocketChannelStream failed", error);
             }

--- a/driver-core/src/main/com/mongodb/connection/netty/ReadTimeoutHandler.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/ReadTimeoutHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ * Copyright 2012 The Netty Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection.netty;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.timeout.ReadTimeoutException;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * Passes a {@link ReadTimeoutException} if the time between a {@link #scheduleTimeout} and {@link #removeTimeout} is longer than the set
+ * timeout.
+ */
+final class ReadTimeoutHandler extends ChannelInboundHandlerAdapter {
+    private final long readTimeout;
+    private volatile ScheduledFuture<?> timeout;
+    private volatile long lastReadTime;
+
+    public ReadTimeoutHandler(final long readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    void scheduleTimeout(final ChannelHandlerContext ctx) {
+        if (readTimeout > 0) {
+            lastReadTime = System.currentTimeMillis();
+            timeout = ctx.executor().schedule(new ReadTimeoutTask(ctx), readTimeout, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    void removeTimeout(final ChannelHandlerContext ctx) {
+        if (readTimeout > 0 && ctx.channel().eventLoop().inEventLoop()) {
+            if (timeout != null) {
+                timeout.cancel(false);
+            }
+        }
+    }
+
+    private final class ReadTimeoutTask implements Runnable {
+
+        private final ChannelHandlerContext ctx;
+
+        ReadTimeoutTask(final ChannelHandlerContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void run() {
+            if (!ctx.channel().isOpen()) {
+                return;
+            }
+
+            long currentTime = System.nanoTime();
+            long nextDelay = readTimeout - (currentTime - lastReadTime);
+            if (nextDelay <= 0) {
+                try {
+                    ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+                    ctx.close();
+                } catch (Throwable t) {
+                    ctx.fireExceptionCaught(t);
+                }
+            } else {
+                // Read occurred before the timeout - set a new timeout with shorter delay.
+                timeout = ctx.executor().schedule(this, nextDelay, TimeUnit.MILLISECONDS);
+            }
+        }
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/AsyncStreamTimeoutsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/AsyncStreamTimeoutsSpecification.groovy
@@ -15,6 +15,7 @@
  */
 
 package com.mongodb.connection
+
 import category.Slow
 import com.mongodb.MongoSocketOpenException
 import com.mongodb.MongoSocketReadTimeoutException
@@ -43,10 +44,8 @@ class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification 
     static SocketSettings readSocketSettings = SocketSettings.builder().readTimeout(5, TimeUnit.SECONDS).build();
 
     @Unroll
-    def 'should the #description should throw a MongoSocketOpenException on failing to open'() {
+    def 'should throw a MongoSocketOpenException when the #description Stream fails to open'() {
         given:
-        new Socket()
-
         def connection = new InternalStreamConnectionFactory(streamFactory, getCredentialList(), new NoOpConnectionListener())
                 .create(new ServerId(new ClusterId(), new ServerAddress(new InetSocketAddress("192.168.255.255", 27017))));
 
@@ -63,7 +62,7 @@ class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification 
     }
 
     @Unroll
-    def 'should the #description should throw a MongoSocketReadTimeoutException'() {
+    def 'should throw a MongoSocketReadTimeoutException with the #description stream'() {
         given:
         def connection = new InternalStreamConnectionFactory(streamFactory, getCredentialList(), new NoOpConnectionListener())
                 .create(new ServerId(new ClusterId(), getPrimary()))

--- a/driver-core/src/test/functional/com/mongodb/connection/AsyncStreamTimeoutsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/AsyncStreamTimeoutsSpecification.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection
+import category.Slow
+import com.mongodb.MongoSocketOpenException
+import com.mongodb.MongoSocketReadTimeoutException
+import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.ServerAddress
+import com.mongodb.connection.netty.NettyStreamFactory
+import com.mongodb.operation.CommandReadOperation
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonString
+import org.bson.codecs.BsonDocumentCodec
+import org.junit.experimental.categories.Category
+import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
+
+import static com.mongodb.ClusterFixture.getCredentialList
+import static com.mongodb.ClusterFixture.getPrimary
+import static com.mongodb.ClusterFixture.getSslSettings
+import static com.mongodb.connection.CommandHelper.executeCommand
+
+@Category(Slow)
+class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification {
+
+    static SocketSettings openSocketSettings = SocketSettings.builder().connectTimeout(1, TimeUnit.MILLISECONDS).build();
+    static SocketSettings readSocketSettings = SocketSettings.builder().readTimeout(5, TimeUnit.SECONDS).build();
+
+    @Unroll
+    def 'should the #description should throw a MongoSocketOpenException on failing to open'() {
+        given:
+        new Socket()
+
+        def connection = new InternalStreamConnectionFactory(streamFactory, getCredentialList(), new NoOpConnectionListener())
+                .create(new ServerId(new ClusterId(), new ServerAddress(new InetSocketAddress("192.168.255.255", 27017))));
+
+        when:
+        connection.open()
+
+        then:
+        thrown(MongoSocketOpenException)
+
+        where:
+        description             | streamFactory
+        'AsynchronousSocket'    | new AsynchronousSocketChannelStreamFactory(openSocketSettings, getSslSettings())
+        'NettyStream'           | new NettyStreamFactory(openSocketSettings, getSslSettings())
+    }
+
+    @Unroll
+    def 'should the #description should throw a MongoSocketReadTimeoutException'() {
+        given:
+        def connection = new InternalStreamConnectionFactory(streamFactory, getCredentialList(), new NoOpConnectionListener())
+                .create(new ServerId(new ClusterId(), getPrimary()))
+        connection.open()
+
+        getCollectionHelper().insertDocuments(new BsonDocument('_id', new BsonInt32(1)));
+        def countCommand = new BsonDocument("count", new BsonString(getCollectionName()))
+        countCommand.put("query", new BsonDocument('$where', new BsonString('sleep(5050); return true;')))
+
+        def countCommandOperation = new CommandReadOperation<BsonDocument>(getDatabaseName(), countCommand, new BsonDocumentCodec())
+
+        when:
+        executeCommand(getDatabaseName(), countCommand, connection)
+
+        then:
+        thrown(MongoSocketReadTimeoutException)
+
+        cleanup:
+        connection?.close()
+
+        where:
+        description             | streamFactory
+        'AsynchronousSocket'    | new AsynchronousSocketChannelStreamFactory(readSocketSettings, getSslSettings())
+        'NettyStream'           | new NettyStreamFactory(readSocketSettings, getSslSettings())
+    }
+
+}


### PR DESCRIPTION
Added local ReadTimeoutHandler based off the netty handler that
measures the idle time between read start and read completed. This is
inline with the AsynchronousSocketChannelStream that has a per read
request timeout.

The Netty ReadTimeoutHandler measured idle time between any reads
happening in the channel. This handler would throw an exception and close
the channel if there was a pause in asking for a read.

JAVA-1934

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rozza/mongo-java-driver/108)
<!-- Reviewable:end -->
