### PR TITLE
Made numeric codec implementations more lenient

### DIFF
--- a/bson/src/main/org/bson/codecs/AtomicIntegerCodec.java
+++ b/bson/src/main/org/bson/codecs/AtomicIntegerCodec.java
@@ -21,8 +21,6 @@ import org.bson.BsonWriter;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.bson.assertions.Assertions.isTrueArgument;
-import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
 import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
@@ -32,26 +30,11 @@ import static org.bson.codecs.NumberCodecHelper.decodeNumber;
  */
 
 public class AtomicIntegerCodec implements Codec<AtomicInteger> {
-    private final double delta;
 
     /**
      * Construct a new instance
      */
     public AtomicIntegerCodec() {
-        this(DEFAULT_DELTA);
-    }
-
-    /**
-     * Construct a new instance
-     *
-     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
-     * considered equal. Required when converting Double values to {@code AtomicInteger} values. Defaults to {@code 0.00000000000001d}.
-     *
-     * @since 3.5
-     */
-    public AtomicIntegerCodec(final double delta) {
-        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
-        this.delta = delta;
     }
 
     @Override
@@ -61,7 +44,7 @@ public class AtomicIntegerCodec implements Codec<AtomicInteger> {
 
     @Override
     public AtomicInteger decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return new AtomicInteger(decodeNumber(reader, Integer.class, delta));
+        return new AtomicInteger(decodeNumber(reader, Integer.class));
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/AtomicIntegerCodec.java
+++ b/bson/src/main/org/bson/codecs/AtomicIntegerCodec.java
@@ -21,7 +21,7 @@ import org.bson.BsonWriter;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+import static org.bson.codecs.NumberCodecHelper.decodeInt;
 
 /**
  * Encodes and decodes {@code AtomicInteger} objects.
@@ -44,7 +44,7 @@ public class AtomicIntegerCodec implements Codec<AtomicInteger> {
 
     @Override
     public AtomicInteger decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return new AtomicInteger(decodeNumber(reader, Integer.class));
+        return new AtomicInteger(decodeInt(reader));
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/AtomicIntegerCodec.java
+++ b/bson/src/main/org/bson/codecs/AtomicIntegerCodec.java
@@ -21,6 +21,10 @@ import org.bson.BsonWriter;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.bson.assertions.Assertions.isTrueArgument;
+import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
+import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+
 /**
  * Encodes and decodes {@code AtomicInteger} objects.
  *
@@ -28,6 +32,28 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 
 public class AtomicIntegerCodec implements Codec<AtomicInteger> {
+    private final double delta;
+
+    /**
+     * Construct a new instance
+     */
+    public AtomicIntegerCodec() {
+        this(DEFAULT_DELTA);
+    }
+
+    /**
+     * Construct a new instance
+     *
+     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
+     * considered equal. Required when converting Double values to {@code AtomicInteger} values. Defaults to {@code 0.00000000000001d}.
+     *
+     * @since 3.5
+     */
+    public AtomicIntegerCodec(final double delta) {
+        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
+        this.delta = delta;
+    }
+
     @Override
     public void encode(final BsonWriter writer, final AtomicInteger value, final EncoderContext encoderContext) {
         writer.writeInt32(value.intValue());
@@ -35,7 +61,7 @@ public class AtomicIntegerCodec implements Codec<AtomicInteger> {
 
     @Override
     public AtomicInteger decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return new AtomicInteger(reader.readInt32());
+        return new AtomicInteger(decodeNumber(reader, Integer.class, delta));
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/AtomicIntegerCodec.java
+++ b/bson/src/main/org/bson/codecs/AtomicIntegerCodec.java
@@ -31,12 +31,6 @@ import static org.bson.codecs.NumberCodecHelper.decodeInt;
 
 public class AtomicIntegerCodec implements Codec<AtomicInteger> {
 
-    /**
-     * Construct a new instance
-     */
-    public AtomicIntegerCodec() {
-    }
-
     @Override
     public void encode(final BsonWriter writer, final AtomicInteger value, final EncoderContext encoderContext) {
         writer.writeInt32(value.intValue());

--- a/bson/src/main/org/bson/codecs/AtomicLongCodec.java
+++ b/bson/src/main/org/bson/codecs/AtomicLongCodec.java
@@ -21,8 +21,6 @@ import org.bson.BsonWriter;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.bson.assertions.Assertions.isTrueArgument;
-import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
 import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
@@ -32,26 +30,11 @@ import static org.bson.codecs.NumberCodecHelper.decodeNumber;
  */
 
 public class AtomicLongCodec implements Codec<AtomicLong> {
-    private final double delta;
 
     /**
      * Construct a new instance
      */
     public AtomicLongCodec() {
-        this(DEFAULT_DELTA);
-    }
-
-    /**
-     * Construct a new instance
-     *
-     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
-     * considered equal. Required when converting Double values to {@code AtomicLong} values. Defaults to {@code 0.00000000000001d}.
-     *
-     * @since 3.5
-     */
-    public AtomicLongCodec(final double delta) {
-        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
-        this.delta = delta;
     }
 
     @Override
@@ -61,7 +44,7 @@ public class AtomicLongCodec implements Codec<AtomicLong> {
 
     @Override
     public AtomicLong decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return new AtomicLong(decodeNumber(reader, Long.class, delta));
+        return new AtomicLong(decodeNumber(reader, Long.class));
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/AtomicLongCodec.java
+++ b/bson/src/main/org/bson/codecs/AtomicLongCodec.java
@@ -21,6 +21,10 @@ import org.bson.BsonWriter;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.bson.assertions.Assertions.isTrueArgument;
+import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
+import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+
 /**
  * Encodes and decodes {@code AtomicLong} objects.
  *
@@ -28,6 +32,28 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 
 public class AtomicLongCodec implements Codec<AtomicLong> {
+    private final double delta;
+
+    /**
+     * Construct a new instance
+     */
+    public AtomicLongCodec() {
+        this(DEFAULT_DELTA);
+    }
+
+    /**
+     * Construct a new instance
+     *
+     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
+     * considered equal. Required when converting Double values to {@code AtomicLong} values. Defaults to {@code 0.00000000000001d}.
+     *
+     * @since 3.5
+     */
+    public AtomicLongCodec(final double delta) {
+        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
+        this.delta = delta;
+    }
+
     @Override
     public void encode(final BsonWriter writer, final AtomicLong value, final EncoderContext encoderContext) {
         writer.writeInt64(value.longValue());
@@ -35,7 +61,7 @@ public class AtomicLongCodec implements Codec<AtomicLong> {
 
     @Override
     public AtomicLong decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return new AtomicLong(reader.readInt64());
+        return new AtomicLong(decodeNumber(reader, Long.class, delta));
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/AtomicLongCodec.java
+++ b/bson/src/main/org/bson/codecs/AtomicLongCodec.java
@@ -31,12 +31,6 @@ import static org.bson.codecs.NumberCodecHelper.decodeLong;
 
 public class AtomicLongCodec implements Codec<AtomicLong> {
 
-    /**
-     * Construct a new instance
-     */
-    public AtomicLongCodec() {
-    }
-
     @Override
     public void encode(final BsonWriter writer, final AtomicLong value, final EncoderContext encoderContext) {
         writer.writeInt64(value.longValue());

--- a/bson/src/main/org/bson/codecs/AtomicLongCodec.java
+++ b/bson/src/main/org/bson/codecs/AtomicLongCodec.java
@@ -21,7 +21,7 @@ import org.bson.BsonWriter;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+import static org.bson.codecs.NumberCodecHelper.decodeLong;
 
 /**
  * Encodes and decodes {@code AtomicLong} objects.
@@ -44,7 +44,7 @@ public class AtomicLongCodec implements Codec<AtomicLong> {
 
     @Override
     public AtomicLong decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return new AtomicLong(decodeNumber(reader, Long.class));
+        return new AtomicLong(decodeLong(reader));
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/ByteCodec.java
+++ b/bson/src/main/org/bson/codecs/ByteCodec.java
@@ -21,7 +21,7 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
 import static java.lang.String.format;
-import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+import static org.bson.codecs.NumberCodecHelper.decodeInt;
 
 /**
  * Encodes and decodes {@code Byte} objects.
@@ -42,7 +42,7 @@ public class ByteCodec implements Codec<Byte> {
 
     @Override
     public Byte decode(final BsonReader reader, final DecoderContext decoderContext) {
-        int value = decodeNumber(reader, Integer.class);
+        int value = decodeInt(reader);
         if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Byte.", value));
         }

--- a/bson/src/main/org/bson/codecs/ByteCodec.java
+++ b/bson/src/main/org/bson/codecs/ByteCodec.java
@@ -29,11 +29,6 @@ import static org.bson.codecs.NumberCodecHelper.decodeInt;
  * @since 3.0
  */
 public class ByteCodec implements Codec<Byte> {
-    /**
-     * Construct a new instance
-     */
-    public ByteCodec() {
-    }
 
     @Override
     public void encode(final BsonWriter writer, final Byte value, final EncoderContext encoderContext) {

--- a/bson/src/main/org/bson/codecs/ByteCodec.java
+++ b/bson/src/main/org/bson/codecs/ByteCodec.java
@@ -21,8 +21,6 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
 import static java.lang.String.format;
-import static org.bson.assertions.Assertions.isTrueArgument;
-import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
 import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
@@ -31,26 +29,10 @@ import static org.bson.codecs.NumberCodecHelper.decodeNumber;
  * @since 3.0
  */
 public class ByteCodec implements Codec<Byte> {
-    private final double delta;
-
     /**
      * Construct a new instance
      */
     public ByteCodec() {
-        this(DEFAULT_DELTA);
-    }
-
-    /**
-     * Construct a new instance
-     *
-     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
-     * considered equal. Required when converting Double values to {@code Byte} values. Defaults to {@code 0.00000000000001d}.
-     *
-     * @since 3.5
-     */
-    public ByteCodec(final double delta) {
-        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
-        this.delta = delta;
     }
 
     @Override
@@ -60,7 +42,7 @@ public class ByteCodec implements Codec<Byte> {
 
     @Override
     public Byte decode(final BsonReader reader, final DecoderContext decoderContext) {
-        int value = decodeNumber(reader, Integer.class, delta);
+        int value = decodeNumber(reader, Integer.class);
         if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Byte.", value));
         }

--- a/bson/src/main/org/bson/codecs/ByteCodec.java
+++ b/bson/src/main/org/bson/codecs/ByteCodec.java
@@ -21,6 +21,9 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
 import static java.lang.String.format;
+import static org.bson.assertions.Assertions.isTrueArgument;
+import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
+import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
  * Encodes and decodes {@code Byte} objects.
@@ -28,6 +31,28 @@ import static java.lang.String.format;
  * @since 3.0
  */
 public class ByteCodec implements Codec<Byte> {
+    private final double delta;
+
+    /**
+     * Construct a new instance
+     */
+    public ByteCodec() {
+        this(DEFAULT_DELTA);
+    }
+
+    /**
+     * Construct a new instance
+     *
+     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
+     * considered equal. Required when converting Double values to {@code Byte} values. Defaults to {@code 0.00000000000001d}.
+     *
+     * @since 3.5
+     */
+    public ByteCodec(final double delta) {
+        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
+        this.delta = delta;
+    }
+
     @Override
     public void encode(final BsonWriter writer, final Byte value, final EncoderContext encoderContext) {
         writer.writeInt32(value);
@@ -35,7 +60,7 @@ public class ByteCodec implements Codec<Byte> {
 
     @Override
     public Byte decode(final BsonReader reader, final DecoderContext decoderContext) {
-        int value = reader.readInt32();
+        int value = decodeNumber(reader, Integer.class, delta);
         if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Byte.", value));
         }

--- a/bson/src/main/org/bson/codecs/DoubleCodec.java
+++ b/bson/src/main/org/bson/codecs/DoubleCodec.java
@@ -34,7 +34,7 @@ public class DoubleCodec implements Codec<Double> {
 
     @Override
     public Double decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return decodeNumber(reader, Double.class, 0);
+        return decodeNumber(reader, Double.class);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/DoubleCodec.java
+++ b/bson/src/main/org/bson/codecs/DoubleCodec.java
@@ -19,7 +19,7 @@ package org.bson.codecs;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
-import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+import static org.bson.codecs.NumberCodecHelper.decodeDouble;
 
 /**
  * Encodes and decodes {@code Double} objects.
@@ -34,7 +34,7 @@ public class DoubleCodec implements Codec<Double> {
 
     @Override
     public Double decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return decodeNumber(reader, Double.class);
+        return decodeDouble(reader);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/DoubleCodec.java
+++ b/bson/src/main/org/bson/codecs/DoubleCodec.java
@@ -19,6 +19,8 @@ package org.bson.codecs;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
+import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+
 /**
  * Encodes and decodes {@code Double} objects.
  *
@@ -32,7 +34,7 @@ public class DoubleCodec implements Codec<Double> {
 
     @Override
     public Double decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return reader.readDouble();
+        return decodeNumber(reader, Double.class, 0);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/FloatCodec.java
+++ b/bson/src/main/org/bson/codecs/FloatCodec.java
@@ -21,7 +21,7 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
 import static java.lang.String.format;
-import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+import static org.bson.codecs.NumberCodecHelper.decodeDouble;
 
 /**
  * Encodes and decodes {@code Float} objects.
@@ -37,7 +37,7 @@ public class FloatCodec implements Codec<Float> {
 
     @Override
     public Float decode(final BsonReader reader, final DecoderContext decoderContext) {
-        double value = decodeNumber(reader, Double.class);
+        double value = decodeDouble(reader);
         if (value < -Float.MAX_VALUE || value > Float.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Float.", value));
         }

--- a/bson/src/main/org/bson/codecs/FloatCodec.java
+++ b/bson/src/main/org/bson/codecs/FloatCodec.java
@@ -37,7 +37,7 @@ public class FloatCodec implements Codec<Float> {
 
     @Override
     public Float decode(final BsonReader reader, final DecoderContext decoderContext) {
-        double value = decodeNumber(reader, Double.class, 0);
+        double value = decodeNumber(reader, Double.class);
         if (value < -Float.MAX_VALUE || value > Float.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Float.", value));
         }

--- a/bson/src/main/org/bson/codecs/FloatCodec.java
+++ b/bson/src/main/org/bson/codecs/FloatCodec.java
@@ -21,6 +21,7 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
 import static java.lang.String.format;
+import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
  * Encodes and decodes {@code Float} objects.
@@ -28,6 +29,7 @@ import static java.lang.String.format;
  * @since 3.0
  */
 public class FloatCodec implements Codec<Float> {
+
     @Override
     public void encode(final BsonWriter writer, final Float value, final EncoderContext encoderContext) {
         writer.writeDouble(value);
@@ -35,7 +37,7 @@ public class FloatCodec implements Codec<Float> {
 
     @Override
     public Float decode(final BsonReader reader, final DecoderContext decoderContext) {
-        double value = reader.readDouble();
+        double value = decodeNumber(reader, Double.class, 0);
         if (value < -Float.MAX_VALUE || value > Float.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Float.", value));
         }

--- a/bson/src/main/org/bson/codecs/IntegerCodec.java
+++ b/bson/src/main/org/bson/codecs/IntegerCodec.java
@@ -28,12 +28,6 @@ import static org.bson.codecs.NumberCodecHelper.decodeInt;
  */
 public class IntegerCodec implements Codec<Integer> {
 
-    /**
-     * Construct a new instance
-     */
-    public IntegerCodec() {
-    }
-
     @Override
     public void encode(final BsonWriter writer, final Integer value, final EncoderContext encoderContext) {
         writer.writeInt32(value);

--- a/bson/src/main/org/bson/codecs/IntegerCodec.java
+++ b/bson/src/main/org/bson/codecs/IntegerCodec.java
@@ -19,7 +19,7 @@ package org.bson.codecs;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
-import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+import static org.bson.codecs.NumberCodecHelper.decodeInt;
 
 /**
  * Encodes and decodes {@code Integer} objects.
@@ -41,7 +41,7 @@ public class IntegerCodec implements Codec<Integer> {
 
     @Override
     public Integer decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return decodeNumber(reader, Integer.class);
+        return decodeInt(reader);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/IntegerCodec.java
+++ b/bson/src/main/org/bson/codecs/IntegerCodec.java
@@ -19,8 +19,6 @@ package org.bson.codecs;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
-import static org.bson.assertions.Assertions.isTrueArgument;
-import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
 import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
@@ -29,26 +27,11 @@ import static org.bson.codecs.NumberCodecHelper.decodeNumber;
  * @since 3.0
  */
 public class IntegerCodec implements Codec<Integer> {
-    private final double delta;
 
     /**
      * Construct a new instance
      */
     public IntegerCodec() {
-        this(DEFAULT_DELTA);
-    }
-
-    /**
-     * Construct a new instance
-     *
-     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
-     * considered equal. Required when converting Double values to {@code Integer} values. Defaults to {@code 0.00000000000001d}.
-     *
-     * @since 3.5
-     */
-    public IntegerCodec(final double delta) {
-        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
-        this.delta = delta;
     }
 
     @Override
@@ -58,7 +41,7 @@ public class IntegerCodec implements Codec<Integer> {
 
     @Override
     public Integer decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return decodeNumber(reader, Integer.class, delta);
+        return decodeNumber(reader, Integer.class);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/IntegerCodec.java
+++ b/bson/src/main/org/bson/codecs/IntegerCodec.java
@@ -19,12 +19,38 @@ package org.bson.codecs;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
+import static org.bson.assertions.Assertions.isTrueArgument;
+import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
+import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+
 /**
  * Encodes and decodes {@code Integer} objects.
  *
  * @since 3.0
  */
 public class IntegerCodec implements Codec<Integer> {
+    private final double delta;
+
+    /**
+     * Construct a new instance
+     */
+    public IntegerCodec() {
+        this(DEFAULT_DELTA);
+    }
+
+    /**
+     * Construct a new instance
+     *
+     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
+     * considered equal. Required when converting Double values to {@code Integer} values. Defaults to {@code 0.00000000000001d}.
+     *
+     * @since 3.5
+     */
+    public IntegerCodec(final double delta) {
+        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
+        this.delta = delta;
+    }
+
     @Override
     public void encode(final BsonWriter writer, final Integer value, final EncoderContext encoderContext) {
         writer.writeInt32(value);
@@ -32,7 +58,7 @@ public class IntegerCodec implements Codec<Integer> {
 
     @Override
     public Integer decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return reader.readInt32();
+        return decodeNumber(reader, Integer.class, delta);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/LongCodec.java
+++ b/bson/src/main/org/bson/codecs/LongCodec.java
@@ -19,6 +19,10 @@ package org.bson.codecs;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
+import static org.bson.assertions.Assertions.isTrueArgument;
+import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
+import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+
 /**
  * Encodes and decodes {@code Long} objects.
  *
@@ -26,6 +30,28 @@ import org.bson.BsonWriter;
  */
 
 public class LongCodec implements Codec<Long> {
+    private final double delta;
+
+    /**
+     * Construct a new instance
+     */
+    public LongCodec() {
+        this(DEFAULT_DELTA);
+    }
+
+    /**
+     * Construct a new instance
+     *
+     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
+     * considered equal. Required when converting Double values to {@code Long} values. Defaults to {@code 0.00000000000001d}.
+     *
+     * @since 3.5
+     */
+    public LongCodec(final double delta) {
+        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
+        this.delta = delta;
+    }
+
     @Override
     public void encode(final BsonWriter writer, final Long value, final EncoderContext encoderContext) {
         writer.writeInt64(value);
@@ -33,7 +59,7 @@ public class LongCodec implements Codec<Long> {
 
     @Override
     public Long decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return reader.readInt64();
+        return decodeNumber(reader, Long.class, delta);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/LongCodec.java
+++ b/bson/src/main/org/bson/codecs/LongCodec.java
@@ -29,12 +29,6 @@ import static org.bson.codecs.NumberCodecHelper.decodeLong;
 
 public class LongCodec implements Codec<Long> {
 
-    /**
-     * Construct a new instance
-     */
-    public LongCodec() {
-    }
-
     @Override
     public void encode(final BsonWriter writer, final Long value, final EncoderContext encoderContext) {
         writer.writeInt64(value);

--- a/bson/src/main/org/bson/codecs/LongCodec.java
+++ b/bson/src/main/org/bson/codecs/LongCodec.java
@@ -19,7 +19,7 @@ package org.bson.codecs;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
-import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+import static org.bson.codecs.NumberCodecHelper.decodeLong;
 
 /**
  * Encodes and decodes {@code Long} objects.
@@ -42,7 +42,7 @@ public class LongCodec implements Codec<Long> {
 
     @Override
     public Long decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return decodeNumber(reader, Long.class);
+        return decodeLong(reader);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/LongCodec.java
+++ b/bson/src/main/org/bson/codecs/LongCodec.java
@@ -19,8 +19,6 @@ package org.bson.codecs;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
-import static org.bson.assertions.Assertions.isTrueArgument;
-import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
 import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
@@ -30,26 +28,11 @@ import static org.bson.codecs.NumberCodecHelper.decodeNumber;
  */
 
 public class LongCodec implements Codec<Long> {
-    private final double delta;
 
     /**
      * Construct a new instance
      */
     public LongCodec() {
-        this(DEFAULT_DELTA);
-    }
-
-    /**
-     * Construct a new instance
-     *
-     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
-     * considered equal. Required when converting Double values to {@code Long} values. Defaults to {@code 0.00000000000001d}.
-     *
-     * @since 3.5
-     */
-    public LongCodec(final double delta) {
-        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
-        this.delta = delta;
     }
 
     @Override
@@ -59,7 +42,7 @@ public class LongCodec implements Codec<Long> {
 
     @Override
     public Long decode(final BsonReader reader, final DecoderContext decoderContext) {
-        return decodeNumber(reader, Long.class, delta);
+        return decodeNumber(reader, Long.class);
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/NumberCodecHelper.java
+++ b/bson/src/main/org/bson/codecs/NumberCodecHelper.java
@@ -21,74 +21,8 @@ import org.bson.BsonReader;
 import org.bson.BsonType;
 
 import static java.lang.String.format;
-import static org.bson.assertions.Assertions.isTrueArgument;
 
 final class NumberCodecHelper {
-
-    @SuppressWarnings("unchecked")
-    static <T extends Number> T decodeNumber(final BsonReader reader, final Class<T> clazz) {
-        isTrueArgument("Clazz must be Integer, Long or Double", clazz == Integer.class || clazz == Long.class || clazz == Double.class);
-
-
-        Number number;
-        T decodedNumber;
-        BsonType bsonType = reader.getCurrentBsonType();
-        switch (bsonType) {
-            case DOUBLE:
-                number = reader.readDouble();
-                Double doubleValue = number.doubleValue();
-                Double convertedDouble = number.doubleValue();
-
-                if (clazz == Integer.class) {
-                    decodedNumber = (T) (Integer) doubleValue.intValue();
-                    convertedDouble = ((Integer) doubleValue.intValue()).doubleValue();
-                } else if (clazz == Long.class) {
-                    decodedNumber = (T) (Long) doubleValue.longValue();
-                    convertedDouble = ((Long) doubleValue.longValue()).doubleValue();
-                } else {
-                    decodedNumber = (T) doubleValue;
-                }
-
-                if (!doubleValue.equals(convertedDouble)) {
-                    throw invalidConversion(clazz, number);
-                }
-                break;
-            case INT64:
-                number = reader.readInt64();
-                Long longValue = number.longValue();
-                Long convertedLong = number.longValue();
-
-                if (clazz == Integer.class) {
-                    decodedNumber = (T) (Integer) longValue.intValue();
-                    convertedLong = ((Integer) longValue.intValue()).longValue();
-                } else if (clazz == Double.class) {
-                    decodedNumber = (T) (Double) longValue.doubleValue();
-                    convertedLong = ((Double) longValue.doubleValue()).longValue();
-                } else {
-                    decodedNumber = (T) longValue;
-                }
-
-                if (!longValue.equals(convertedLong)) {
-                    throw invalidConversion(clazz, number);
-                }
-                break;
-            case INT32:
-                number = reader.readInt32();
-                Integer intValue = number.intValue();
-
-                if (clazz == Double.class) {
-                    decodedNumber = (T) (Double) intValue.doubleValue();
-                } else if (clazz == Long.class) {
-                    decodedNumber = (T) (Long) intValue.longValue();
-                } else {
-                    decodedNumber = (T) intValue;
-                }
-                break;
-            default:
-                throw new BsonInvalidOperationException(format("Invalid numeric type, found: %s", bsonType));
-        }
-        return decodedNumber;
-    }
 
     static int decodeInt(final BsonReader reader) {
         int intValue;
@@ -100,7 +34,7 @@ final class NumberCodecHelper {
             case INT64:
                 long longValue = reader.readInt64();
                 intValue = (int) longValue;
-                if (longValue != (double) intValue) {
+                if (longValue != (long) intValue) {
                     throw invalidConversion(Integer.class, longValue);
                 }
                 break;
@@ -163,8 +97,8 @@ final class NumberCodecHelper {
         return doubleValue;
     }
 
-    private static  <T extends Number> BsonInvalidOperationException invalidConversion(final Class<T> clazz, final Number number) {
-        return new BsonInvalidOperationException(format("Could not convert number (%s) to %s without losing precision", number, clazz));
+    private static  <T extends Number> BsonInvalidOperationException invalidConversion(final Class<T> clazz, final Object value) {
+        return new BsonInvalidOperationException(format("Could not convert `%s` to a %s without losing precision", value, clazz));
     }
 
     private NumberCodecHelper() {

--- a/bson/src/main/org/bson/codecs/NumberCodecHelper.java
+++ b/bson/src/main/org/bson/codecs/NumberCodecHelper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonInvalidOperationException;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+
+import static java.lang.String.format;
+
+final class NumberCodecHelper {
+
+    static final double DEFAULT_DELTA = 0.00000000000001d;
+
+    @SuppressWarnings("unchecked")
+    static <T extends Number> T decodeNumber(final BsonReader reader, final Class<T> clazz, final double delta) {
+        Number number;
+        boolean isADownConversion;
+        BsonType bsonType = reader.getCurrentBsonType();
+        switch (bsonType) {
+            case DOUBLE:
+                number = reader.readDouble();
+                isADownConversion = clazz != Double.class;
+                break;
+            case INT64:
+                number = reader.readInt64();
+                isADownConversion = clazz == Integer.class;
+                break;
+            case INT32:
+                number = reader.readInt32();
+                isADownConversion = false;
+                break;
+            default:
+                throw new BsonInvalidOperationException(format("Invalid numeric type, found: %s", bsonType));
+        }
+
+        Number converted;
+        if (clazz == Double.class) {
+            converted = number.doubleValue();
+        } else if (clazz == Integer.class) {
+            converted = number.intValue();
+        } else if (clazz == Long.class) {
+            converted = number.longValue();
+        } else {
+            throw new BsonInvalidOperationException(format("Unsupported numeric type, found: %s", clazz));
+        }
+
+        if (isADownConversion && hasLostPrecision(number.doubleValue(), converted.doubleValue(), delta)) {
+            throw new BsonInvalidOperationException(format("Could not convert number (%s) to %s without losing precision", number, clazz));
+        }
+
+        return (T) converted;
+    }
+
+    private static <T extends Number> boolean hasLostPrecision(final double d1, final double d2, final double delta) {
+        if (Double.compare(d1, d2) == 0) {
+            return false;
+        }
+        if ((Math.abs(d1 - d2) <= delta)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private NumberCodecHelper() {
+    }
+}

--- a/bson/src/main/org/bson/codecs/NumberCodecHelper.java
+++ b/bson/src/main/org/bson/codecs/NumberCodecHelper.java
@@ -28,6 +28,8 @@ final class NumberCodecHelper {
     @SuppressWarnings("unchecked")
     static <T extends Number> T decodeNumber(final BsonReader reader, final Class<T> clazz) {
         isTrueArgument("Clazz must be Integer, Long or Double", clazz == Integer.class || clazz == Long.class || clazz == Double.class);
+
+
         Number number;
         T decodedNumber;
         BsonType bsonType = reader.getCurrentBsonType();
@@ -86,6 +88,79 @@ final class NumberCodecHelper {
                 throw new BsonInvalidOperationException(format("Invalid numeric type, found: %s", bsonType));
         }
         return decodedNumber;
+    }
+
+    static int decodeInt(final BsonReader reader) {
+        int intValue;
+        BsonType bsonType = reader.getCurrentBsonType();
+        switch (bsonType) {
+            case INT32:
+                intValue = reader.readInt32();
+                break;
+            case INT64:
+                long longValue = reader.readInt64();
+                intValue = (int) longValue;
+                if (longValue != (double) intValue) {
+                    throw invalidConversion(Integer.class, longValue);
+                }
+                break;
+            case DOUBLE:
+                double doubleValue = reader.readDouble();
+                intValue = (int) doubleValue;
+                if (doubleValue != (double) intValue) {
+                    throw invalidConversion(Integer.class, doubleValue);
+                }
+                break;
+            default:
+                throw new BsonInvalidOperationException(format("Invalid numeric type, found: %s", bsonType));
+        }
+        return intValue;
+    }
+
+    static long decodeLong(final BsonReader reader) {
+        long longValue;
+        BsonType bsonType = reader.getCurrentBsonType();
+        switch (bsonType) {
+            case INT32:
+                longValue = reader.readInt32();
+                break;
+            case INT64:
+                longValue = reader.readInt64();
+                break;
+            case DOUBLE:
+                double doubleValue = reader.readDouble();
+                longValue = (long) doubleValue;
+                if (doubleValue != (double) longValue) {
+                    throw invalidConversion(Long.class, doubleValue);
+                }
+                break;
+            default:
+                throw new BsonInvalidOperationException(format("Invalid numeric type, found: %s", bsonType));
+        }
+        return longValue;
+    }
+
+    static double decodeDouble(final BsonReader reader) {
+        double doubleValue;
+        BsonType bsonType = reader.getCurrentBsonType();
+        switch (bsonType) {
+            case INT32:
+                doubleValue = reader.readInt32();
+                break;
+            case INT64:
+                long longValue = reader.readInt64();
+                doubleValue = longValue;
+                if (longValue != (long) doubleValue) {
+                    throw invalidConversion(Double.class, longValue);
+                }
+                break;
+            case DOUBLE:
+                doubleValue = reader.readDouble();
+                break;
+            default:
+                throw new BsonInvalidOperationException(format("Invalid numeric type, found: %s", bsonType));
+        }
+        return doubleValue;
     }
 
     private static  <T extends Number> BsonInvalidOperationException invalidConversion(final Class<T> clazz, final Number number) {

--- a/bson/src/main/org/bson/codecs/ShortCodec.java
+++ b/bson/src/main/org/bson/codecs/ShortCodec.java
@@ -21,7 +21,7 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
 import static java.lang.String.format;
-import static org.bson.codecs.NumberCodecHelper.decodeNumber;
+import static org.bson.codecs.NumberCodecHelper.decodeInt;
 
 /**
  * Encodes and decodes {@code Short} objects.
@@ -42,7 +42,7 @@ public class ShortCodec implements Codec<Short> {
 
     @Override
     public Short decode(final BsonReader reader, final DecoderContext decoderContext) {
-        int value = decodeNumber(reader, Integer.class);
+        int value = decodeInt(reader);
         if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Short.", value));
         }

--- a/bson/src/main/org/bson/codecs/ShortCodec.java
+++ b/bson/src/main/org/bson/codecs/ShortCodec.java
@@ -21,6 +21,9 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
 import static java.lang.String.format;
+import static org.bson.assertions.Assertions.isTrueArgument;
+import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
+import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
  * Encodes and decodes {@code Short} objects.
@@ -28,6 +31,28 @@ import static java.lang.String.format;
  * @since 3.0
  */
 public class ShortCodec implements Codec<Short> {
+    private final double delta;
+
+    /**
+     * Construct a new instance
+     */
+    public ShortCodec() {
+        this(DEFAULT_DELTA);
+    }
+
+    /**
+     * Construct a new instance
+     *
+     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
+     * considered equal. Required when converting Double values to {@code Short} values. Defaults to {@code 0.00000000000001d}.
+     *
+     * @since 3.5
+     */
+    public ShortCodec(final double delta) {
+        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
+        this.delta = delta;
+    }
+
     @Override
     public void encode(final BsonWriter writer, final Short value, final EncoderContext encoderContext) {
         writer.writeInt32(value);
@@ -35,7 +60,7 @@ public class ShortCodec implements Codec<Short> {
 
     @Override
     public Short decode(final BsonReader reader, final DecoderContext decoderContext) {
-        int value = reader.readInt32();
+        int value = decodeNumber(reader, Integer.class, delta);
         if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Short.", value));
         }

--- a/bson/src/main/org/bson/codecs/ShortCodec.java
+++ b/bson/src/main/org/bson/codecs/ShortCodec.java
@@ -21,8 +21,6 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 
 import static java.lang.String.format;
-import static org.bson.assertions.Assertions.isTrueArgument;
-import static org.bson.codecs.NumberCodecHelper.DEFAULT_DELTA;
 import static org.bson.codecs.NumberCodecHelper.decodeNumber;
 
 /**
@@ -31,26 +29,10 @@ import static org.bson.codecs.NumberCodecHelper.decodeNumber;
  * @since 3.0
  */
 public class ShortCodec implements Codec<Short> {
-    private final double delta;
-
     /**
      * Construct a new instance
      */
     public ShortCodec() {
-        this(DEFAULT_DELTA);
-    }
-
-    /**
-     * Construct a new instance
-     *
-     * @param delta the maximum delta between {@code expected} and {@code actual} for which both numbers are still
-     * considered equal. Required when converting Double values to {@code Short} values. Defaults to {@code 0.00000000000001d}.
-     *
-     * @since 3.5
-     */
-    public ShortCodec(final double delta) {
-        isTrueArgument("The delta must be greater than or equal to zero and less than one", delta >= 0 && delta < 1);
-        this.delta = delta;
     }
 
     @Override
@@ -60,7 +42,7 @@ public class ShortCodec implements Codec<Short> {
 
     @Override
     public Short decode(final BsonReader reader, final DecoderContext decoderContext) {
-        int value = decodeNumber(reader, Integer.class, delta);
+        int value = decodeNumber(reader, Integer.class);
         if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Short.", value));
         }

--- a/bson/src/main/org/bson/codecs/ShortCodec.java
+++ b/bson/src/main/org/bson/codecs/ShortCodec.java
@@ -29,11 +29,6 @@ import static org.bson.codecs.NumberCodecHelper.decodeInt;
  * @since 3.0
  */
 public class ShortCodec implements Codec<Short> {
-    /**
-     * Construct a new instance
-     */
-    public ShortCodec() {
-    }
 
     @Override
     public void encode(final BsonWriter writer, final Short value, final EncoderContext encoderContext) {

--- a/bson/src/test/unit/org/bson/codecs/AtomicIntegerCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/AtomicIntegerCodecTest.java
@@ -28,7 +28,10 @@ public final class AtomicIntegerCodecTest extends CodecTestCase {
 
     @Test
     public void shouldRoundTripAtomicIntegerValues() {
-        Document original = new Document("a", new AtomicInteger(1));
+        Document original = new Document("a", new AtomicInteger(Integer.MAX_VALUE));
+        roundTrip(original, new AtomicIntegerComparator(original));
+
+        original = new Document("a", new AtomicInteger(Integer.MIN_VALUE));
         roundTrip(original, new AtomicIntegerComparator(original));
     }
 

--- a/bson/src/test/unit/org/bson/codecs/AtomicIntegerCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/AtomicIntegerCodecTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonInvalidOperationException;
+import org.bson.Document;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public final class AtomicIntegerCodecTest extends CodecTestCase {
+
+    @Test
+    public void shouldRoundTripAtomicIntegerValues() {
+        Document original = new Document("a", new AtomicInteger(1));
+        roundTrip(original, new AtomicIntegerComparator(original));
+    }
+
+    @Test
+    public void shouldHandleAlternativeNumberValues() {
+        Document expected = new Document("a", new AtomicInteger(10));
+        roundTrip(new Document("a", 10), new AtomicIntegerComparator(expected));
+        roundTrip(new Document("a", 10L), new AtomicIntegerComparator(expected));
+        roundTrip(new Document("a", 10.00), new AtomicIntegerComparator(expected));
+        roundTrip(new Document("a", 9.9999999999999992), new AtomicIntegerComparator(expected));
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldThrowWhenHandlingLossyDoubleValues() {
+        Document original = new Document("a", 9.9999999999999991);
+        roundTrip(original, new AtomicIntegerComparator(original));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIfTheDeltaIsOutOfRange() {
+        new AtomicIntegerCodec(1);
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldSupportACustomDelta() {
+        roundTripWithCodec(new Document("a", 9.9999999999999991), new AtomicIntegerCodec(0));
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldErrorDecodingOutsideMinRange() {
+        roundTrip(new Document("a", Long.MIN_VALUE));
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldErrorDecodingOutsideMaxRange() {
+        roundTrip(new Document("a", Long.MAX_VALUE));
+    }
+
+    @Override
+    DocumentCodecProvider getDocumentCodecProvider() {
+        return getSpecificNumberDocumentCodecProvider(AtomicInteger.class);
+    }
+
+    private class AtomicIntegerComparator implements Comparator<Document> {
+        private final Document expected;
+
+        AtomicIntegerComparator(final Document expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public void apply(final Document result) {
+            assertEquals("Codec Round Trip",
+                    expected.get("a", AtomicInteger.class).get(),
+                    result.get("a", AtomicInteger.class).get());
+        }
+    }
+
+}

--- a/bson/src/test/unit/org/bson/codecs/AtomicIntegerCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/AtomicIntegerCodecTest.java
@@ -47,16 +47,6 @@ public final class AtomicIntegerCodecTest extends CodecTestCase {
         roundTrip(original, new AtomicIntegerComparator(original));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIfTheDeltaIsOutOfRange() {
-        new AtomicIntegerCodec(1);
-    }
-
-    @Test(expected = BsonInvalidOperationException.class)
-    public void shouldSupportACustomDelta() {
-        roundTripWithCodec(new Document("a", 9.9999999999999991), new AtomicIntegerCodec(0));
-    }
-
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldErrorDecodingOutsideMinRange() {
         roundTrip(new Document("a", Long.MIN_VALUE));

--- a/bson/src/test/unit/org/bson/codecs/AtomicLongCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/AtomicLongCodecTest.java
@@ -41,16 +41,6 @@ public final class AtomicLongCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), new AtomicLongComparator(expected));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIfTheDeltaIsOutOfRange() {
-        new AtomicLongCodec(1);
-    }
-
-    @Test(expected = BsonInvalidOperationException.class)
-    public void shouldSupportACustomDelta() {
-        roundTripWithCodec(new Document("a", 9.9999999999999991), new AtomicLongCodec(0));
-    }
-
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldThrowWhenHandlingLossyDoubleValues() {
         Document original = new Document("a", 9.9999999999999991);

--- a/bson/src/test/unit/org/bson/codecs/AtomicLongCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/AtomicLongCodecTest.java
@@ -28,7 +28,10 @@ public final class AtomicLongCodecTest extends CodecTestCase {
 
     @Test
     public void shouldRoundTripAtomicLongValues() {
-        Document original = new Document("a", new AtomicLong(1L));
+        Document original = new Document("a", new AtomicLong(Long.MAX_VALUE));
+        roundTrip(original, new AtomicLongComparator(original));
+
+        original = new Document("a", new AtomicLong(Long.MIN_VALUE));
         roundTrip(original, new AtomicLongComparator(original));
     }
 

--- a/bson/src/test/unit/org/bson/codecs/AtomicLongCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/AtomicLongCodecTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonInvalidOperationException;
+import org.bson.Document;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+
+public final class AtomicLongCodecTest extends CodecTestCase {
+
+    @Test
+    public void shouldRoundTripAtomicLongValues() {
+        Document original = new Document("a", new AtomicLong(1L));
+        roundTrip(original, new AtomicLongComparator(original));
+    }
+
+    @Test
+    public void shouldHandleAlternativeNumberValues() {
+        Document expected = new Document("a", new AtomicLong(10L));
+        roundTrip(new Document("a", 10), new AtomicLongComparator(expected));
+        roundTrip(new Document("a", 10L), new AtomicLongComparator(expected));
+        roundTrip(new Document("a", 10.00), new AtomicLongComparator(expected));
+        roundTrip(new Document("a", 9.9999999999999992), new AtomicLongComparator(expected));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIfTheDeltaIsOutOfRange() {
+        new AtomicLongCodec(1);
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldSupportACustomDelta() {
+        roundTripWithCodec(new Document("a", 9.9999999999999991), new AtomicLongCodec(0));
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldThrowWhenHandlingLossyDoubleValues() {
+        Document original = new Document("a", 9.9999999999999991);
+        roundTrip(original, new AtomicLongComparator(original));
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldErrorDecodingOutsideMinRange() {
+        roundTrip(new Document("a", -Double.MAX_VALUE));
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldErrorDecodingOutsideMaxRange() {
+        roundTrip(new Document("a", Double.MAX_VALUE));
+    }
+
+    @Override
+    DocumentCodecProvider getDocumentCodecProvider() {
+        return getSpecificNumberDocumentCodecProvider(AtomicLong.class);
+    }
+
+    private class AtomicLongComparator implements Comparator<Document> {
+        private final Document expected;
+
+        AtomicLongComparator(final Document expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public void apply(final Document result) {
+            assertEquals("Codec Round Trip",
+                    expected.get("a", AtomicLong.class).get(),
+                    result.get("a", AtomicLong.class).get());
+        }
+    }
+
+}

--- a/bson/src/test/unit/org/bson/codecs/ByteCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/ByteCodecTest.java
@@ -24,7 +24,8 @@ public final class ByteCodecTest extends CodecTestCase {
 
     @Test
     public void shouldRoundTripByteValues() {
-        roundTrip(new Document("a", new Byte("1")));
+        roundTrip(new Document("a", Byte.MAX_VALUE));
+        roundTrip(new Document("a", Byte.MIN_VALUE));
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/ByteCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/ByteCodecTest.java
@@ -35,16 +35,6 @@ public final class ByteCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIfTheDeltaIsOutOfRange() {
-        new ByteCodec(1);
-    }
-
-    @Test(expected = BsonInvalidOperationException.class)
-    public void shouldSupportACustomDelta() {
-        roundTripWithCodec(new Document("a", 9.9999999999999991), new ByteCodec(0));
-    }
-
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldErrorDecodingOutsideMinRange() {
         roundTrip(new Document("a", Integer.MIN_VALUE));

--- a/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
@@ -31,9 +31,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 
 import static java.util.Arrays.asList;
-import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
-import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import static org.junit.Assert.assertEquals;
 
 abstract class CodecTestCase {
@@ -47,15 +45,11 @@ abstract class CodecTestCase {
     }
 
     <T> void roundTrip(final T value) {
-        roundTrip(value, new DefaultComparator(value));
+        roundTrip(value, new DefaultComparator<T>(value));
     }
 
     <T> void roundTrip(final T value, final Comparator<T> comparator) {
         roundTripWithRegistry(value, comparator, getRegistry());
-    }
-
-    <T, V> void roundTripWithCodec(final T value, final Codec<V> codec) {
-        roundTripWithRegistry(value, new DefaultComparator(value), fromRegistries(fromCodecs(codec), getRegistry()));
     }
 
     @SuppressWarnings("unchecked")

--- a/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
@@ -18,30 +18,61 @@ package org.bson.codecs;
 
 import org.bson.BsonBinaryReader;
 import org.bson.BsonBinaryWriter;
+import org.bson.BsonType;
 import org.bson.BsonWriter;
 import org.bson.ByteBufNIO;
+import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.io.ByteBufferBsonInput;
 import org.bson.io.OutputBuffer;
-import org.junit.Assert;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 
 import static java.util.Arrays.asList;
+import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+import static org.junit.Assert.assertEquals;
 
 abstract class CodecTestCase {
-    abstract DocumentCodecProvider getDocumentCodecProvider();
+
+    DocumentCodecProvider getDocumentCodecProvider() {
+        return new DocumentCodecProvider();
+    }
+
     CodecRegistry getRegistry() {
         return fromProviders(asList(new ValueCodecProvider(), getDocumentCodecProvider()));
     }
 
-    @SuppressWarnings("unchecked")
     <T> void roundTrip(final T value) {
-        Codec<T> codec = (Codec<T>) getRegistry().get(value.getClass());
+        roundTrip(value, new DefaultComparator(value));
+    }
+
+    <T> void roundTrip(final T value, final Comparator<T> comparator) {
+        roundTripWithRegistry(value, comparator, getRegistry());
+    }
+
+    <T, V> void roundTripWithCodec(final T value, final Codec<V> codec) {
+        roundTripWithRegistry(value, new DefaultComparator(value), fromRegistries(fromCodecs(codec), getRegistry()));
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> void roundTripWithRegistry(final T value, final Comparator<T> comparator, final CodecRegistry codecRegistry) {
+        Codec<T> codec = (Codec<T>) codecRegistry.get(value.getClass());
         OutputBuffer encoded = encode(codec, value);
-        Assert.assertEquals("Codec Round Trip", value, decode(codec, encoded));
+        T decoded = decode(codec, encoded);
+        comparator.apply(decoded);
+    }
+
+    public void roundTrip(final Document input, final Document expected) {
+        roundTrip(input, new Comparator<Document>() {
+            @Override
+            public void apply(final Document result) {
+                assertEquals("Codec Round Trip", expected, result);
+            }
+        });
     }
 
     <T> OutputBuffer encode(final Codec<T> codec, final T value) {
@@ -55,4 +86,30 @@ abstract class CodecTestCase {
         BsonBinaryReader reader = new BsonBinaryReader(new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap(buffer.toByteArray()))));
         return codec.decode(reader, DecoderContext.builder().build());
     }
+
+    DocumentCodecProvider getSpecificNumberDocumentCodecProvider(final Class<? extends Number> clazz) {
+        HashMap<BsonType, Class<?>> replacements = new HashMap<BsonType, Class<?>>();
+        replacements.put(BsonType.DOUBLE, clazz);
+        replacements.put(BsonType.INT32, clazz);
+        replacements.put(BsonType.INT64, clazz);
+        return new DocumentCodecProvider(new BsonTypeClassMap(replacements));
+    }
+
+    interface Comparator<T> {
+        void apply(T result);
+    }
+
+    class DefaultComparator<T> implements Comparator<T> {
+        private final T original;
+
+        DefaultComparator(final T original) {
+            this.original = original;
+        }
+
+        @Override
+        public void apply(final T result) {
+            assertEquals("Codec Round Trip", original, result);
+        }
+    }
+
 }

--- a/bson/src/test/unit/org/bson/codecs/DoubleCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/DoubleCodecTest.java
@@ -16,42 +16,25 @@
 
 package org.bson.codecs;
 
-import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.junit.Test;
 
-public final class FloatCodecTest extends CodecTestCase {
+public final class DoubleCodecTest extends CodecTestCase {
 
     @Test
-    public void shouldRoundTripFloatValues() {
-        roundTrip(new Document("a", new Float(1)));
-    }
-
-    @Test
-    public void shouldRoundTripNegativeFloatValues() {
-        roundTrip(new Document("a", new Float(-1)));
+    public void shouldRoundTripDoubleValues() {
+        roundTrip(new Document("a", 10.0));
     }
 
     @Test
     public void shouldHandleAlternativeNumberValues() {
-        Document expected = new Document("a", 10f);
+        Document expected = new Document("a", 10.00);
         roundTrip(new Document("a", 10), expected);
         roundTrip(new Document("a", 10L), expected);
-        roundTrip(new Document("a", 9.9999999999999992), expected);
-    }
-
-    @Test(expected = BsonInvalidOperationException.class)
-    public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", -Double.MAX_VALUE));
-    }
-
-    @Test(expected = BsonInvalidOperationException.class)
-    public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Double.MAX_VALUE));
     }
 
     @Override
     DocumentCodecProvider getDocumentCodecProvider() {
-        return getSpecificNumberDocumentCodecProvider(Float.class);
+        return getSpecificNumberDocumentCodecProvider(Double.class);
     }
 }

--- a/bson/src/test/unit/org/bson/codecs/DoubleCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/DoubleCodecTest.java
@@ -16,6 +16,7 @@
 
 package org.bson.codecs;
 
+import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.junit.Test;
 
@@ -23,7 +24,8 @@ public final class DoubleCodecTest extends CodecTestCase {
 
     @Test
     public void shouldRoundTripDoubleValues() {
-        roundTrip(new Document("a", 10.0));
+        roundTrip(new Document("a", Long.MAX_VALUE), new Document("a", (double) Long.MAX_VALUE));
+        roundTrip(new Document("a", Long.MIN_VALUE), new Document("a", (double) Long.MIN_VALUE));
     }
 
     @Test
@@ -31,6 +33,16 @@ public final class DoubleCodecTest extends CodecTestCase {
         Document expected = new Document("a", 10.00);
         roundTrip(new Document("a", 10), expected);
         roundTrip(new Document("a", 10L), expected);
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldThrowWhenHandlingLossyLongValues() {
+        roundTrip(new Document("a", Long.MAX_VALUE - 1));
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldThrowWhenHandlingLossyLongValues2() {
+        roundTrip(new Document("a", Long.MIN_VALUE + 1));
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/codecs/FloatCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/FloatCodecTest.java
@@ -24,7 +24,8 @@ public final class FloatCodecTest extends CodecTestCase {
 
     @Test
     public void shouldRoundTripFloatValues() {
-        roundTrip(new Document("a", new Float(1)));
+        roundTrip(new Document("a", Float.MAX_VALUE));
+        roundTrip(new Document("a", -Float.MAX_VALUE));
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/IntegerCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/IntegerCodecTest.java
@@ -35,16 +35,6 @@ public final class IntegerCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIfTheDeltaIsOutOfRange() {
-        new IntegerCodec(1);
-    }
-
-    @Test(expected = BsonInvalidOperationException.class)
-    public void shouldSupportACustomDelta() {
-        roundTripWithCodec(new Document("a", 9.9999999999999991), new IntegerCodec(0));
-    }
-
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldErrorDecodingOutsideMinRange() {
         roundTrip(new Document("a", Long.MIN_VALUE));

--- a/bson/src/test/unit/org/bson/codecs/IntegerCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/IntegerCodecTest.java
@@ -24,7 +24,8 @@ public final class IntegerCodecTest extends CodecTestCase {
 
     @Test
     public void shouldRoundTripIntegerValues() {
-        roundTrip(new Document("a", 1));
+        roundTrip(new Document("a", Integer.MAX_VALUE));
+        roundTrip(new Document("a", Integer.MIN_VALUE));
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/IntegerCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/IntegerCodecTest.java
@@ -20,17 +20,16 @@ import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.junit.Test;
 
-public final class ShortCodecTest extends CodecTestCase {
+public final class IntegerCodecTest extends CodecTestCase {
 
     @Test
-    public void shouldRoundTripFloatValues() {
-        roundTrip(new Document("a", new Short("1")));
+    public void shouldRoundTripIntegerValues() {
+        roundTrip(new Document("a", 1));
     }
 
     @Test
     public void shouldHandleAlternativeNumberValues() {
-        Document expected = new Document("a", new Short("10"));
-        roundTrip(new Document("a", 10), expected);
+        Document expected = new Document("a", 10);
         roundTrip(new Document("a", 10L), expected);
         roundTrip(new Document("a", 10.00), expected);
         roundTrip(new Document("a", 9.9999999999999992), expected);
@@ -38,26 +37,31 @@ public final class ShortCodecTest extends CodecTestCase {
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIfTheDeltaIsOutOfRange() {
-        new ShortCodec(1);
+        new IntegerCodec(1);
     }
 
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldSupportACustomDelta() {
-        roundTripWithCodec(new Document("a", 9.9999999999999991), new ShortCodec(0));
+        roundTripWithCodec(new Document("a", 9.9999999999999991), new IntegerCodec(0));
     }
 
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", Integer.MIN_VALUE));
+        roundTrip(new Document("a", Long.MIN_VALUE));
     }
 
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Integer.MAX_VALUE));
+        roundTrip(new Document("a", Long.MAX_VALUE));
+    }
+
+    @Test(expected = BsonInvalidOperationException.class)
+    public void shouldThrowWhenHandlingLossyDoubleValues() {
+        roundTrip(new Document("a", 9.9999999999999991));
     }
 
     @Override
     DocumentCodecProvider getDocumentCodecProvider() {
-        return getSpecificNumberDocumentCodecProvider(Short.class);
+        return getSpecificNumberDocumentCodecProvider(Integer.class);
     }
 }

--- a/bson/src/test/unit/org/bson/codecs/LongCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/LongCodecTest.java
@@ -20,44 +20,43 @@ import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.junit.Test;
 
-public final class ShortCodecTest extends CodecTestCase {
+public final class LongCodecTest extends CodecTestCase {
 
     @Test
-    public void shouldRoundTripFloatValues() {
-        roundTrip(new Document("a", new Short("1")));
+    public void shouldRoundTripLongValues() {
+        roundTrip(new Document("a", 1L));
     }
 
     @Test
     public void shouldHandleAlternativeNumberValues() {
-        Document expected = new Document("a", new Short("10"));
+        Document expected = new Document("a", 10L);
         roundTrip(new Document("a", 10), expected);
-        roundTrip(new Document("a", 10L), expected);
         roundTrip(new Document("a", 10.00), expected);
         roundTrip(new Document("a", 9.9999999999999992), expected);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIfTheDeltaIsOutOfRange() {
-        new ShortCodec(1);
+        new LongCodec(1);
     }
 
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldSupportACustomDelta() {
-        roundTripWithCodec(new Document("a", 9.9999999999999991), new ShortCodec(0));
+        roundTripWithCodec(new Document("a", 9.9999999999999991), new LongCodec(0));
     }
 
     @Test(expected = BsonInvalidOperationException.class)
-    public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", Integer.MIN_VALUE));
+    public void shouldThrowWhenHandlingLossyLongValues() {
+        roundTrip(new Document("a", Double.MAX_VALUE));
     }
 
     @Test(expected = BsonInvalidOperationException.class)
-    public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Integer.MAX_VALUE));
+    public void shouldThrowWhenHandlingLossyDoubleValues() {
+        roundTrip(new Document("a", 9.9999999999999991));
     }
 
     @Override
     DocumentCodecProvider getDocumentCodecProvider() {
-        return getSpecificNumberDocumentCodecProvider(Short.class);
+        return getSpecificNumberDocumentCodecProvider(Long.class);
     }
 }

--- a/bson/src/test/unit/org/bson/codecs/LongCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/LongCodecTest.java
@@ -35,16 +35,6 @@ public final class LongCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIfTheDeltaIsOutOfRange() {
-        new LongCodec(1);
-    }
-
-    @Test(expected = BsonInvalidOperationException.class)
-    public void shouldSupportACustomDelta() {
-        roundTripWithCodec(new Document("a", 9.9999999999999991), new LongCodec(0));
-    }
-
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldThrowWhenHandlingLossyLongValues() {
         roundTrip(new Document("a", Double.MAX_VALUE));

--- a/bson/src/test/unit/org/bson/codecs/LongCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/LongCodecTest.java
@@ -24,7 +24,8 @@ public final class LongCodecTest extends CodecTestCase {
 
     @Test
     public void shouldRoundTripLongValues() {
-        roundTrip(new Document("a", 1L));
+        roundTrip(new Document("a", Long.MAX_VALUE));
+        roundTrip(new Document("a", Long.MIN_VALUE));
     }
 
     @Test
@@ -36,7 +37,7 @@ public final class LongCodecTest extends CodecTestCase {
     }
 
     @Test(expected = BsonInvalidOperationException.class)
-    public void shouldThrowWhenHandlingLossyLongValues() {
+    public void shouldThrowWhenHandlingLossyValues() {
         roundTrip(new Document("a", Double.MAX_VALUE));
     }
 

--- a/bson/src/test/unit/org/bson/codecs/ShortCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/ShortCodecTest.java
@@ -24,7 +24,8 @@ public final class ShortCodecTest extends CodecTestCase {
 
     @Test
     public void shouldRoundTripFloatValues() {
-        roundTrip(new Document("a", new Short("1")));
+        roundTrip(new Document("a", Short.MAX_VALUE));
+        roundTrip(new Document("a", Short.MIN_VALUE));
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/ShortCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/ShortCodecTest.java
@@ -36,16 +36,6 @@ public final class ShortCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIfTheDeltaIsOutOfRange() {
-        new ShortCodec(1);
-    }
-
-    @Test(expected = BsonInvalidOperationException.class)
-    public void shouldSupportACustomDelta() {
-        roundTripWithCodec(new Document("a", 9.9999999999999991), new ShortCodec(0));
-    }
-
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldErrorDecodingOutsideMinRange() {
         roundTrip(new Document("a", Integer.MIN_VALUE));

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCodecTest.java
@@ -90,6 +90,14 @@ public final class PojoCodecTest extends PojoTestCase {
     }
 
     @Test
+    public void testNumberCoercionInPrimitivesModel() {
+        PrimitivesModel model = getPrimitivesModel();
+        decodesTo(getCodecRegistry(getPojoCodecProviderBuilder(PrimitivesModel.class)),
+                "{ 'myBoolean': true, 'myByte': 1.0, 'myCharacter': '1', 'myDouble': 1, 'myFloat': 2, "
+                        + "'myInteger': { '$numberLong': '3' }, 'myLong': 5.0, 'myShort': { '$numberLong': '6' }}", model);
+    }
+
+    @Test
     public void testRoundTripConcreteCollectionsModel() {
         ConcreteCollectionsModel  model = getConcreteCollectionsModel();
         roundTrip(getPojoCodecProviderBuilder(ConcreteCollectionsModel.class), model,


### PR DESCRIPTION
The leniency covers the following BsonTypes: DOUBLE, INT32 and INT64.

Its relatively simple compared to the conversions available in c#. I'm not sure we want to expand this further as I don't see users mixing types with Decimals in the same way as they might with ints and longs.

JAVA-2529