### PR TITLE
Docs API header updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,28 @@ configure(subprojects.findAll { it.name != 'util' }) {
         options.encoding = 'UTF-8'
         options.charSet 'UTF-8'
         options.docEncoding 'UTF-8'
+        options.header = '''
+            <script type="text/javascript">
+            <!-- Set the location hash in the classFrame -->
+            try {
+              locationHash = top.location.hash;
+              if (window.name == "classFrame" && locationHash != "") {
+                window.location.hash = locationHash;
+              }
+            } catch (error) {}
+            <!-- GA Tracking code -->
+            if (window.name == "" || window.name == "classFrame") {
+                var _elqQ = _elqQ || [];
+                _elqQ.push(["elqSetSiteId", "413370795"]);
+                _elqQ.push(["elqTrackPageView"]);
+                (function () {
+                function async_load() { var s = document.createElement("script"); s.type = "text/javascript"; s.async = true; s.src = "//img03.en25.com/i/elqCfg.min.js"; var x = document.getElementsByTagName("script")[0]; x.parentNode.insertBefore(s, x); }
+                if (window.addEventListener) window.addEventListener("DOMContentLoaded", async_load, false);
+                else if (window.attachEvent) window.attachEvent("onload", async_load);
+                })();
+            }
+            </script>
+        '''
     }
 }
 


### PR DESCRIPTION
Ensures the location hash is passed to the "classFrames" frame. This is
done in a try / catch due so doesn't error due to same origin policy.

Added google analytics tag.  Have to check if we are in frames view, then
the only page we care about is the "classFrame" or in no frames view then
we always care.

JAVA-1724

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rozza/mongo-java-driver/111)
<!-- Reviewable:end -->
