### PR TITLE
Allow for missing parameters when creating new instances

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
@@ -138,10 +138,11 @@ final class ConventionAnnotationImpl implements Convention {
             for (int i = 0; i < properties.size(); i++) {
                 BsonProperty bsonProperty = properties.get(i);
                 Class<?> parameterType = parameterTypes.get(i);
+                TypeData<?> parameterTypeData = TypeData.builder(parameterType).build();
                 PropertyModelBuilder<?> propertyModelBuilder = classModelBuilder.getProperty(bsonProperty.value());
                 if (propertyModelBuilder == null) {
                     addCreatorPropertyToClassModelBuilder(classModelBuilder, bsonProperty.value(), parameterType);
-                } else if (propertyModelBuilder.getTypeData().getType() != parameterType) {
+                } else if (!propertyModelBuilder.getTypeData().equals(parameterTypeData)) {
                     throw creatorExecutable.getError(format("Invalid Property type for '%s'. Expected %s, found %s.", bsonProperty.value(),
                             propertyModelBuilder.getTypeData().getType(), parameterType));
                 }

--- a/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
@@ -72,8 +72,16 @@ final class InstanceCreatorImpl<T> implements InstanceCreator<T> {
     @Override
     public T getInstance() {
         if (newInstance == null) {
-            throw new CodecConfigurationException(format("Could not construct new instance of: %s. Missing the following properties: %s",
-                    creatorExecutable.getType().getSimpleName(), properties.keySet()));
+            try {
+                for (Map.Entry<String, Integer> entry : properties.entrySet()) {
+                    params[entry.getValue()] = null;
+                }
+                constructInstanceAndProcessCachedValues();
+            } catch (CodecConfigurationException e) {
+                throw new CodecConfigurationException(format("Could not construct new instance of: %s. "
+                                + "Missing the following properties: %s",
+                        creatorExecutable.getType().getSimpleName(), properties.keySet()), e);
+            }
         }
         return newInstance;
     }

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -34,8 +34,8 @@ import org.bson.codecs.pojo.entities.SimpleEnumModel;
 import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.SimpleNestedPojoModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationModel;
+import org.bson.codecs.pojo.entities.conventions.CreatorConstructorPrimitivesModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorThrowsExceptionModel;
-import org.bson.codecs.pojo.entities.conventions.CreatorMethodModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorMethodThrowsExceptionModel;
 import org.bson.types.ObjectId;
 import org.junit.Test;
@@ -295,8 +295,8 @@ public final class PojoCustomTest extends PojoTestCase {
     }
 
     @Test(expected = CodecConfigurationException.class)
-    public void testCreatorMethodModelWithMissingParameters() {
-        decodingShouldFail(getCodec(CreatorMethodModel.class), "{'stringField': 'eleven', 'longField': {$numberLong: '12'}}");
+    public void testBsonCreatorPrimitivesAndNullValues() {
+        decodingShouldFail(getCodec(CreatorConstructorPrimitivesModel.class), "{intField: 100,  stringField: 'test'}");
     }
 
     @Test(expected = CodecConfigurationException.class)

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -236,14 +236,22 @@ public final class PojoRoundTripTest extends PojoTestCase {
                 getPojoCodecProviderBuilder(CreatorMethodModel.class),
                 "{'integerField': 30, 'stringField': 'two', 'longField': {$numberLong: '32'}}"));
 
+        data.add(new TestData("Creator method", CreatorMethodModel.create(30),
+                getPojoCodecProviderBuilder(CreatorMethodModel.class),
+                "{'integerField': 30, 'longField': {$numberLong: '0'}}"));
+
         data.add(new TestData("Creator no-args method", new CreatorNoArgsMethodModel(10, "one", 11),
                 getPojoCodecProviderBuilder(CreatorNoArgsMethodModel.class),
                 "{'integerField': 10, 'stringField': 'one', 'longField': {$numberLong: '11'}}"));
 
-        data.add(new TestData("Creator no-args method", new CreatorAllFinalFieldsModel("pId", "Ada", "Lovelace"),
+        data.add(new TestData("Creator all final", new CreatorAllFinalFieldsModel("pId", "Ada", "Lovelace"),
                 getPojoCodecProviderBuilder(CreatorAllFinalFieldsModel.class),
                 "{'_id': 'pId', '_t': 'org.bson.codecs.pojo.entities.conventions.CreatorAllFinalFieldsModel', "
                         + "'firstName': 'Ada', 'lastName': 'Lovelace'}"));
+
+        data.add(new TestData("Creator all final with nulls", new CreatorAllFinalFieldsModel("pId", "Ada", null),
+                getPojoCodecProviderBuilder(CreatorAllFinalFieldsModel.class),
+                "{'_id': 'pId', '_t': 'org.bson.codecs.pojo.entities.conventions.CreatorAllFinalFieldsModel', 'firstName': 'Ada'}"));
 
         return data;
     }

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorPrimitivesModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorPrimitivesModel.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public final class CreatorConstructorPrimitivesModel {
+    private final int intField;
+    private final String stringField;
+    private final long longField;
+
+
+    @BsonCreator
+    public CreatorConstructorPrimitivesModel(@BsonProperty("intField") final int intField,
+                                             @BsonProperty("stringField") final String stringField,
+                                             @BsonProperty("longField") final long longField) {
+        this.intField = intField;
+        this.stringField = stringField;
+        this.longField = longField;
+    }
+
+    /**
+     * Returns the intField
+     *
+     * @return the intField
+     */
+    public int getIntField() {
+        return intField;
+    }
+
+    /**
+     * Returns the stringField
+     *
+     * @return the stringField
+     */
+    public String getStringField() {
+        return stringField;
+    }
+
+    /**
+     * Returns the longField
+     *
+     * @return the longField
+     */
+    public long getLongField() {
+        return longField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CreatorConstructorPrimitivesModel that = (CreatorConstructorPrimitivesModel) o;
+
+        if (getIntField() != that.getIntField()) {
+            return false;
+        }
+        if (getLongField() != that.getLongField()) {
+            return false;
+        }
+        if (getStringField() != null ? !getStringField().equals(that.getStringField()) : that.getStringField() != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getIntField();
+        result = 31 * result + (getStringField() != null ? getStringField().hashCode() : 0);
+        result = 31 * result + (int) (getLongField() ^ (getLongField() >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CreatorConstructorPrimativesModel{"
+                + "intField=" + intField
+                + ", stringField='" + stringField + "'"
+                + ", longField=" + longField
+                + "}";
+    }
+}


### PR DESCRIPTION
Make any missing @BsonProperty values null, then try to construct a new instance.
This allows non serialized null values to be round tripped.

JAVA-2587