### PR TITLE
Mark the QueryBatchCursor closed before calling killCursor

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -141,18 +141,16 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
 
     @Override
     public void close() {
-        if (closed) {
-            return;
-        }
-        try {
-            killCursor();
-        } finally {
-            if (connectionSource != null) {
-                connectionSource.release();
+        if (!closed) {
+            closed = true;
+            try {
+                killCursor();
+            } finally {
+                if (connectionSource != null) {
+                    connectionSource.release();
+                }
             }
         }
-
-        closed = true;
     }
 
     @Override

--- a/driver-core/src/test/unit/com/mongodb/operation/QueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/QueryBatchCursorSpecification.groovy
@@ -17,6 +17,7 @@
 package com.mongodb.operation
 
 import com.mongodb.MongoNamespace
+import com.mongodb.MongoSocketException
 import com.mongodb.ServerAddress
 import com.mongodb.binding.ConnectionSource
 import com.mongodb.connection.Connection
@@ -81,5 +82,37 @@ class QueryBatchCursorSpecification extends Specification {
         0          | 0          | null
         2          | 0          | null
         0          | 100        | 100
+    }
+
+    def 'should handle exceptions when closing'() {
+        given:
+        def serverAddress = new ServerAddress()
+        def connection = Mock(Connection) {
+            _ * getDescription() >> Stub(ConnectionDescription) {
+                getServerVersion() >> new ServerVersion([3, 2, 0])
+            }
+            _ * killCursor(_, _) >> { throw new MongoSocketException('No MongoD', serverAddress) }
+
+        }
+        def connectionSource = Stub(ConnectionSource) {
+            getConnection() >> { connection }
+        }
+        connectionSource.retain() >> connectionSource
+
+        def namespace = new MongoNamespace('test', 'QueryBatchCursorSpecification')
+        def firstBatch = new QueryResult(namespace, [], 42, serverAddress)
+        def cursor = new QueryBatchCursor<Document>(firstBatch, 0, 2, 100, new BsonDocumentCodec(), connectionSource, connection)
+
+        when:
+        cursor.close()
+
+        then:
+        thrown(MongoSocketException)
+
+        when:
+        cursor.close()
+
+        then:
+        notThrown(Exception)
     }
 }


### PR DESCRIPTION
This ensures if there is an error killing the cursor subsequent calls to the
cursor will act as expected for a closed cursor.

JAVA-2379