### PR TITLE
Added the USE_GETTERS_FOR_SETTERS convention

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/ConventionUseGettersAsSettersImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionUseGettersAsSettersImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.configuration.CodecConfigurationException;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+final class ConventionUseGettersAsSettersImpl implements Convention {
+
+    @Override
+    public void apply(final ClassModelBuilder<?> classModelBuilder) {
+        for (PropertyModelBuilder<?> propertyModelBuilder : classModelBuilder.getPropertyModelBuilders()) {
+            if (!(propertyModelBuilder.getPropertyAccessor() instanceof PropertyAccessorImpl)) {
+                throw new CodecConfigurationException(format("The USE_GETTER_AS_SETTER_CONVENTION is not compatible with "
+                        + "propertyModelBuilder instance that have custom implementations of org.bson.codecs.pojo.PropertyAccessor: %s",
+                        propertyModelBuilder.getPropertyAccessor().getClass().getName()));
+            }
+            PropertyAccessorImpl<?> defaultAccessor = (PropertyAccessorImpl<?>) propertyModelBuilder.getPropertyAccessor();
+            PropertyMetadata<?> propertyMetaData = defaultAccessor.getPropertyMetadata();
+            if (!propertyMetaData.isDeserializable() && propertyMetaData.isSerializable()
+                    && isMapOrCollection(propertyMetaData.getTypeData().getType())) {
+                setPropertyAccessor(propertyModelBuilder);
+            }
+        }
+    }
+
+    private <T> boolean isMapOrCollection(final Class<T> clazz) {
+        return Collection.class.isAssignableFrom(clazz) || Map.class.isAssignableFrom(clazz);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> void setPropertyAccessor(final PropertyModelBuilder<T> propertyModelBuilder) {
+        propertyModelBuilder.propertyAccessor(new PrivateProperyAccessor<T>(
+                (PropertyAccessorImpl<T>) propertyModelBuilder.getPropertyAccessor()));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static final class PrivateProperyAccessor<T> implements PropertyAccessor<T> {
+        private final PropertyAccessorImpl<T> wrapped;
+
+        private PrivateProperyAccessor(final PropertyAccessorImpl<T> wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public <S> T get(final S instance) {
+            return wrapped.get(instance);
+        }
+
+        @Override
+        public <S> void set(final S instance, final T value) {
+            if (value instanceof Collection) {
+                mutateCollection(instance, (Collection) value);
+            } else if (value instanceof Map) {
+                mutateMap(instance, (Map) value);
+            } else {
+                setError(format("Unexpected type: '%s'", value.getClass()), null);
+            }
+        }
+
+        private <S> void mutateCollection(final S instance, final Collection value) {
+            T originalCollection = get(instance);
+            Collection<?> collection = ((Collection<?>) originalCollection);
+            if (collection == null) {
+                setError("The getter returned null.", null);
+            } if (!collection.isEmpty()) {
+                setError("The getter returned a non empty collection.", null);
+            } else {
+                try {
+                    collection.addAll(value);
+                } catch (Exception e) {
+                    setError("collection#addAll failed.", e);
+                }
+            }
+        }
+
+        private <S> void mutateMap(final S instance, final Map value) {
+            T originalMap = get(instance);
+            Map<?, ?> map = ((Map<?, ?>) originalMap);
+            if (map == null) {
+                setError("The getter returned null.", null);
+            } if (!map.isEmpty()) {
+                setError("The getter returned a non empty map.", null);
+            } else {
+                try {
+                    map.putAll(value);
+                } catch (Exception e) {
+                    setError("map#putAll failed.", e);
+                }
+            }
+        }
+        private void setError(final String reason, final Exception cause) {
+            throw new CodecConfigurationException(format("Cannot use getter in '%s' to set '%s'. %s",
+                    wrapped.getPropertyMetadata().getDeclaringClassName(), wrapped.getPropertyMetadata().getName(), reason), cause);
+        }
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/ConventionUseGettersAsSettersImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionUseGettersAsSettersImpl.java
@@ -72,7 +72,7 @@ final class ConventionUseGettersAsSettersImpl implements Convention {
             } else if (value instanceof Map) {
                 mutateMap(instance, (Map) value);
             } else {
-                setError(format("Unexpected type: '%s'", value.getClass()), null);
+                throwCodecConfigurationException(format("Unexpected type: '%s'", value.getClass()), null);
             }
         }
 
@@ -80,14 +80,14 @@ final class ConventionUseGettersAsSettersImpl implements Convention {
             T originalCollection = get(instance);
             Collection<?> collection = ((Collection<?>) originalCollection);
             if (collection == null) {
-                setError("The getter returned null.", null);
-            } if (!collection.isEmpty()) {
-                setError("The getter returned a non empty collection.", null);
+                throwCodecConfigurationException("The getter returned null.", null);
+            } else if (!collection.isEmpty()) {
+                throwCodecConfigurationException("The getter returned a non empty collection.", null);
             } else {
                 try {
                     collection.addAll(value);
                 } catch (Exception e) {
-                    setError("collection#addAll failed.", e);
+                    throwCodecConfigurationException("collection#addAll failed.", e);
                 }
             }
         }
@@ -96,18 +96,18 @@ final class ConventionUseGettersAsSettersImpl implements Convention {
             T originalMap = get(instance);
             Map<?, ?> map = ((Map<?, ?>) originalMap);
             if (map == null) {
-                setError("The getter returned null.", null);
-            } if (!map.isEmpty()) {
-                setError("The getter returned a non empty map.", null);
+                throwCodecConfigurationException("The getter returned null.", null);
+            } else if (!map.isEmpty()) {
+                throwCodecConfigurationException("The getter returned a non empty map.", null);
             } else {
                 try {
                     map.putAll(value);
                 } catch (Exception e) {
-                    setError("map#putAll failed.", e);
+                    throwCodecConfigurationException("map#putAll failed.", e);
                 }
             }
         }
-        private void setError(final String reason, final Exception cause) {
+        private void throwCodecConfigurationException(final String reason, final Exception cause) {
             throw new CodecConfigurationException(format("Cannot use getter in '%s' to set '%s'. %s",
                     wrapped.getPropertyMetadata().getDeclaringClassName(), wrapped.getPropertyMetadata().getName(), reason), cause);
         }

--- a/bson/src/main/org/bson/codecs/pojo/Conventions.java
+++ b/bson/src/main/org/bson/codecs/pojo/Conventions.java
@@ -60,6 +60,16 @@ public final class Conventions {
     public static final Convention SET_PRIVATE_FIELDS_CONVENTION = new ConventionSetPrivateFieldImpl();
 
     /**
+     * A convention that uses getter methods as setters for collections and maps if there is no setter.
+     *
+     * <p>This convention mimics how JAXB mutate collections and maps.</p>
+     * <p>Note: This convention is not part of the {@code DEFAULT_CONVENTIONS} list and must explicitly be set.</p>
+     *
+     * @since 3.6
+     */
+    public static final Convention USE_GETTERS_FOR_SETTERS = new ConventionUseGettersAsSettersImpl();
+
+    /**
      * The default conventions list
      */
     public static final List<Convention> DEFAULT_CONVENTIONS =

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -43,9 +43,17 @@ import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.SimpleNestedPojoModel;
 import org.bson.codecs.pojo.entities.UpperBoundsModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationModel;
+import org.bson.codecs.pojo.entities.conventions.CollectionsGetterNonEmptyModel;
+import org.bson.codecs.pojo.entities.conventions.CollectionsGetterNullModel;
+import org.bson.codecs.pojo.entities.conventions.CollectionsGetterImmutableModel;
+import org.bson.codecs.pojo.entities.conventions.CollectionsGetterMutableModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorPrimitivesModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorThrowsExceptionModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorMethodThrowsExceptionModel;
+import org.bson.codecs.pojo.entities.conventions.MapGetterNonEmptyModel;
+import org.bson.codecs.pojo.entities.conventions.MapGetterNullModel;
+import org.bson.codecs.pojo.entities.conventions.MapGetterImmutableModel;
+import org.bson.codecs.pojo.entities.conventions.MapGetterMutableModel;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
@@ -63,6 +71,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import static org.bson.codecs.pojo.Conventions.DEFAULT_CONVENTIONS;
 import static org.bson.codecs.pojo.Conventions.NO_CONVENTIONS;
 import static org.bson.codecs.pojo.Conventions.SET_PRIVATE_FIELDS_CONVENTION;
+import static org.bson.codecs.pojo.Conventions.USE_GETTERS_FOR_SETTERS;
 
 public final class PojoCustomTest extends PojoTestCase {
 
@@ -166,6 +175,64 @@ public final class PojoCustomTest extends PojoTestCase {
 
         roundTrip(builder, new PrivateSetterFieldModel(1, "2", asList("a", "b")),
                 "{'integerField': 1, 'stringField': '2', listField: ['a', 'b']}");
+    }
+
+    @Test
+    public void testUseGettersForSettersConvention() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterMutableModel.class, MapGetterMutableModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        roundTrip(builder, new CollectionsGetterMutableModel(asList(1, 2)), "{listField: [1, 2]}");
+        roundTrip(builder, new MapGetterMutableModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testUseGettersForSettersConventionImmutableCollection() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterImmutableModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        roundTrip(builder, new CollectionsGetterImmutableModel(asList(1, 2)), "{listField: [1, 2]}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testUseGettersForSettersConventionImmutableMap() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(MapGetterImmutableModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        roundTrip(builder, new MapGetterImmutableModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testUseGettersForSettersConventionNullCollection() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterNullModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        roundTrip(builder, new CollectionsGetterNullModel(asList(1, 2)), "{listField: [1, 2]}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testUseGettersForSettersConventionNullMap() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(MapGetterNullModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        roundTrip(builder, new MapGetterNullModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testUseGettersForSettersConventionNotEmptyCollection() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterNonEmptyModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        roundTrip(builder, new CollectionsGetterNonEmptyModel(asList(1, 2)), "{listField: [1, 2]}");
+    }
+
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testUseGettersForSettersConventionNotEmptyMap() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(MapGetterNonEmptyModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        roundTrip(builder, new MapGetterNonEmptyModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}");
     }
 
     @Test
@@ -402,4 +469,11 @@ public final class PojoCustomTest extends PojoTestCase {
     public void testInvalidGetterAndSetterModelDecoding() {
         decodingShouldFail(getCodec(InvalidGetterAndSetterModel.class), "{'integerField': 42, 'stringField': 'myString'}");
     }
+
+    private List<Convention> getDefaultAndUseGettersConvention() {
+        List<Convention> conventions = new ArrayList<Convention>(DEFAULT_CONVENTIONS);
+        conventions.add(USE_GETTERS_FOR_SETTERS);
+        return conventions;
+    }
+
 }

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -187,6 +187,22 @@ public final class PojoCustomTest extends PojoTestCase {
     }
 
     @Test(expected = CodecConfigurationException.class)
+    public void testUseGettersForSettersConventionInvalidTypeForCollection() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterMutableModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        decodingShouldFail(getCodec(builder, CollectionsGetterMutableModel.class), "{listField: ['1', '2']}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testUseGettersForSettersConventionInvalidTypeForMap() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(MapGetterMutableModel.class)
+                .conventions(getDefaultAndUseGettersConvention());
+
+        decodingShouldFail(getCodec(builder, MapGetterMutableModel.class), "{mapField: {a: '1'}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
     public void testUseGettersForSettersConventionImmutableCollection() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterImmutableModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
@@ -225,7 +241,6 @@ public final class PojoCustomTest extends PojoTestCase {
 
         roundTrip(builder, new CollectionsGetterNonEmptyModel(asList(1, 2)), "{listField: [1, 2]}");
     }
-
 
     @Test(expected = CodecConfigurationException.class)
     public void testUseGettersForSettersConventionNotEmptyMap() {

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionsGetterImmutableModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionsGetterImmutableModel.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CollectionsGetterImmutableModel {
+
+    private final List<Integer> listField;
+
+    public CollectionsGetterImmutableModel() {
+        this(Collections.<Integer>emptyList());
+    }
+
+    public CollectionsGetterImmutableModel(final List<Integer> listField) {
+        this.listField = Collections.unmodifiableList(listField);
+    }
+
+    public List<Integer> getListField() {
+        return listField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+
+        CollectionsGetterImmutableModel that = (CollectionsGetterImmutableModel) o;
+
+        return listField != null ? listField.equals(that.listField) : that.listField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return listField != null ? listField.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionsGetterMutableModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionsGetterMutableModel.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollectionsGetterMutableModel {
+
+    private final List<Integer> listField;
+
+    public CollectionsGetterMutableModel() {
+        this(new ArrayList<Integer>());
+    }
+
+    public CollectionsGetterMutableModel(final List<Integer> listField) {
+        this.listField = listField;
+    }
+
+    public List<Integer> getListField() {
+        return listField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CollectionsGetterMutableModel that = (CollectionsGetterMutableModel) o;
+        return listField != null ? listField.equals(that.listField) : that.listField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return listField != null ? listField.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionsGetterNonEmptyModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionsGetterNonEmptyModel.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class CollectionsGetterNonEmptyModel {
+
+    private final List<Integer> listField;
+
+    public CollectionsGetterNonEmptyModel() {
+        this(asList(1, 2));
+    }
+
+    public CollectionsGetterNonEmptyModel(final List<Integer> listField) {
+        this.listField = listField;
+    }
+
+    public List<Integer> getListField() {
+        return listField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+
+        CollectionsGetterNonEmptyModel that = (CollectionsGetterNonEmptyModel) o;
+
+        return listField != null ? listField.equals(that.listField) : that.listField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return listField != null ? listField.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionsGetterNullModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionsGetterNullModel.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.List;
+
+public class CollectionsGetterNullModel {
+
+    private final List<Integer> listField;
+
+    public CollectionsGetterNullModel() {
+        this(null);
+    }
+
+    public CollectionsGetterNullModel(final List<Integer> listField) {
+        this.listField = listField;
+    }
+
+    public List<Integer> getListField() {
+        return listField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+
+        CollectionsGetterNullModel that = (CollectionsGetterNullModel) o;
+        return listField != null ? listField.equals(that.listField) : that.listField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return listField != null ? listField.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/MapGetterImmutableModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/MapGetterImmutableModel.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class MapGetterImmutableModel {
+
+    private final Map<String, Integer> mapField;
+
+    public MapGetterImmutableModel() {
+        this(Collections.<String, Integer>emptyMap());
+    }
+
+    public MapGetterImmutableModel(final Map<String, Integer> mapField) {
+        this.mapField = Collections.unmodifiableMap(mapField);
+    }
+
+    public Map<String, Integer> getMapField() {
+        return mapField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+
+        MapGetterImmutableModel that = (MapGetterImmutableModel) o;
+
+        return mapField != null ? mapField.equals(that.mapField) : that.mapField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return mapField != null ? mapField.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/MapGetterMutableModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/MapGetterMutableModel.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapGetterMutableModel {
+
+    private final Map<String, Integer> mapField;
+
+    public MapGetterMutableModel() {
+        this.mapField = new HashMap<String, Integer>();
+    }
+
+    public MapGetterMutableModel(final Map<String, Integer> mapField) {
+        this.mapField = mapField;
+    }
+
+    public Map<String, Integer> getMapField() {
+        return mapField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+
+        MapGetterMutableModel that = (MapGetterMutableModel) o;
+        return mapField != null ? mapField.equals(that.mapField) : that.mapField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return mapField != null ? mapField.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/MapGetterNonEmptyModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/MapGetterNonEmptyModel.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class MapGetterNonEmptyModel {
+
+    private final Map<String, Integer> mapField;
+
+    public MapGetterNonEmptyModel() {
+        this(Collections.singletonMap("a", 1));
+    }
+
+    public MapGetterNonEmptyModel(final Map<String, Integer> mapField) {
+        this.mapField = mapField;
+    }
+
+    public Map<String, Integer> getMapField() {
+        return mapField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+
+        MapGetterNonEmptyModel that = (MapGetterNonEmptyModel) o;
+
+        return mapField != null ? mapField.equals(that.mapField) : that.mapField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return mapField != null ? mapField.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/MapGetterNullModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/MapGetterNullModel.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.Map;
+
+public class MapGetterNullModel {
+
+    private final Map<String, Integer> mapField;
+
+    public MapGetterNullModel() {
+        this(null);
+    }
+
+    public MapGetterNullModel(final Map<String, Integer> mapField) {
+        this.mapField = mapField;
+    }
+
+    public Map<String, Integer> getMapField() {
+        return mapField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+
+        MapGetterNullModel that = (MapGetterNullModel) o;
+
+        return mapField != null ? mapField.equals(that.mapField) : that.mapField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return  mapField != null ? mapField.hashCode() : 0;
+    }
+}

--- a/docs/reference/content/bson/pojos.md
+++ b/docs/reference/content/bson/pojos.md
@@ -317,6 +317,8 @@ The following Conventions are available from the [`Conventions`]({{<apiref "org/
         the PropertyModels. If the `idProperty` isn't set and there is a property named `_id` or `id` then it will be marked as the `idProperty`.
   * The [`SET_PRIVATE_FIELDS_CONVENTION`]({{<apiref "org/bson/codecs/pojo/Conventions.html#SET_PRIVATE_FIELDS_CONVENTION">}}).  Enables 
         private fields to be set directly using reflection, without the need of a setter method. Note this convention is not enabled by default.
+  * The [`USE_GETTERS_FOR_SETTERS`]({{<apiref "org/bson/codecs/pojo/Conventions.html#USE_GETTERS_FOR_SETTERS">}}). Allows getters to be used
+        for Map and Collection properties without setters, the collection/map is then mutated. Note this convention is not enabled by default.
   * The [`DEFAULT_CONVENTIONS`]({{<apiref "org/bson/codecs/pojo/Conventions.html#DEFAULT_CONVENTIONS">}}), a list containing the 
     `ANNOTATION_CONVENTION` and the `CLASS_AND_PROPERTY_CONVENTION`.
   * The [`NO_CONVENTIONS`]({{<apiref "org/bson/codecs/pojo/Conventions.html#NO_CONVENTIONS">}}) an empty list.

--- a/docs/reference/content/whats-new.md
+++ b/docs/reference/content/whats-new.md
@@ -49,6 +49,7 @@ The 3.6 release brings new improvements to the `PojoCodec`:
   * Improvements to the `BsonCreator` annotation, which now supports `@BsonId` and `@BsonProperty` with values that represent the read name of the property.
   * A new [`PropertyCodecProvider`]({{<apiref "org/bson/codecs/pojo/PropertyCodecProvider">}}) API, allowing for easy and type-safe handling of container types.
   * Added the [`SET_PRIVATE_FIELDS_CONVENTION`]({{<apiref "org/bson/codecs/pojo/Conventions.html#SET_PRIVATE_FIELDS_CONVENTION">}}) convention.
+  * Added the [`USE_GETTERS_FOR_SETTERS`]({{<apiref "org/bson/codecs/pojo/Conventions.html#USE_GETTERS_FOR_SETTERS">}}) convention.
 
 The MongoDB Java drivers team would like to thank both [Joseph Florencio](https://github.com/jflorencio) and [Qi Liu](https://github.com/visualage)
 for their excellent contributions to the PojoCodec.


### PR DESCRIPTION
Allows the getters for Map / Collection properties to provide
the initial data, which is then mutated.

JAVA-2648