### PR TITLE
Relax type comparision in BasicDBObject#equals

### DIFF
--- a/driver-core/src/main/com/mongodb/BasicDBObject.java
+++ b/driver-core/src/main/com/mongodb/BasicDBObject.java
@@ -201,22 +201,22 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
             return true;
         }
 
-        if (!(o instanceof DBObject)) {
+        if (!(o instanceof BSONObject)) {
             return false;
         }
 
-        DBObject other = (DBObject) o;
+        BSONObject other = (BSONObject) o;
 
         if (!keySet().equals(other.keySet())) {
             return false;
         }
 
-        return Arrays.equals(toBson(canonicalizeDBObject(this)), toBson(canonicalizeDBObject(other)));
+        return Arrays.equals(toBson(canonicalizeBSONObject(this)), toBson(canonicalizeBSONObject(other)));
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(toBson(canonicalizeDBObject(this)));
+        return Arrays.hashCode(toBson(canonicalizeBSONObject(this)));
     }
 
     private static byte[] toBson(final DBObject dbObject) {
@@ -275,7 +275,7 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
     @SuppressWarnings("unchecked")
     private static Object canonicalize(final Object from) {
         if (from instanceof BSONObject && !(from instanceof BasicBSONList)) {
-            return canonicalizeDBObject((DBObject) from);
+            return canonicalizeBSONObject((BSONObject) from);
         } else if (from instanceof List) {
             return canonicalizeList((List<Object>) from);
         } else if (from instanceof Map) {
@@ -295,7 +295,7 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
         return canonicalized;
     }
 
-    private static DBObject canonicalizeDBObject(final DBObject from) {
+    private static DBObject canonicalizeBSONObject(final BSONObject from) {
         BasicDBObject canonicalized = new BasicDBObject();
         TreeSet<String> keysInOrder = new TreeSet<String>(from.keySet());
         for (String key : keysInOrder) {

--- a/driver-core/src/test/unit/com/mongodb/BasicDBObjectTest.java
+++ b/driver-core/src/test/unit/com/mongodb/BasicDBObjectTest.java
@@ -16,9 +16,12 @@
 
 package com.mongodb;
 
+import org.bson.BSONObject;
+import org.bson.BasicBSONObject;
 import org.bson.codecs.Codec;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
+import org.bson.types.BasicBSONList;
 import org.bson.types.ObjectId;
 import org.junit.Assert;
 import org.junit.Test;
@@ -165,12 +168,16 @@ public class BasicDBObjectTest {
         assertEquality(new BasicDBObject(), new BasicDBObject());
 
         assertEquality(new BasicDBObject("x", 1), new BasicDBObject("x", 1));
+        assertEquality(new BasicDBObject("x", 1), new BasicBSONObject("x", 1));
 
         assertInequality(new BasicDBObject("x", 1), new BasicDBObject("x", 2));
+        assertInequality(new BasicDBObject("x", 1), new BasicBSONObject("x", 2));
 
         assertInequality(new BasicDBObject("x", 1), new BasicDBObject("y", 1));
+        assertInequality(new BasicDBObject("x", 1), new BasicBSONObject("y", 1));
 
         assertEquality(new BasicDBObject("x", asList(1, 2, 3)), new BasicDBObject("x", new int[]{1, 2, 3}));
+        assertEquality(new BasicDBObject("x", asList(1, 2, 3)), new BasicBSONObject("x", asList(1, 2, 3)));
 
         BasicDBList list = new BasicDBList();
         list.put(0, 1);
@@ -178,17 +185,26 @@ public class BasicDBObjectTest {
         list.put(2, 3);
 
         assertEquality(new BasicDBObject("x", asList(1, 2, 3)), new BasicDBObject("x", list));
+        assertEquality(new BasicDBObject("x", asList(1, 2, 3)), new BasicBSONObject("x", list));
+
 
         assertEquality(new BasicDBObject("x", 1).append("y", 2), new BasicDBObject("y", 2).append("x", 1));
+        assertEquality(new BasicDBObject("x", 1).append("y", 2), new BasicBSONObject("y", 2).append("x", 1));
 
         assertEquality(new BasicDBObject("a", new BasicDBObject("y", 2).append("x", 1)),
                        new BasicDBObject("a", new BasicDBObject("x", 1).append("y", 2)));
+        assertEquality(new BasicDBObject("a", new BasicDBObject("y", 2).append("x", 1)),
+                       new BasicBSONObject("a", new BasicBSONObject("x", 1).append("y", 2)));
 
         assertEquality(new BasicDBObject("a", asList(new BasicDBObject("y", 2).append("x", 1))),
                        new BasicDBObject("a", asList(new BasicDBObject("x", 1).append("y", 2))));
+        assertEquality(new BasicDBObject("a", asList(new BasicDBObject("y", 2).append("x", 1))),
+                       new BasicBSONObject("a", asList(new BasicBSONObject("x", 1).append("y", 2))));
 
         assertEquality(new BasicDBObject("a", new BasicDBList().put(1, new BasicDBObject("y", 2).append("x", 1))),
                        new BasicDBObject("a", new BasicDBList().put(1, new BasicDBObject("x", 1).append("y", 2))));
+        assertEquality(new BasicDBObject("a", new BasicDBList().put(1, new BasicDBObject("y", 2).append("x", 1))),
+                       new BasicBSONObject("a", new BasicBSONList().put(1, new BasicBSONObject("x", 1).append("y", 2))));
 
         Map<String, Object> first = new HashMap<String, Object>();
         first.put("1", new BasicDBObject("y", 2).append("x", 1));
@@ -196,17 +212,21 @@ public class BasicDBObjectTest {
         Map<String, Object> second = new TreeMap<String, Object>();
         second.put("2", new BasicDBObject("b", 1).append("a", 2));
         second.put("1", new BasicDBObject("x", 1).append("y", 2));
+        Map<String, Object> third = new TreeMap<String, Object>();
+        third.put("2", new BasicBSONObject("a", 2).append("b", 1));
+        third.put("1", new BasicBSONObject("x", 1).append("y", 2));
 
         assertEquality(new BasicDBObject("a", first), new BasicDBObject("a", second));
+        assertEquality(new BasicDBObject("a", first), new BasicBSONObject("a", third));
     }
 
-    void assertEquality(final BasicDBObject x, final BasicDBObject y) {
+    void assertEquality(final BSONObject x, final BSONObject y) {
         assertEquals(x, y);
         assertEquals(y, x);
         assertEquals(x.hashCode(), y.hashCode());
     }
 
-    void assertInequality(final BasicDBObject x, final BasicDBObject y) {
+    void assertInequality(final BSONObject x, final BSONObject y) {
         assertThat(x, not(y));
         assertThat(y, not(x));
         assertThat(x.hashCode(), not(y.hashCode()));


### PR DESCRIPTION
Allow comparison against other BSONObject types

JAVA-2841