### PR TITLE
Added a SET_PRIVATE_FIELDS_CONVENTION

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/ConventionSetPrivateFieldImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionSetPrivateFieldImpl.java
@@ -18,8 +18,6 @@ package org.bson.codecs.pojo;
 
 import org.bson.codecs.configuration.CodecConfigurationException;
 
-import java.lang.reflect.Field;
-
 import static java.lang.String.format;
 import static java.lang.reflect.Modifier.isPrivate;
 
@@ -68,9 +66,7 @@ final class ConventionSetPrivateFieldImpl implements Convention {
         @Override
         public <S> void set(final S instance, final T value) {
             try {
-                Field field = wrapped.getPropertyMetadata().getField();
-                field.setAccessible(true);
-                field.set(instance, value);
+                wrapped.getPropertyMetadata().getField().set(instance, value);
             } catch (Exception e) {
                 throw new CodecConfigurationException(format("Unable to set value for property '%s' in %s",
                         wrapped.getPropertyMetadata().getName(), wrapped.getPropertyMetadata().getDeclaringClassName()), e);

--- a/bson/src/main/org/bson/codecs/pojo/ConventionSetPrivateFieldImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionSetPrivateFieldImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.configuration.CodecConfigurationException;
+
+import java.lang.reflect.Field;
+
+import static java.lang.String.format;
+import static java.lang.reflect.Modifier.isPrivate;
+
+final class ConventionSetPrivateFieldImpl implements Convention {
+
+    @Override
+    public void apply(final ClassModelBuilder<?> classModelBuilder) {
+        for (PropertyModelBuilder<?> propertyModelBuilder : classModelBuilder.getPropertyModelBuilders()) {
+            if (propertyModelBuilder.getPropertyAccessor() instanceof PropertyAccessorImpl) {
+                PropertyAccessorImpl<?> defaultAccessor = (PropertyAccessorImpl<?>) propertyModelBuilder.getPropertyAccessor();
+                PropertyMetadata<?> propertyMetaData = defaultAccessor.getPropertyMetadata();
+                if (!propertyMetaData.isDeserializable() && isPrivate(propertyMetaData.getField().getModifiers())) {
+                    setPropertyAccessor(propertyModelBuilder);
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> void setPropertyAccessor(final PropertyModelBuilder<T> propertyModelBuilder) {
+        propertyModelBuilder.propertyAccessor(new PrivateProperyAccessor<T>(
+                (PropertyAccessorImpl<T>) propertyModelBuilder.getPropertyAccessor()));
+    }
+
+    private static final class PrivateProperyAccessor<T> implements PropertyAccessor<T> {
+        private final PropertyAccessorImpl<T> wrapped;
+
+        private PrivateProperyAccessor(final PropertyAccessorImpl<T> wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public <S> T get(final S instance) {
+            return wrapped.get(instance);
+        }
+
+        @Override
+        public <S> void set(final S instance, final T value) {
+            try {
+                Field field = wrapped.getPropertyMetadata().getField();
+                field.setAccessible(true);
+                field.set(instance, value);
+            } catch (Exception e) {
+                throw new CodecConfigurationException(format("Unable to set value for property '%s' in %s",
+                        wrapped.getPropertyMetadata().getName(),
+                        wrapped.getPropertyMetadata().getDeclaringClassName()), e);
+            }
+        }
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/Conventions.java
+++ b/bson/src/main/org/bson/codecs/pojo/Conventions.java
@@ -52,7 +52,7 @@ public final class Conventions {
     /**
      * A convention that enables private fields to be set using reflection.
      *
-     * <p>This convention, mimics how some other JSON libraries directly set a private field when there is no setter.</p>
+     * <p>This convention mimics how some other JSON libraries directly set a private field when there is no setter.</p>
      * <p>Note: This convention is not part of the {@code DEFAULT_CONVENTIONS} list and must explicitly be set.</p>
      *
      * @since 3.6

--- a/bson/src/main/org/bson/codecs/pojo/Conventions.java
+++ b/bson/src/main/org/bson/codecs/pojo/Conventions.java
@@ -50,6 +50,16 @@ public final class Conventions {
     public static final Convention ANNOTATION_CONVENTION = new ConventionAnnotationImpl();
 
     /**
+     * A convention that enables private fields to be set using reflection.
+     *
+     * <p>This convention, mimics how some other JSON libraries directly set a private field when there is no setter.</p>
+     * <p>Note: This convention is not part of the {@code DEFAULT_CONVENTIONS} list and must explicitly be set.</p>
+     *
+     * @since 3.6
+     */
+    public static final Convention SET_PRIVATE_FIELDS_CONVENTION = new ConventionSetPrivateFieldImpl();
+
+    /**
      * The default conventions list
      */
     public static final List<Convention> DEFAULT_CONVENTIONS =

--- a/bson/src/main/org/bson/codecs/pojo/PropertyAccessorImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/PropertyAccessorImpl.java
@@ -61,6 +61,10 @@ final class PropertyAccessorImpl<T> implements PropertyAccessor<T> {
         }
     }
 
+    PropertyMetadata<T> getPropertyMetadata() {
+        return propertyMetadata;
+    }
+
     private CodecConfigurationException getError(final Exception cause) {
         return new CodecConfigurationException(format("Unable to get value for property '%s' in %s", propertyMetadata.getName(),
                 propertyMetadata.getDeclaringClassName()), cause);

--- a/bson/src/test/unit/org/bson/codecs/pojo/ConventionsTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ConventionsTest.java
@@ -25,6 +25,8 @@ import org.bson.codecs.pojo.entities.conventions.CreatorInvalidConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMethodModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMethodReturnTypeModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMultipleConstructorsModel;
+import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMultipleCreatorsModel;
+import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMultipleStaticCreatorsModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidTypeConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidTypeMethodModel;
 import org.junit.Test;
@@ -144,6 +146,18 @@ public final class ConventionsTest {
     @Test(expected = CodecConfigurationException.class)
     public void testCreatorInvalidMultipleConstructorsModel() {
         ClassModel.builder(CreatorInvalidMultipleConstructorsModel.class)
+                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testCreatorInvalidMultipleCreatorsModel() {
+        ClassModel.builder(CreatorInvalidMultipleCreatorsModel.class)
+                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testCreatorInvalidMultipleStaticCreatorsModel() {
+        ClassModel.builder(CreatorInvalidMultipleStaticCreatorsModel.class)
                 .conventions(singletonList(ANNOTATION_CONVENTION)).build();
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -36,6 +36,7 @@ import org.bson.codecs.pojo.entities.InvalidSetterArgsModel;
 import org.bson.codecs.pojo.entities.Optional;
 import org.bson.codecs.pojo.entities.OptionalPropertyCodecProvider;
 import org.bson.codecs.pojo.entities.PrimitivesModel;
+import org.bson.codecs.pojo.entities.PrivateSetterFieldModel;
 import org.bson.codecs.pojo.entities.SimpleEnum;
 import org.bson.codecs.pojo.entities.SimpleEnumModel;
 import org.bson.codecs.pojo.entities.SimpleModel;
@@ -48,6 +49,7 @@ import org.bson.codecs.pojo.entities.conventions.CreatorMethodThrowsExceptionMod
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -58,7 +60,9 @@ import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+import static org.bson.codecs.pojo.Conventions.DEFAULT_CONVENTIONS;
 import static org.bson.codecs.pojo.Conventions.NO_CONVENTIONS;
+import static org.bson.codecs.pojo.Conventions.SET_PRIVATE_FIELDS_CONVENTION;
 
 public final class PojoCustomTest extends PojoTestCase {
 
@@ -151,6 +155,17 @@ public final class PojoCustomTest extends PojoTestCase {
                 "{ '_id': 'id', '_cls': 'convention_model', 'my_final_field': 10, 'my_int_field': 10,"
                         + "'child': { '_id': 'child', 'my_final_field': 10, 'my_int_field': 10, "
                         + "           'simple_model': {'integer_field': 42, 'string_field': 'myString' } } }");
+    }
+
+    @Test
+    public void testSetPrivateFieldConvention() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(PrivateSetterFieldModel.class);
+        ArrayList<Convention> conventions = new ArrayList<Convention>(DEFAULT_CONVENTIONS);
+        conventions.add(SET_PRIVATE_FIELDS_CONVENTION);
+        builder.conventions(conventions);
+
+        roundTrip(builder, new PrivateSetterFieldModel(1, "2", asList("a", "b")),
+                "{'integerField': 1, 'stringField': '2', listField: ['a', 'b']}");
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/PrivateSetterFieldModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/PrivateSetterFieldModel.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import java.util.List;
+
+public final class PrivateSetterFieldModel {
+
+    private Integer integerField;
+    private String stringField;
+    private List<String> listField;
+
+    public PrivateSetterFieldModel(){
+    }
+
+    public PrivateSetterFieldModel(final Integer integerField, final String stringField, final List<String> listField) {
+        this.integerField = integerField;
+        this.stringField = stringField;
+        this.listField = listField;
+    }
+
+    public Integer getIntegerField() {
+        return integerField;
+    }
+
+    public String getStringField() {
+        return stringField;
+    }
+
+    public List<String> getListField() {
+        return listField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PrivateSetterFieldModel that = (PrivateSetterFieldModel) o;
+
+        if (getIntegerField() != null ? !getIntegerField().equals(that.getIntegerField()) : that.getIntegerField() != null) {
+            return false;
+        }
+        if (getStringField() != null ? !getStringField().equals(that.getStringField()) : that.getStringField() != null) {
+            return false;
+        }
+        return getListField() != null ? getListField().equals(that.getListField()) : that.getListField() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getIntegerField() != null ? getIntegerField().hashCode() : 0;
+        result = 31 * result + (getStringField() != null ? getStringField().hashCode() : 0);
+        result = 31 * result + (getListField() != null ? getListField().hashCode() : 0);
+        return result;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInvalidMultipleCreatorsModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInvalidMultipleCreatorsModel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,28 +19,25 @@ package org.bson.codecs.pojo.entities.conventions;
 import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
-public final class CreatorInvalidMultipleConstructorsModel {
+public final class CreatorInvalidMultipleCreatorsModel {
     private final Integer integerField;
     private String stringField;
     public long longField;
 
     @BsonCreator
-    public CreatorInvalidMultipleConstructorsModel(@BsonProperty("integerField") final Integer integerField) {
+    public CreatorInvalidMultipleCreatorsModel(@BsonProperty("integerField") final Integer integerField) {
         this.integerField = integerField;
     }
 
-    @BsonCreator
-    public CreatorInvalidMultipleConstructorsModel(@BsonProperty("integerField") final Integer integerField,
-                                                   @BsonProperty("stringField") final String string) {
-        this(integerField);
-        setStringField(stringField);
-    }
-
-
-    public CreatorInvalidMultipleConstructorsModel(final Integer integerField, final String stringField, final long longField) {
+    public CreatorInvalidMultipleCreatorsModel(final Integer integerField, final String stringField, final long longField) {
         this.integerField = integerField;
         this.stringField = stringField;
         this.longField = longField;
+    }
+
+    @BsonCreator
+    public static CreatorInvalidMultipleCreatorsModel create(@BsonProperty("integerField") final Integer integerField) {
+        return new CreatorInvalidMultipleCreatorsModel(integerField);
     }
 
     public Integer getIntegerField() {
@@ -64,7 +61,7 @@ public final class CreatorInvalidMultipleConstructorsModel {
             return false;
         }
 
-        CreatorInvalidMultipleConstructorsModel that = (CreatorInvalidMultipleConstructorsModel) o;
+        CreatorInvalidMultipleCreatorsModel that = (CreatorInvalidMultipleCreatorsModel) o;
 
         if (longField != that.longField) {
             return false;

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInvalidMultipleStaticCreatorsModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInvalidMultipleStaticCreatorsModel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,28 +19,32 @@ package org.bson.codecs.pojo.entities.conventions;
 import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
-public final class CreatorInvalidMultipleConstructorsModel {
+public final class CreatorInvalidMultipleStaticCreatorsModel {
     private final Integer integerField;
     private String stringField;
     public long longField;
 
-    @BsonCreator
-    public CreatorInvalidMultipleConstructorsModel(@BsonProperty("integerField") final Integer integerField) {
+    private CreatorInvalidMultipleStaticCreatorsModel(final Integer integerField) {
         this.integerField = integerField;
     }
 
-    @BsonCreator
-    public CreatorInvalidMultipleConstructorsModel(@BsonProperty("integerField") final Integer integerField,
-                                                   @BsonProperty("stringField") final String string) {
-        this(integerField);
-        setStringField(stringField);
-    }
-
-
-    public CreatorInvalidMultipleConstructorsModel(final Integer integerField, final String stringField, final long longField) {
+    public CreatorInvalidMultipleStaticCreatorsModel(final Integer integerField, final String stringField, final long longField) {
         this.integerField = integerField;
         this.stringField = stringField;
         this.longField = longField;
+    }
+
+    @BsonCreator
+    public static CreatorInvalidMultipleStaticCreatorsModel create(@BsonProperty("integerField") final Integer integerField) {
+        return new CreatorInvalidMultipleStaticCreatorsModel(integerField);
+    }
+
+    @BsonCreator
+    public static CreatorInvalidMultipleStaticCreatorsModel create(@BsonProperty("integerField") final Integer integerField,
+                                                                   @BsonProperty("stringField") final String stringField) {
+        CreatorInvalidMultipleStaticCreatorsModel model = new CreatorInvalidMultipleStaticCreatorsModel(integerField);
+        model.setStringField(stringField);
+        return model;
     }
 
     public Integer getIntegerField() {
@@ -64,7 +68,7 @@ public final class CreatorInvalidMultipleConstructorsModel {
             return false;
         }
 
-        CreatorInvalidMultipleConstructorsModel that = (CreatorInvalidMultipleConstructorsModel) o;
+        CreatorInvalidMultipleStaticCreatorsModel that = (CreatorInvalidMultipleStaticCreatorsModel) o;
 
         if (longField != that.longField) {
             return false;


### PR DESCRIPTION
Some existing JSON libraries set field values directly.

While we respect field access modifiers by default, this commit adds a
`SET_PRIVATE_FIELDS_CONVENTION` that can be used to directly set
private fields, thus mimicing other librarues.

This convention is not part of the default conventions and must be explicitly set.

JAVA-2648