### PR TITLE
Revert DBCollection.find requring notNull queries

### DIFF
--- a/driver/src/main/com/mongodb/DBCursor.java
+++ b/driver/src/main/com/mongodb/DBCursor.java
@@ -103,7 +103,7 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
     private DBCursor(final DBCollection collection, final DBObject filter, final DBCollectionFindOptions findOptions,
                      final OperationExecutor executor, final DBDecoderFactory decoderFactory, final Decoder<DBObject> decoder) {
         this.collection = notNull("collection", collection);
-        this.filter = notNull("filter", filter);
+        this.filter = filter;
         this.executor = notNull("executor", executor);
         this.findOptions = notNull("findOptions", findOptions.copy());
         this.decoderFactory = decoderFactory;

--- a/driver/src/test/functional/com/mongodb/DBCollectionTest.java
+++ b/driver/src/test/functional/com/mongodb/DBCollectionTest.java
@@ -124,6 +124,12 @@ public class DBCollectionTest extends DatabaseTestCase {
     }
 
     @Test
+    public void testFindWithNullQuery() {
+        collection.insert(new BasicDBObject("_id", 1).append("x", 2));
+        assertEquals(new BasicDBObject("_id", 1).append("x", 2), collection.find(null).next());
+    }
+
+    @Test
     public void testInsertDuplicateKeyException() {
         DBObject doc = new BasicDBObject("_id", 1);
         collection.insert(doc, WriteConcern.ACKNOWLEDGED);


### PR DESCRIPTION
Historically it has, so changing it breaks existing behaviour.
JAVA-2322