### PR TITLE
NettyStream fix

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
@@ -149,14 +149,7 @@ final class NettyStream implements Stream {
                     channel.closeFuture().addListener(new ChannelFutureListener() {
                         @Override
                         public void operationComplete(final ChannelFuture f2) throws Exception {
-                            PendingReader pending = null;
-                            synchronized (this) {
-                                pending = pendingReader;
-                                pendingReader = null;
-                            }
-                            if (pending != null) {
-                                pending.handler.failed(new MongoSocketException("The connection to the server was closed", address));
-                            }
+                            handleReadResponse(null, new IOException("The connection to the server was closed"));
                         }
                     });
                     handler.completed(null);


### PR DESCRIPTION
Ensure any cleanly closed connections from the server notify any
pending readers that the connection has closed.

JAVA-2306