### PR TITLE
Now uses a cursor in the GridFSDownload Stream

### DIFF
--- a/driver/src/main/com/mongodb/client/gridfs/GridFSDownloadStream.java
+++ b/driver/src/main/com/mongodb/client/gridfs/GridFSDownloadStream.java
@@ -42,6 +42,18 @@ public abstract class GridFSDownloadStream extends InputStream {
      */
     public abstract GridFSFile getGridFSFile();
 
+    /**
+     * Sets the number of chunks to return per batch.
+     *
+     * <p>Can be used to control the memory consumption of this InputStream. The smaller the batchSize the lower the memory consumption
+     * and higher latency.</p>
+     *
+     * @param batchSize the batch size
+     * @return this
+     * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
+     */
+    public abstract GridFSDownloadStream batchSize(int batchSize);
+
     @Override
     public abstract int read();
 

--- a/driver/src/main/com/mongodb/client/gridfs/GridFSDownloadStreamImpl.java
+++ b/driver/src/main/com/mongodb/client/gridfs/GridFSDownloadStreamImpl.java
@@ -63,9 +63,7 @@ class GridFSDownloadStreamImpl extends GridFSDownloadStream {
 
     @Override
     public GridFSDownloadStream batchSize(final int batchSize) {
-        if (batchSize != 0) {
-            isTrueArgument("batchSize cannot be negative", batchSize >= 0);
-        }
+        isTrueArgument("batchSize cannot be negative", batchSize >= 0);
         this.batchSize = batchSize;
         cursor = null;
         return this;

--- a/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -204,6 +204,7 @@ class GridFSBucketSpecification extends Specification {
         1 * findIterable.first() >> fileInfo
         1 * chunksCollection.find(_) >> findIterable
         1 * findIterable.sort(_) >> findIterable
+        1 * findIterable.batchSize(_) >> findIterable
         1 * findIterable.iterator() >> mongoCursor
         1 * mongoCursor.hasNext() >> true
         1 * mongoCursor.next() >> chunkDocument
@@ -241,6 +242,7 @@ class GridFSBucketSpecification extends Specification {
         1 * findIterable.first() >> fileInfo
         1 * chunksCollection.find(_) >> findIterable
         1 * findIterable.sort(_) >> findIterable
+        1 * findIterable.batchSize(_) >> findIterable
         1 * findIterable.iterator() >> mongoCursor
         1 * mongoCursor.hasNext() >> true
         1 * mongoCursor.next() >> chunkDocument
@@ -283,6 +285,7 @@ class GridFSBucketSpecification extends Specification {
         then:
         1 * chunksCollection.find(_) >> findIterable
         1 * findIterable.sort(_) >> findIterable
+        1 * findIterable.batchSize(_) >> findIterable
         1 * findIterable.iterator() >> mongoCursor
         1 * mongoCursor.hasNext() >> true
         1 * mongoCursor.next() >> chunkDocument


### PR DESCRIPTION
The second commit adds batchSize support - so users can control memory consumption v latency.

JAVA-1916

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rozza/mongo-java-driver/109)
<!-- Reviewable:end -->
