### PR TITLE
Explicitly handle null values in the CommandResultArrayCodec

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/CommandResultArrayCodec.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandResultArrayCodec.java
@@ -45,7 +45,12 @@ class CommandResultArrayCodec<T> extends BsonArrayCodec {
 
         List<T> list = new ArrayList<T>();
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
-            list.add(decoder.decode(reader, decoderContext));
+            if (reader.getCurrentBsonType() == BsonType.NULL) {
+                reader.readNull();
+                list.add(null);
+            } else {
+                list.add(decoder.decode(reader, decoderContext));
+            }
         }
         reader.readEndArray();
 

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/core/CollectionAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/core/CollectionAcceptanceTest.java
@@ -310,6 +310,22 @@ public class CollectionAcceptanceTest extends DatabaseTestCase {
                         new BsonDocument("e", new BsonInt32(3))))))));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldBeAbleToHandleNullValuesWhenUsingDistinct() {
+        collection.drop();
+        collection.insertMany(asList(new Document("id", "a"), new Document("id", "b"), new Document("id", null)));
+
+        List<String> distinctStrings = collection.distinct("id", String.class).into(new ArrayList<String>());
+        assertTrue(distinctStrings.containsAll(asList("a", "b", null)));
+
+        collection.drop();
+        collection.insertMany(asList(new Document("id", 1), new Document("id", 2), new Document("id", null)));
+
+        List<Integer> distinctInts = collection.distinct("id", Integer.class).into(new ArrayList<Integer>());
+        assertTrue(distinctInts.containsAll(asList(1, 2, null)));
+    }
+
     private void initialiseCollectionWithDocuments(final int numberOfDocuments) {
         MongoCollection<Document> collection = database.getCollection(getCollectionName()).withWriteConcern(WriteConcern.ACKNOWLEDGED);
         for (int i = 0; i < numberOfDocuments; i++) {


### PR DESCRIPTION
Allows null values to be handled when using distinct
JAVA-2386