### PR TITLE
Ensure use of generateIdIfAbsentFromDocument assigns the result

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
@@ -270,7 +270,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
             } else if (writeModel instanceof InsertOneModel) {
                 TDocument document = ((InsertOneModel<TDocument>) writeModel).getDocument();
                 if (getCodec() instanceof CollectibleCodec) {
-                    ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
+                    document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
                 }
                 writeRequest = new InsertRequest(documentToBsonDocument(document));
             } else if (writeModel instanceof ReplaceOneModel) {
@@ -322,7 +322,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     public void insertOne(final TDocument document, final InsertOneOptions options, final SingleResultCallback<Void> callback) {
         TDocument insertDocument = document;
         if (getCodec() instanceof CollectibleCodec) {
-            ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(insertDocument);
+            insertDocument = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(insertDocument);
         }
         executeSingleWriteRequest(new InsertRequest(documentToBsonDocument(insertDocument)), options.getBypassDocumentValidation(),
                 new SingleResultCallback<BulkWriteResult>() {

--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
@@ -38,6 +38,8 @@ import com.mongodb.bulk.IndexRequest
 import com.mongodb.bulk.InsertRequest
 import com.mongodb.bulk.UpdateRequest
 import com.mongodb.bulk.WriteConcernError
+import com.mongodb.client.ImmutableDocument
+import com.mongodb.client.ImmutableDocumentCodecProvider
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CountOptions
@@ -96,6 +98,7 @@ import static com.mongodb.bulk.WriteRequest.Type.REPLACE
 import static com.mongodb.bulk.WriteRequest.Type.UPDATE
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries
 import static spock.util.matcher.HamcrestSupport.expect
 
 @SuppressWarnings('ClassSize')
@@ -1202,6 +1205,54 @@ class MongoCollectionSpecification extends Specification {
 
         then:
         expect operation, isTheSameAs(expectedOperation)
+    }
+
+    def 'should not expect to mutate the document when inserting'() {
+        given:
+        def executor = new TestOperationExecutor([null])
+        def customCodecRegistry = fromRegistries(codecRegistry, fromProviders(new ImmutableDocumentCodecProvider()))
+        def collection = new MongoCollectionImpl(namespace, ImmutableDocument, customCodecRegistry, readPreference, writeConcern,
+                readConcern, executor)
+        def document = new ImmutableDocument(['a': 1])
+        def futureResultCallback = new FutureResultCallback<Void>()
+
+        when:
+        collection.insertOne(document, futureResultCallback)
+        futureResultCallback.get()
+
+        then:
+        !document.containsKey('_id')
+
+        when:
+        def operation = executor.getWriteOperation() as MixedBulkWriteOperation
+        def request = operation.writeRequests.get(0) as InsertRequest
+
+        then:
+        request.getDocument().containsKey('_id')
+    }
+
+    def 'should not expect to mutate the document when bulk writing'() {
+        given:
+        def executor = new TestOperationExecutor([null])
+        def customCodecRegistry = fromRegistries(codecRegistry, fromProviders(new ImmutableDocumentCodecProvider()))
+        def collection = new MongoCollectionImpl(namespace, ImmutableDocument, customCodecRegistry, readPreference, writeConcern,
+                readConcern, executor)
+        def document = new ImmutableDocument(['a': 1])
+        def futureResultCallback = new FutureResultCallback<BulkWriteResult>()
+
+        when:
+        collection.bulkWrite([new InsertOneModel<ImmutableDocument>(document)], futureResultCallback)
+        futureResultCallback.get()
+
+        then:
+        !document.containsKey('_id')
+
+        when:
+        def operation = executor.getWriteOperation() as MixedBulkWriteOperation
+        def request = operation.writeRequests.get(0) as InsertRequest
+
+        then:
+        request.getDocument().containsKey('_id')
     }
 
 }

--- a/driver-core/src/test/unit/com/mongodb/client/ImmutableDocument.java
+++ b/driver-core/src/test/unit/com/mongodb/client/ImmutableDocument.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWrapper;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+public final class ImmutableDocument implements Map<String, Object>, Serializable, Bson {
+    private final Map<String, Object> immutableDocument;
+
+    /**
+     * Creates a Document instance initialized with the given map.
+     *
+     * @param map initial map
+     */
+    public ImmutableDocument(final Map<String, Object> map) {
+        immutableDocument = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(map));
+    }
+
+
+    @Override
+    public int size() {
+        return immutableDocument.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return immutableDocument.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return immutableDocument.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        return immutableDocument.containsValue(value);
+    }
+
+    @Override
+    public Object get(final Object key) {
+        return immutableDocument.get(key);
+    }
+
+    @Override
+    public Object put(final String key, final Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object remove(final Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putAll(final Map<? extends String, ?> m) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return immutableDocument.keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return immutableDocument.values();
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        return immutableDocument.entrySet();
+    }
+
+    @Override
+    public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> tDocumentClass, final CodecRegistry codecRegistry) {
+        return new BsonDocumentWrapper<ImmutableDocument>(this, codecRegistry.get(ImmutableDocument.class));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/ImmutableDocumentCodec.java
+++ b/driver-core/src/test/unit/com/mongodb/client/ImmutableDocumentCodec.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import org.bson.BsonReader;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.Document;
+import org.bson.codecs.CollectibleCodec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.types.ObjectId;
+
+import java.util.LinkedHashMap;
+
+import static java.lang.String.format;
+
+public final class ImmutableDocumentCodec implements CollectibleCodec<ImmutableDocument> {
+    private final CodecRegistry codecRegistry;
+    private static final String ID_FIELD_NAME = "_id";
+
+    public ImmutableDocumentCodec(final CodecRegistry codecRegistry) {
+        this.codecRegistry = codecRegistry;
+    }
+
+    @Override
+    public ImmutableDocument generateIdIfAbsentFromDocument(final ImmutableDocument document) {
+        LinkedHashMap<String, Object> mutable = new LinkedHashMap<String, Object>(document);
+        mutable.put(ID_FIELD_NAME, new ObjectId());
+        return new ImmutableDocument(mutable);
+    }
+
+    @Override
+    public boolean documentHasId(final ImmutableDocument document) {
+        return document.containsKey(ID_FIELD_NAME);
+    }
+
+    @Override
+    public BsonValue getDocumentId(final ImmutableDocument document) {
+        if (!documentHasId(document)) {
+            throw new IllegalStateException(format("The document does not contain an %s", ID_FIELD_NAME));
+        }
+        return document.toBsonDocument(ImmutableDocument.class, codecRegistry).get(ID_FIELD_NAME);
+    }
+
+    @Override
+    public void encode(final BsonWriter writer, final ImmutableDocument value, final EncoderContext encoderContext) {
+        codecRegistry.get(Document.class).encode(writer, new Document(value), encoderContext);
+    }
+
+    @Override
+    public Class<ImmutableDocument> getEncoderClass() {
+        return ImmutableDocument.class;
+    }
+
+    @Override
+    public ImmutableDocument decode(final BsonReader reader, final DecoderContext decoderContext) {
+        Document document = codecRegistry.get(Document.class).decode(reader, decoderContext);
+        return new ImmutableDocument(document);
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/ImmutableDocumentCodecProvider.java
+++ b/driver-core/src/test/unit/com/mongodb/client/ImmutableDocumentCodecProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import org.bson.codecs.Codec;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+
+public final class ImmutableDocumentCodecProvider implements CodecProvider {
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
+        if (clazz.equals(ImmutableDocument.class)) {
+            return (Codec<T>) new ImmutableDocumentCodec(registry);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
There is no guarantee that CollectibleCodec<TDocument> will be able to
mutate the TDocument instance.

JAVA-2272