### PR TITLE
JAVA-2900: Store driver version in a generated class

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,10 @@ A couple of manual configuration steps are required to run the code in IntelliJ:
  **Fix:** Settings > Build, Execution, Deployment > Compiler > Java Compiler - untick "Use '--release' option for cross-compilation (Java 9 and later)"
 
 - **Error:** `java: package com.mongodb.internal.build does not exist`<br>
- **Fix:** Either run the `compileBuildConfig` task via Gradle > driver-core > Tasks > other > compileBuildConfig or `./gradlew compileBuildConfig`<br>
- Or delegate all build actions to Gradle: Settings > Build, Execution, Deployment > Build Tools > Gradle > Runner - tick "Delegate IDE build/run actions to gradle"
+ **Fixes:** Any of the following: <br>
+ - Run the `compileBuildConfig` task: eg: `./gradlew compileBuildConfig` or via Gradle > driver-core > Tasks > other > compileBuildConfig
+ - Set `compileBuildConfig` to execute Before Build. via Gradle > Tasks > other > right click compileBuildConfig - set "Execute Before Build" 
+ - Delegate all build actions to Gradle: Settings > Build, Execution, Deployment > Build Tools > Gradle > Runner - tick "Delegate IDE build/run actions to gradle"
 
 ### Build status:
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ $ mongod --dbpath ./data/db --logpath ./data/mongod.log --port 27017 --logappend
 If you encounter `"Too many open files"` errors when running the tests then you will need to increase 
 the number of available file descriptors prior to starting mongod as described in [https://docs.mongodb.com/manual/reference/ulimit/](https://docs.mongodb.com/manual/reference/ulimit/)
 
+## IntelliJ IDEA
+
+A couple of manual configuration steps are required to run the code in IntelliJ:
+
+- Java 9 is required to build and compile the source.
+
+- **Error:** `java: cannot find symbol: class SNIHostName location: package javax.net.ssl`<br>
+ **Fix:** Settings > Build, Execution, Deployment > Compiler > Java Compiler - untick "Use '--release' option for cross-compilation (Java 9 and later)"
+
+- **Error:** `java: package com.mongodb.internal.build does not exist`<br>
+ **Fix:** Either run the `compileBuildConfig` task via Gradle > driver-core > Tasks > other > compileBuildConfig or `./gradlew compileBuildConfig`<br>
+ Or delegate all build actions to Gradle: Settings > Build, Execution, Deployment > Build Tools > Gradle > Runner - tick "Delegate IDE build/run actions to gradle"
+
 ### Build status:
 
 [![Build Status](https://travis-ci.org/mongodb/mongo-java-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-java-driver)

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildscript {
         classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:1.12.+'
         classpath 'com.bmuschko:gradle-nexus-plugin:2.2'
         classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.1"
+        classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
     }
 }
 

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+apply plugin: 'idea'
 apply plugin: 'osgi'
 apply plugin: 'org.kordamp.gradle.clirr'
+apply plugin: 'de.fuerstenau.buildconfig'
 
 def configDir = new File(rootDir, 'config')
 archivesBaseName = 'mongodb-driver-core'
@@ -36,6 +38,14 @@ dependencies {
     compile "org.xerial.snappy:snappy-java:$snappyVersion", optional
 
     testCompile project(':bson').sourceSets.test.output
+}
+
+buildConfig {
+    appName = 'mongo-java-driver'
+    version = getGitVersion()
+
+    clsName = 'MongoDriverVersion'
+    packageName = 'com.mongodb.internal.build'
 }
 
 jar {

--- a/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.MongoDriverInformation;
+import com.mongodb.internal.build.MongoDriverVersion;
 import org.bson.BsonBinaryWriter;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
@@ -24,15 +25,8 @@ import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 
-import java.io.IOException;
-import java.net.JarURLConnection;
-import java.net.URL;
 import java.nio.charset.Charset;
-import java.security.CodeSource;
-import java.security.ProtectionDomain;
 import java.util.List;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static java.lang.String.format;
@@ -102,47 +96,6 @@ public final class ClientMetadataHelper {
             }
         }
         return false;
-    }
-
-    private static String getDriverVersion() {
-        String driverVersion = "unknown";
-        String path = getCodeSourcePath();
-        if (path != null) {
-            try {
-                URL jarUrl = path.endsWith(".jar") ? new URL("jar:file:" + path + "!/") : null;
-                if (jarUrl != null) {
-                    JarURLConnection jarURLConnection = (JarURLConnection) jarUrl.openConnection();
-                    Manifest manifest = jarURLConnection.getManifest();
-                    if (manifest != null) {
-                        Attributes mainAttributes = manifest.getMainAttributes();
-                        if (mainAttributes != null) {
-                            String version = (String) mainAttributes.get(new Attributes.Name("Build-Version"));
-                            if (version != null) {
-                                driverVersion = version;
-                            }
-                        }
-                    }
-                }
-            } catch (IOException e) {
-                // do nothing
-            }
-        }
-        return driverVersion;
-    }
-
-    private static String getCodeSourcePath() {
-        String path = null;
-        ProtectionDomain protectionDomain = InternalStreamConnectionInitializer.class.getProtectionDomain();
-        if (protectionDomain != null) {
-            CodeSource codeSource = protectionDomain.getCodeSource();
-            if (codeSource != null) {
-                URL location = codeSource.getLocation();
-                if (location != null) {
-                    path = location.getPath();
-                }
-            }
-        }
-        return path;
     }
 
     static BsonDocument createClientMetadataDocument(final String applicationName) {
@@ -215,8 +168,8 @@ public final class ClientMetadataHelper {
         MongoDriverInformation.Builder builder = mongoDriverInformation != null ? MongoDriverInformation.builder(mongoDriverInformation)
                 : MongoDriverInformation.builder();
         return builder
-                .driverName("mongo-java-driver")
-                .driverVersion(getDriverVersion())
+                .driverName(MongoDriverVersion.NAME)
+                .driverVersion(MongoDriverVersion.VERSION)
                 .driverPlatform(format("Java/%s/%s", getProperty("java.vendor", "unknown-vendor"),
                         getProperty("java.runtime.version", "unknown-version")))
                 .build();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ClientMetadataHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ClientMetadataHelperSpecification.groovy
@@ -17,6 +17,7 @@
 package com.mongodb.internal.connection
 
 import com.mongodb.MongoDriverInformation
+import com.mongodb.internal.build.MongoDriverVersion
 import org.bson.BsonBinaryWriter
 import org.bson.BsonDocument
 import org.bson.BsonString
@@ -149,9 +150,8 @@ class ClientMetadataHelperSpecification extends Specification {
     }
 
     static BsonDocument createExpectedClientMetadataDocument(String appName) {
-        String driverVersion = 'unknown'
-        def expectedDriverDocument = new BsonDocument('name', new BsonString('mongo-java-driver'))
-                .append('version', new BsonString(driverVersion))
+        def expectedDriverDocument = new BsonDocument('name', new BsonString(MongoDriverVersion.NAME))
+                .append('version', new BsonString(MongoDriverVersion.VERSION))
         def expectedOperatingSystemDocument = new BsonDocument('type',
                 new BsonString(ClientMetadataHelper.getOperatingSystemType(System.getProperty('os.name'))))
                 .append('name', new BsonString(System.getProperty('os.name')))

--- a/mongo-java-driver/build.gradle
+++ b/mongo-java-driver/build.gradle
@@ -35,10 +35,13 @@ sourceSets {
             srcDirs = ["$rootDir/driver-legacy/src/main",
                        "$rootDir/driver-sync/src/main",
                        "$rootDir/driver-core/src/main",
+                       "$rootDir/driver-core/build/gen/buildconfig/src/main",
                        "$rootDir/bson/src/main"]
         }
     }
 }
+
+compileJava.dependsOn(":driver-core:compileBuildConfig")
 
 // copied from driver-core
 jar {


### PR DESCRIPTION
Accessing the driver version from META-INF/MANIFEST.MF has proved to be
too fragile, as it fails when the driver is deployed in ways in which
that file is difficult to access or no longer even exists.

Generating a class at build time and storing it in the class path will
be robust against any attempts to re-package.