### PR TITLE
Ensure that the underlying collections are updated correctly

### DIFF
--- a/driver/src/main/com/mongodb/client/gridfs/GridFSBucketImpl.java
+++ b/driver/src/main/com/mongodb/client/gridfs/GridFSBucketImpl.java
@@ -44,11 +44,11 @@ import java.util.ArrayList;
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.lang.String.format;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 
 @SuppressWarnings("deprecation")
 final class GridFSBucketImpl implements GridFSBucket {
     private static final int DEFAULT_CHUNKSIZE_BYTES = 255 * 1024;
-    private final MongoDatabase database;
     private final String bucketName;
     private final int chunkSizeBytes;
     private final MongoCollection<Document> filesCollection;
@@ -60,20 +60,13 @@ final class GridFSBucketImpl implements GridFSBucket {
     }
 
     GridFSBucketImpl(final MongoDatabase database, final String bucketName) {
-        this(notNull("database", database), notNull("bucketName", bucketName), DEFAULT_CHUNKSIZE_BYTES, database.getReadPreference(),
-                database.getReadConcern(), database.getWriteConcern());
+        this(notNull("bucketName", bucketName), DEFAULT_CHUNKSIZE_BYTES,
+                getFilesCollection(notNull("database", database), bucketName),
+                getChunksCollection(database, bucketName));
     }
 
-    GridFSBucketImpl(final MongoDatabase database, final String bucketName, final int chunkSizeBytes, final ReadPreference readPreference,
-                     final ReadConcern readConcern, final WriteConcern writeConcern) {
-        this(database, bucketName, chunkSizeBytes,
-                getFilesCollection(database, bucketName, readPreference, readConcern, writeConcern),
-                getChunksCollection(database, bucketName, readPreference, readConcern, writeConcern));
-    }
-
-    GridFSBucketImpl(final MongoDatabase database, final String bucketName, final int chunkSizeBytes,
-                     final MongoCollection<Document> filesCollection, final MongoCollection<Document> chunksCollection) {
-        this.database = notNull("database", database);
+    GridFSBucketImpl(final String bucketName, final int chunkSizeBytes, final MongoCollection<Document> filesCollection,
+                     final MongoCollection<Document> chunksCollection) {
         this.bucketName = notNull("bucketName", bucketName);
         this.chunkSizeBytes = chunkSizeBytes;
         this.filesCollection = notNull("filesCollection", filesCollection);
@@ -107,22 +100,25 @@ final class GridFSBucketImpl implements GridFSBucket {
 
     @Override
     public GridFSBucket withChunkSizeBytes(final int chunkSizeBytes) {
-        return new GridFSBucketImpl(database, bucketName, chunkSizeBytes, getReadPreference(), getReadConcern(), getWriteConcern());
+        return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection, chunksCollection);
     }
 
     @Override
     public GridFSBucket withReadPreference(final ReadPreference readPreference) {
-        return new GridFSBucketImpl(database, bucketName, chunkSizeBytes, readPreference, getReadConcern(), getWriteConcern());
+        return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection.withReadPreference(readPreference),
+                chunksCollection.withReadPreference(readPreference));
     }
 
     @Override
     public GridFSBucket withWriteConcern(final WriteConcern writeConcern) {
-        return new GridFSBucketImpl(database, bucketName, chunkSizeBytes, getReadPreference(), getReadConcern(), writeConcern);
+        return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection.withWriteConcern(writeConcern),
+                chunksCollection.withWriteConcern(writeConcern));
     }
 
     @Override
     public GridFSBucket withReadConcern(final ReadConcern readConcern) {
-        return new GridFSBucketImpl(database, bucketName, chunkSizeBytes, getReadPreference(), readConcern, getWriteConcern());
+        return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection.withReadConcern(readConcern),
+                chunksCollection.withReadConcern(readConcern));
     }
 
     @Override
@@ -236,26 +232,13 @@ final class GridFSBucketImpl implements GridFSBucket {
         chunksCollection.drop();
     }
 
-    private static MongoCollection<Document> getFilesCollection(final MongoDatabase database, final String bucketName,
-                                                                final ReadPreference readPreference, final ReadConcern readConcern,
-                                                                final WriteConcern writeConcern) {
-        return getCollection(database, bucketName + ".files", readPreference, readConcern, writeConcern);
+    private static MongoCollection<Document> getFilesCollection(final MongoDatabase database, final String bucketName) {
+        return database.getCollection(bucketName + ".files").withCodecRegistry(fromRegistries(database.getCodecRegistry(),
+                MongoClient.getDefaultCodecRegistry()));
     }
 
-    private static MongoCollection<Document> getChunksCollection(final MongoDatabase database, final String bucketName,
-                                                                 final ReadPreference readPreference, final ReadConcern readConcern,
-                                                                 final WriteConcern writeConcern) {
-        return getCollection(database, bucketName + ".chunks", readPreference, readConcern, writeConcern);
-    }
-
-    private static MongoCollection<Document> getCollection(final MongoDatabase database, final String collectionName,
-                                                           final ReadPreference readPreference, final ReadConcern readConcern,
-                                                           final WriteConcern writeConcern) {
-        return database.getCollection(collectionName)
-                .withCodecRegistry(MongoClient.getDefaultCodecRegistry())
-                .withReadPreference(readPreference)
-                .withReadConcern(readConcern)
-                .withWriteConcern(writeConcern);
+    private static MongoCollection<Document> getChunksCollection(final MongoDatabase database, final String bucketName) {
+        return database.getCollection(bucketName + ".chunks").withCodecRegistry(MongoClient.getDefaultCodecRegistry());
     }
 
     private void checkCreateIndex() {

--- a/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -87,36 +87,62 @@ class GridFSBucketSpecification extends Specification {
 
     def 'should behave correctly when using withReadPreference'() {
         given:
+        def filesCollection = Mock(MongoCollection)
+        def chunksCollection = Mock(MongoCollection)
         def newReadPreference = secondary()
 
         when:
-        def gridFSBucket = new GridFSBucketImpl(database).withReadPreference(newReadPreference)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection).withReadPreference(newReadPreference)
 
         then:
-        gridFSBucket.getReadPreference() == newReadPreference
+        1 * filesCollection.withReadPreference(newReadPreference) >> filesCollection
+        1 * chunksCollection.withReadPreference(newReadPreference) >> chunksCollection
+
+        when:
+        gridFSBucket.getReadConcern()
+
+        then:
+        1 * filesCollection.getReadConcern()
     }
 
     def 'should behave correctly when using withWriteConcern'() {
         given:
+        def filesCollection = Mock(MongoCollection)
+        def chunksCollection = Mock(MongoCollection)
         def newWriteConcern = WriteConcern.MAJORITY
 
         when:
-        def gridFSBucket = new GridFSBucketImpl(database).withWriteConcern(newWriteConcern)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection).withWriteConcern(newWriteConcern)
 
         then:
-        gridFSBucket.getWriteConcern() == newWriteConcern
+        1 * filesCollection.withWriteConcern(newWriteConcern) >> filesCollection
+        1 * chunksCollection.withWriteConcern(newWriteConcern) >> chunksCollection
+
+        when:
+        gridFSBucket.getWriteConcern()
+
+        then:
+        1 * filesCollection.getWriteConcern()
     }
 
     def 'should behave correctly when using withReadConcern'() {
         given:
+        def filesCollection = Mock(MongoCollection)
+        def chunksCollection = Mock(MongoCollection)
         def newReadConcern = ReadConcern.MAJORITY
 
-
         when:
-        def gridFSBucket = new GridFSBucketImpl(database).withReadConcern(newReadConcern)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection).withReadConcern(newReadConcern)
 
         then:
-        gridFSBucket.getReadConcern() == newReadConcern
+        1 * filesCollection.withReadConcern(newReadConcern) >> filesCollection
+        1 * chunksCollection.withReadConcern(newReadConcern) >> chunksCollection
+
+        when:
+        gridFSBucket.getReadConcern()
+
+        then:
+        1 * filesCollection.getReadConcern() >> newReadConcern
     }
 
     def 'should get defaults from MongoDatabase'() {

--- a/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -16,10 +16,11 @@
 
 package com.mongodb.client.gridfs
 
+import com.mongodb.MongoClient
 import com.mongodb.MongoDatabaseImpl
 import com.mongodb.MongoGridFSException
+import com.mongodb.MongoNamespace
 import com.mongodb.ReadConcern
-import com.mongodb.ReadPreference
 import com.mongodb.TestOperationExecutor
 import com.mongodb.WriteConcern
 import com.mongodb.client.FindIterable
@@ -31,11 +32,15 @@ import com.mongodb.client.gridfs.model.GridFSDownloadByNameOptions
 import com.mongodb.client.gridfs.model.GridFSFile
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
+import com.mongodb.operation.BatchCursor
+import com.mongodb.operation.FindOperation
+import com.mongodb.operation.OperationExecutor
+import org.bson.BsonDocument
 import org.bson.BsonObjectId
 import org.bson.BsonString
 import org.bson.Document
+import org.bson.codecs.DocumentCodec
 import org.bson.codecs.DocumentCodecProvider
-import org.bson.codecs.configuration.CodecRegistry
 import org.bson.types.Binary
 import org.bson.types.ObjectId
 import spock.lang.Specification
@@ -51,13 +56,12 @@ import static spock.util.matcher.HamcrestSupport.expect
 class GridFSBucketSpecification extends Specification {
 
     def readConcern = ReadConcern.DEFAULT
+    def database = databaseWithExecutor(Stub(OperationExecutor))
+    def databaseWithExecutor(OperationExecutor executor) {
+        new MongoDatabaseImpl('test', MongoClient.defaultCodecRegistry, primary(), WriteConcern.ACKNOWLEDGED, readConcern, executor)
+    }
 
     def 'should return the correct bucket name'() {
-        given:
-        def database = Stub(MongoDatabase) {
-            getReadConcern() >> ReadConcern.DEFAULT
-        }
-
         when:
         def bucketName = new GridFSBucketImpl(database).getBucketName()
 
@@ -74,9 +78,6 @@ class GridFSBucketSpecification extends Specification {
     def 'should behave correctly when using withChunkSizeBytes'() {
         given:
         def newChunkSize = 200
-        def database = Stub(MongoDatabase) {
-            getReadConcern() >> ReadConcern.DEFAULT
-        }
 
         when:
         def gridFSBucket = new GridFSBucketImpl(database).withChunkSizeBytes(newChunkSize)
@@ -87,10 +88,7 @@ class GridFSBucketSpecification extends Specification {
 
     def 'should behave correctly when using withReadPreference'() {
         given:
-        def newReadPreference = primary()
-        def database = Stub(MongoDatabase) {
-            getReadConcern() >> ReadConcern.DEFAULT
-        }
+        def newReadPreference = secondary()
 
         when:
         def gridFSBucket = new GridFSBucketImpl(database).withReadPreference(newReadPreference)
@@ -102,9 +100,6 @@ class GridFSBucketSpecification extends Specification {
     def 'should behave correctly when using withWriteConcern'() {
         given:
         def newWriteConcern = WriteConcern.MAJORITY
-        def database = Stub(MongoDatabase) {
-            getReadConcern() >> ReadConcern.DEFAULT
-        }
 
         when:
         def gridFSBucket = new GridFSBucketImpl(database).withWriteConcern(newWriteConcern)
@@ -116,9 +111,7 @@ class GridFSBucketSpecification extends Specification {
     def 'should behave correctly when using withReadConcern'() {
         given:
         def newReadConcern = ReadConcern.MAJORITY
-        def database = Stub(MongoDatabase) {
-            getReadConcern() >> ReadConcern.DEFAULT
-        }
+
 
         when:
         def gridFSBucket = new GridFSBucketImpl(database).withReadConcern(newReadConcern)
@@ -147,8 +140,7 @@ class GridFSBucketSpecification extends Specification {
         given:
         def filesCollection = Stub(MongoCollection)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         def stream = gridFSBucket.openUploadStream('filename')
@@ -160,15 +152,21 @@ class GridFSBucketSpecification extends Specification {
 
     def 'should upload from stream'() {
         given:
+        def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
         def contentBytes = 'content' as byte[]
         def inputStream = new ByteArrayInputStream(contentBytes)
 
         when:
         gridFSBucket.uploadFromStream('filename', inputStream)
+
+        then: 'index check'
+        1 * filesCollection.withReadPreference(primary()) >> filesCollection
+        1 * filesCollection.find() >> findIterable
+        1 * findIterable.projection(new Document('_id', 1)) >> findIterable
+        1 * findIterable.first() >> new Document()
 
         then:
         1 * chunksCollection.insertOne(_)
@@ -179,16 +177,22 @@ class GridFSBucketSpecification extends Specification {
 
     def 'should clean up any chunks when upload from stream throws an IOException'() {
         given:
+        def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
         def inputStream = Mock(InputStream) {
             2 * read(_) >> 255 >> { throw new IOException('stream failure') }
         }
 
         when:
         gridFSBucket.uploadFromStream('filename', inputStream)
+
+        then: 'index check'
+        1 * filesCollection.withReadPreference(primary()) >> filesCollection
+        1 * filesCollection.find() >> findIterable
+        1 * findIterable.projection(new Document('_id', 1)) >> findIterable
+        1 * findIterable.first() >> new Document()
 
         then:
         1 * chunksCollection.insertOne(_)
@@ -206,17 +210,23 @@ class GridFSBucketSpecification extends Specification {
 
     def 'should not clean up any chunks when upload throws an exception'() {
         given:
+        def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def alternativeException = new MongoGridFSException('Alternative failure')
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
         def inputStream = Mock(InputStream) {
             2 * read(_) >> 255 >> { throw alternativeException }
         }
 
         when:
         gridFSBucket.uploadFromStream('filename', inputStream)
+
+        then: 'index check'
+        1 * filesCollection.withReadPreference(primary()) >> filesCollection
+        1 * filesCollection.find() >> findIterable
+        1 * findIterable.projection(new Document('_id', 1)) >> findIterable
+        1 * findIterable.first() >> new Document()
 
         then:
         1 * chunksCollection.insertOne(_)
@@ -241,8 +251,7 @@ class GridFSBucketSpecification extends Specification {
             1 * find() >> findIterable
         }
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255,  Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         def stream = gridFSBucket.openDownloadStream(fileId.getValue())
@@ -269,8 +278,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[10]
         def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255,  Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
 
         when:
@@ -304,8 +312,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[10]
         def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255,  Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
 
         when:
@@ -341,8 +348,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[10]
         def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
 
         when:
@@ -376,8 +382,7 @@ class GridFSBucketSpecification extends Specification {
             1 * find() >> findIterable
         }
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.openDownloadStream(fileId)
@@ -403,8 +408,7 @@ class GridFSBucketSpecification extends Specification {
             1 * find() >> findIterable
         }
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         def stream = gridFSBucket.openDownloadStreamByName(filename, new GridFSDownloadByNameOptions().revision(version))
@@ -432,28 +436,28 @@ class GridFSBucketSpecification extends Specification {
 
     def 'should create the expected GridFSFindIterable'() {
         given:
-        def database = Mock(MongoDatabase)
-        def collection = Mock(MongoCollection)
-        def findIterable = Mock(FindIterable)
-        def filter = new Document('filename', 'filename')
-        def gridFSBucket = new GridFSBucketImpl(database, 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, collection, Stub(MongoCollection), true)
+        def executor = new TestOperationExecutor([Stub(BatchCursor), Stub(BatchCursor)])
+        def database = databaseWithExecutor(executor)
+        def gridFSBucket = new GridFSBucketImpl(database)
+        def decoder = new DocumentCodec()
 
         when:
-        def result = gridFSBucket.find()
-
+        gridFSBucket.find().iterator()
 
         then:
-        1 * collection.find() >> findIterable
-        expect result, isTheSameAs(new GridFSFindIterableImpl(findIterable))
+        executor.getReadPreference() == primary()
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation<Document>(new MongoNamespace('test.fs.files'), decoder)
+                .filter(new BsonDocument()))
 
         when:
-        result = gridFSBucket.find(filter)
+        def filter = new BsonDocument('filename', new BsonString('filename'))
+        def readConcern = ReadConcern.MAJORITY
+        gridFSBucket.withReadPreference(secondary()).withReadConcern(readConcern).find(filter).iterator()
 
         then:
-        1 * collection.find() >> findIterable
-        1 * findIterable.filter(filter)
-        expect result, isTheSameAs(new GridFSFindIterableImpl(findIterable))
+        executor.getReadPreference() == secondary()
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation<Document>(new MongoNamespace('test.fs.files'), decoder)
+                .readConcern(readConcern).filter(filter).slaveOk(true))
     }
 
     def 'should throw an exception if file not found when opening by name'() {
@@ -461,8 +465,7 @@ class GridFSBucketSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def findIterable = Mock(FindIterable)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
         when:
         gridFSBucket.openDownloadStreamByName('filename')
 
@@ -484,8 +487,7 @@ class GridFSBucketSpecification extends Specification {
         def chunksCollection = Mock(MongoCollection)
         def listIndexesIterable = Mock(ListIndexesIterable)
         def findIterable = Mock(FindIterable)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, false)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.openUploadStream('filename')
@@ -520,8 +522,7 @@ class GridFSBucketSpecification extends Specification {
         def chunksCollection = Mock(MongoCollection)
         def listIndexesIterable = Mock(ListIndexesIterable)
         def findIterable = Mock(FindIterable)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, false)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.openUploadStream('filename')
@@ -556,8 +557,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.delete(fileId)
@@ -574,8 +574,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.delete(fileId)
@@ -595,8 +594,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def newFilename = 'newFilename'
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, Stub(MongoCollection), true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, Stub(MongoCollection))
 
         when:
         gridFSBucket.rename(fileId, newFilename)
@@ -614,8 +612,7 @@ class GridFSBucketSpecification extends Specification {
             1 * updateOne(_, _) >> new UpdateResult.AcknowledgedUpdateResult(0, 0, null)
         }
         def newFilename = 'newFilename'
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, Stub(MongoCollection), true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, Stub(MongoCollection))
 
         when:
         gridFSBucket.rename(fileId, newFilename)
@@ -628,8 +625,7 @@ class GridFSBucketSpecification extends Specification {
         given:
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, Stub(CodecRegistry), Stub(ReadPreference),
-                Stub(WriteConcern), readConcern, filesCollection, chunksCollection, true)
+        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.drop()

--- a/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -461,6 +461,21 @@ class GridFSBucketSpecification extends Specification {
 
     def 'should create the expected GridFSFindIterable'() {
         given:
+        def collection = Mock(MongoCollection)
+        def findIterable = Mock(FindIterable)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, collection, Stub(MongoCollection))
+
+
+        when:
+        def result = gridFSBucket.find()
+
+        then:
+        1 * collection.find() >> findIterable
+        expect result, isTheSameAs(new GridFSFindIterableImpl(findIterable))
+    }
+
+    def 'should execute the expected FindOperation when finding a file'() {
+        given:
         def executor = new TestOperationExecutor([Stub(BatchCursor), Stub(BatchCursor)])
         def database = databaseWithExecutor(executor)
         def gridFSBucket = new GridFSBucketImpl(database)

--- a/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -27,7 +27,6 @@ import com.mongodb.client.FindIterable
 import com.mongodb.client.ListIndexesIterable
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoCursor
-import com.mongodb.client.MongoDatabase
 import com.mongodb.client.gridfs.model.GridFSDownloadByNameOptions
 import com.mongodb.client.gridfs.model.GridFSFile
 import com.mongodb.client.result.DeleteResult
@@ -58,7 +57,7 @@ class GridFSBucketSpecification extends Specification {
     def readConcern = ReadConcern.DEFAULT
     def database = databaseWithExecutor(Stub(OperationExecutor))
     def databaseWithExecutor(OperationExecutor executor) {
-        new MongoDatabaseImpl('test', MongoClient.defaultCodecRegistry, primary(), WriteConcern.ACKNOWLEDGED, readConcern, executor)
+        new MongoDatabaseImpl('test', MongoClient.getDefaultCodecRegistry(), primary(), WriteConcern.ACKNOWLEDGED, readConcern, executor)
     }
 
     def 'should return the correct bucket name'() {
@@ -140,7 +139,7 @@ class GridFSBucketSpecification extends Specification {
         given:
         def filesCollection = Stub(MongoCollection)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def stream = gridFSBucket.openUploadStream('filename')
@@ -155,7 +154,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def contentBytes = 'content' as byte[]
         def inputStream = new ByteArrayInputStream(contentBytes)
 
@@ -180,7 +179,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def inputStream = Mock(InputStream) {
             2 * read(_) >> 255 >> { throw new IOException('stream failure') }
         }
@@ -214,7 +213,7 @@ class GridFSBucketSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def alternativeException = new MongoGridFSException('Alternative failure')
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def inputStream = Mock(InputStream) {
             2 * read(_) >> 255 >> { throw alternativeException }
         }
@@ -251,7 +250,7 @@ class GridFSBucketSpecification extends Specification {
             1 * find() >> findIterable
         }
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def stream = gridFSBucket.openDownloadStream(fileId.getValue())
@@ -278,7 +277,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[10]
         def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
 
         when:
@@ -312,7 +311,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[10]
         def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
 
         when:
@@ -348,7 +347,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[10]
         def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
 
         when:
@@ -382,7 +381,7 @@ class GridFSBucketSpecification extends Specification {
             1 * find() >> findIterable
         }
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.openDownloadStream(fileId)
@@ -408,7 +407,7 @@ class GridFSBucketSpecification extends Specification {
             1 * find() >> findIterable
         }
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def stream = gridFSBucket.openDownloadStreamByName(filename, new GridFSDownloadByNameOptions().revision(version))
@@ -465,7 +464,7 @@ class GridFSBucketSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def findIterable = Mock(FindIterable)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         when:
         gridFSBucket.openDownloadStreamByName('filename')
 
@@ -487,7 +486,7 @@ class GridFSBucketSpecification extends Specification {
         def chunksCollection = Mock(MongoCollection)
         def listIndexesIterable = Mock(ListIndexesIterable)
         def findIterable = Mock(FindIterable)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.openUploadStream('filename')
@@ -522,7 +521,7 @@ class GridFSBucketSpecification extends Specification {
         def chunksCollection = Mock(MongoCollection)
         def listIndexesIterable = Mock(ListIndexesIterable)
         def findIterable = Mock(FindIterable)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.openUploadStream('filename')
@@ -557,7 +556,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.delete(fileId)
@@ -574,7 +573,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.delete(fileId)
@@ -594,7 +593,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def newFilename = 'newFilename'
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, Stub(MongoCollection))
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, Stub(MongoCollection))
 
         when:
         gridFSBucket.rename(fileId, newFilename)
@@ -612,7 +611,7 @@ class GridFSBucketSpecification extends Specification {
             1 * updateOne(_, _) >> new UpdateResult.AcknowledgedUpdateResult(0, 0, null)
         }
         def newFilename = 'newFilename'
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, Stub(MongoCollection))
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, Stub(MongoCollection))
 
         when:
         gridFSBucket.rename(fileId, newFilename)
@@ -625,7 +624,7 @@ class GridFSBucketSpecification extends Specification {
         given:
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl(Stub(MongoDatabase), 'fs', 255, filesCollection, chunksCollection)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.drop()


### PR DESCRIPTION
When the user sets a new ReadConcern, ReadPreference or WriteConcern those changes
should be reflected in the underlying files and chunks collections.

JAVA-2049