### PR TITLE
Allow MongoIterableSubscription to use batchSize if set

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/FindIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/FindIterableImpl.java
@@ -100,6 +100,11 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
     }
 
     @Override
+    public Integer getBatchSize() {
+        return findOptions.getBatchSize();
+    }
+
+    @Override
     public FindIterable<TResult> collation(final Collation collation) {
         findOptions.collation(collation);
         return this;

--- a/driver-async/src/main/com/mongodb/async/client/MappingIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MappingIterable.java
@@ -107,6 +107,11 @@ class MappingIterable<U, V> implements MongoIterable<V> {
     }
 
     @Override
+    public Integer getBatchSize() {
+        return iterable.getBatchSize();
+    }
+
+    @Override
     public void batchCursor(final SingleResultCallback<AsyncBatchCursor<V>> callback) {
         notNull("callback", callback);
         iterable.batchCursor(new SingleResultCallback<AsyncBatchCursor<U>>() {

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
@@ -71,6 +71,7 @@ public interface MongoIterable<TResult> {
      * @param batchSize the batch size
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
+     * @since 3.7
      */
     MongoIterable<TResult> batchSize(int batchSize);
 

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
@@ -75,6 +75,14 @@ public interface MongoIterable<TResult> {
     MongoIterable<TResult> batchSize(int batchSize);
 
     /**
+     * Gets the number of documents to return per batch or null if not set.
+     *
+     * @return the batch size, which may be null
+     * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
+     */
+    Integer getBatchSize();
+
+    /**
      * Provide the underlying {@link com.mongodb.async.AsyncBatchCursor} allowing fine grained control of the cursor.
      *
      * @param callback a callback that will be passed the AsyncBatchCursor

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
@@ -71,7 +71,6 @@ public interface MongoIterable<TResult> {
      * @param batchSize the batch size
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
-     * @since 3.7
      */
     MongoIterable<TResult> batchSize(int batchSize);
 
@@ -80,6 +79,7 @@ public interface MongoIterable<TResult> {
      *
      * @return the batch size, which may be null
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
+     * @since 3.7
      */
     Integer getBatchSize();
 

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterableImpl.java
@@ -69,6 +69,7 @@ abstract class MongoIterableImpl<TResult> implements MongoIterable<TResult> {
         return readConcern;
     }
 
+    @Override
     public Integer getBatchSize() {
         return batchSize;
     }

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSFindIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSFindIterableImpl.java
@@ -99,6 +99,11 @@ final class GridFSFindIterableImpl implements GridFSFindIterable {
     }
 
     @Override
+    public Integer getBatchSize() {
+        return underlying.getBatchSize();
+    }
+
+    @Override
     public GridFSFindIterable collation(final Collation collation) {
         underlying.collation(collation);
         return this;

--- a/driver-async/src/test/unit/com/mongodb/async/client/AggregateIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/AggregateIterableSpecification.groovy
@@ -337,4 +337,20 @@ class AggregateIterableSpecification extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    def 'should get and set batchSize as expected'() {
+        when:
+        def batchSize = 5
+        def mongoIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
+                readConcern, writeConcern, Stub(AsyncOperationExecutor), [null])
+
+        then:
+        mongoIterable.getBatchSize() == null
+
+        when:
+        mongoIterable.batchSize(batchSize)
+
+        then:
+        mongoIterable.getBatchSize() == batchSize
+    }
+
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/ChangeStreamIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ChangeStreamIterableSpecification.groovy
@@ -317,6 +317,34 @@ class ChangeStreamIterableSpecification extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    def 'should get and set batchSize as expected'() {
+        when:
+        def batchSize = 5
+        def mongoIterable = new ChangeStreamIterableImpl(null, namespace, codecRegistry, readPreference, readConcern,
+                Stub(AsyncOperationExecutor), [BsonDocument.parse('{$match: 1}')], BsonDocument)
+
+        then:
+        mongoIterable.getBatchSize() == null
+
+        when:
+        mongoIterable.batchSize(batchSize)
+
+        then:
+        mongoIterable.getBatchSize() == batchSize
+
+        when:
+        def adaptedMongoIterable = mongoIterable.withDocumentClass(Document)
+
+        then:
+        adaptedMongoIterable.getBatchSize() == null
+
+        when:
+        adaptedMongoIterable.batchSize(batchSize)
+
+        then:
+        adaptedMongoIterable.getBatchSize() == batchSize
+    }
+
     def cursor(List<?> cannedResults) {
         Stub(AsyncBatchCursor) {
             def count = 0

--- a/driver-async/src/test/unit/com/mongodb/async/client/DistinctIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/DistinctIterableSpecification.groovy
@@ -237,4 +237,20 @@ class DistinctIterableSpecification extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    def 'should get and set batchSize as expected'() {
+        when:
+        def batchSize = 5
+        def mongoIterable = new DistinctIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern,
+                Stub(AsyncOperationExecutor), 'field', new BsonDocument())
+
+        then:
+        mongoIterable.getBatchSize() == null
+
+        when:
+        mongoIterable.batchSize(batchSize)
+
+        then:
+        mongoIterable.getBatchSize() == batchSize
+    }
+
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/FindIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/FindIterableSpecification.groovy
@@ -83,7 +83,7 @@ class FindIterableSpecification extends Specification {
                 .showRecordId(false)
                 .snapshot(false)
         def findIterable = new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, executor,
-                                                new Document('filter', 1), findOptions)
+                new Document('filter', 1), findOptions)
 
         when: 'default input should be as expected'
         findIterable.into([]) { result, t -> }
@@ -180,7 +180,7 @@ class FindIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([cursor]);
         def findOptions = new FindOptions()
         def findIterable = new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, executor,
-                                                new Document('filter', 1), findOptions)
+                new Document('filter', 1), findOptions)
 
         when:
         findIterable.filter(new Document('filter', 1))
@@ -223,7 +223,7 @@ class FindIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
         def findOptions = new FindOptions()
         def mongoIterable = new FindIterableImpl(null, new MongoNamespace('db', 'coll'), Document, Document, codecRegistry,
-                                                 readPreference, readConcern, executor, new Document(), findOptions)
+                readPreference, readConcern, executor, new Document(), findOptions)
 
         when:
         def results = new FutureResultCallback()
@@ -326,5 +326,21 @@ class FindIterableSpecification extends Specification {
 
         then:
         thrown(IllegalArgumentException)
+    }
+
+    def 'should get and set batchSize as expected'() {
+        when:
+        def batchSize = 5
+        def mongoIterable = new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
+                readConcern, Stub(AsyncOperationExecutor), new Document(), new FindOptions())
+
+        then:
+        mongoIterable.getBatchSize() == 0
+
+        when:
+        mongoIterable.batchSize(batchSize)
+
+        then:
+        mongoIterable.getBatchSize() == batchSize
     }
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/ListCollectionsIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ListCollectionsIterableSpecification.groovy
@@ -198,4 +198,20 @@ class ListCollectionsIterableSpecification extends Specification {
         then:
         thrown(IllegalArgumentException)
     }
+
+    def 'should get and set batchSize as expected'() {
+        when:
+        def batchSize = 5
+        def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', Document, codecRegistry, readPreference,
+                Stub(AsyncOperationExecutor))
+
+        then:
+        mongoIterable.getBatchSize() == null
+
+        when:
+        mongoIterable.batchSize(batchSize)
+
+        then:
+        mongoIterable.getBatchSize() == batchSize
+    }
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/ListDatabasesIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ListDatabasesIterableSpecification.groovy
@@ -197,4 +197,20 @@ class ListDatabasesIterableSpecification extends Specification {
         then:
         thrown(IllegalArgumentException)
     }
+
+    def 'should get and set batchSize as expected'() {
+        when:
+        def batchSize = 5
+        def mongoIterable = new ListDatabasesIterableImpl<Document>(null, Document, codecRegistry, readPreference,
+                Stub(AsyncOperationExecutor))
+
+        then:
+        mongoIterable.getBatchSize() == null
+
+        when:
+        mongoIterable.batchSize(batchSize)
+
+        then:
+        mongoIterable.getBatchSize() == batchSize
+    }
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/ListIndexesIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ListIndexesIterableSpecification.groovy
@@ -200,4 +200,20 @@ class ListIndexesIterableSpecification extends Specification {
         then:
         thrown(IllegalArgumentException)
     }
+
+    def 'should get and set batchSize as expected'() {
+        when:
+        def batchSize = 5
+        def mongoIterable = new ListIndexesIterableImpl<Document>(null, namespace, Document, codecRegistry, readPreference,
+                Stub(AsyncOperationExecutor))
+
+        then:
+        mongoIterable.getBatchSize() == null
+
+        when:
+        mongoIterable.batchSize(batchSize)
+
+        then:
+        mongoIterable.getBatchSize() == batchSize
+    }
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/MapReduceIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MapReduceIterableSpecification.groovy
@@ -342,4 +342,19 @@ class MapReduceIterableSpecification extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    def 'should get and set batchSize as expected'() {
+        when:
+        def batchSize = 5
+        def mongoIterable = new MapReduceIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
+                readConcern, writeConcern, Stub(AsyncOperationExecutor), 'map', 'reduce')
+
+        then:
+        mongoIterable.getBatchSize() == null
+
+        when:
+        mongoIterable.batchSize(batchSize)
+
+        then:
+        mongoIterable.getBatchSize() == batchSize
+    }
 }


### PR DESCRIPTION
Previously, it would only use the requested demand. Control of requested
demand can be limited when interacting with third party libraries,
especially when composing observables.

JAVA-2710