### PR TITLE
Fix ChangeStreamDocumentCodec registry order

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocumentCodec.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocumentCodec.java
@@ -56,7 +56,7 @@ final class ChangeStreamDocumentCodec<TResult> implements Codec<ChangeStreamDocu
                 .register(changeStreamDocumentClassModel)
                 .build();
 
-        CodecRegistry registry = fromRegistries(codecRegistry, fromProviders(provider));
+        CodecRegistry registry = fromRegistries(fromProviders(provider), codecRegistry);
         this.codec = (Codec<ChangeStreamDocument<TResult>>) (Codec<? extends ChangeStreamDocument>)
                 registry.get(ChangeStreamDocument.class);
     }

--- a/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentCodecSpecification.groovy
@@ -28,6 +28,7 @@ import org.bson.codecs.DecoderContext
 import org.bson.codecs.DocumentCodecProvider
 import org.bson.codecs.EncoderContext
 import org.bson.codecs.ValueCodecProvider
+import org.bson.codecs.pojo.PojoCodecProvider
 import spock.lang.Specification
 
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
@@ -36,7 +37,8 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
 
     def 'should round trip ChangeStreamDocument successfully'() {
         given:
-        def codecRegistry = fromProviders([new DocumentCodecProvider(), new BsonValueCodecProvider(), new ValueCodecProvider()])
+        def codecRegistry = fromProviders([new DocumentCodecProvider(), new BsonValueCodecProvider(), new ValueCodecProvider(),
+                                           PojoCodecProvider.builder().automatic(true).build()])
         def codec = new ChangeStreamDocumentCodec(clazz, codecRegistry)
 
         when:


### PR DESCRIPTION
Previously, prevented the use of automatic codecs.

JAVA-2800