### PR TITLE
Ensure BsonDbPointers in json can roundtrip

### DIFF
--- a/bson/src/main/org/bson/json/ExtendedJsonBsonDbPointerConverter.java
+++ b/bson/src/main/org/bson/json/ExtendedJsonBsonDbPointerConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.bson.json;
+
+import org.bson.BsonDbPointer;
+
+class ExtendedJsonBsonDbPointerConverter implements Converter<BsonDbPointer> {
+    private static ExtendedJsonObjectIdConverter objectIdConverter = new ExtendedJsonObjectIdConverter();
+
+    @Override
+    public void convert(final BsonDbPointer value, final StrictJsonWriter writer) {
+        writer.writeStartObject();
+        writer.writeStartObject("$dbPointer");
+        writer.writeString("$ref", value.getNamespace());
+        writer.writeName("$id");
+        objectIdConverter.convert(value.getId(), writer);
+        writer.writeEndObject();
+        writer.writeEndObject();
+    }
+}

--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -758,7 +758,15 @@ public class JsonReader extends AbstractBsonReader {
         verifyToken(JsonTokenType.LEFT_PAREN);
         String namespace = readStringFromExtendedJson();
         verifyToken(JsonTokenType.COMMA);
-        ObjectId id = new ObjectId(readStringFromExtendedJson());
+        JsonToken token = popToken();
+        pushToken(token);
+        verifyToken(JsonTokenType.UNQUOTED_STRING);
+        String value = token.getValue(String.class);
+        if (!value.equals("new")) {
+            pushToken(token);
+        }
+        verifyToken(JsonTokenType.UNQUOTED_STRING, "ObjectId");
+        ObjectId id = visitObjectIdConstructor();
         verifyToken(JsonTokenType.RIGHT_PAREN);
         return new BsonDbPointer(namespace, id);
     }

--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -132,31 +132,7 @@ public class JsonWriter extends AbstractBsonWriter {
 
     @Override
     protected void doWriteDBPointer(final BsonDbPointer value) {
-        if (settings.getOutputMode() == JsonMode.EXTENDED) {
-            new Converter<BsonDbPointer>() {
-                @Override
-                public void convert(final BsonDbPointer value1, final StrictJsonWriter writer) {
-                    writer.writeStartObject();
-                    writer.writeStartObject("$dbPointer");
-                    writer.writeString("$ref", value1.getNamespace());
-                    writer.writeName("$id");
-                    doWriteObjectId(value1.getId());
-                    writer.writeEndObject();
-                    writer.writeEndObject();
-                }
-            }.convert(value, strictJsonWriter);
-        } else {
-            new Converter<BsonDbPointer>() {
-                @Override
-                public void convert(final BsonDbPointer value1, final StrictJsonWriter writer) {
-                    writer.writeStartObject();
-                    writer.writeString("$ref", value1.getNamespace());
-                    writer.writeName("$id");
-                    doWriteObjectId(value1.getId());
-                    writer.writeEndObject();
-                }
-            }.convert(value, strictJsonWriter);
-        }
+        settings.getBsonDbPointerConverter().convert(value, strictJsonWriter);
     }
 
     @Override
@@ -242,11 +218,11 @@ public class JsonWriter extends AbstractBsonWriter {
     }
 
     /**
-     * Return true if the output has been truncated due to exceeding the length specified in {@link JsonWriterSettings#maxLength}.
+     * Return true if the output has been truncated due to exceeding the length specified in {@link JsonWriterSettings#getMaxLength}.
      *
      * @return true if the output has been truncated
      * @since 3.7
-     * @see JsonWriterSettings#maxLength
+     * @see JsonWriterSettings#getMaxLength
      */
     public boolean isTruncated() {
         return strictJsonWriter.isTruncated();

--- a/bson/src/main/org/bson/json/JsonWriterSettings.java
+++ b/bson/src/main/org/bson/json/JsonWriterSettings.java
@@ -17,6 +17,7 @@
 package org.bson.json;
 
 import org.bson.BsonBinary;
+import org.bson.BsonDbPointer;
 import org.bson.BsonMaxKey;
 import org.bson.BsonMinKey;
 import org.bson.BsonNull;
@@ -77,6 +78,9 @@ public class JsonWriterSettings extends BsonWriterSettings {
     private static final LegacyExtendedJsonRegularExpressionConverter LEGACY_EXTENDED_JSON_REGULAR_EXPRESSION_CONVERTER =
             new LegacyExtendedJsonRegularExpressionConverter();
     private static final ShellRegularExpressionConverter SHELL_REGULAR_EXPRESSION_CONVERTER = new ShellRegularExpressionConverter();
+    private static final ExtendedJsonBsonDbPointerConverter EXTENDED_JSON_BSON_DB_POINTER_CONVERTER =
+            new ExtendedJsonBsonDbPointerConverter();
+    private static final ShellBsonDbPointerConverter SHELL_BSON_DB_POINTER_CONVERTER = new ShellBsonDbPointerConverter();
 
     private final boolean indent;
     private final String newLineCharacters;
@@ -100,6 +104,7 @@ public class JsonWriterSettings extends BsonWriterSettings {
     private final Converter<BsonMinKey> minKeyConverter;
     private final Converter<BsonMaxKey> maxKeyConverter;
     private final Converter<String> javaScriptConverter;
+    private final Converter<BsonDbPointer> bsonDbPointerConverter;
 
     /**
      * Create a builder for JsonWriterSettings, which are immutable.
@@ -333,6 +338,12 @@ public class JsonWriterSettings extends BsonWriterSettings {
         } else {
             regularExpressionConverter = SHELL_REGULAR_EXPRESSION_CONVERTER;
         }
+
+        if (outputMode == JsonMode.SHELL) {
+            bsonDbPointerConverter = SHELL_BSON_DB_POINTER_CONVERTER;
+        } else {
+            bsonDbPointerConverter = EXTENDED_JSON_BSON_DB_POINTER_CONVERTER;
+        }
     }
 
     /**
@@ -550,6 +561,10 @@ public class JsonWriterSettings extends BsonWriterSettings {
      */
     public Converter<String> getJavaScriptConverter() {
         return javaScriptConverter;
+    }
+
+    Converter<BsonDbPointer> getBsonDbPointerConverter() {
+        return bsonDbPointerConverter;
     }
 
     /**

--- a/bson/src/main/org/bson/json/ShellBsonDbPointerConverter.java
+++ b/bson/src/main/org/bson/json/ShellBsonDbPointerConverter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.bson.json;
+
+import org.bson.BsonDbPointer;
+
+import static java.lang.String.format;
+
+class ShellBsonDbPointerConverter implements Converter<BsonDbPointer> {
+    @Override
+    public void convert(final BsonDbPointer value, final StrictJsonWriter writer) {
+        writer.writeRaw(format("DBPointer(\"%s\", ObjectId(\"%s\"))", value.getNamespace(), value.getId().toHexString()));
+    }
+}

--- a/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
@@ -18,11 +18,15 @@ package org.bson
 
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DecoderContext
+import org.bson.json.JsonMode
+import org.bson.json.JsonWriterSettings
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static org.bson.BsonHelper.documentWithValuesOfEveryType
+import static org.bson.BsonHelper.documentWithValuesOfEveryTypeRelaxed
 
 class BsonDocumentSpecification extends Specification {
 
@@ -359,6 +363,20 @@ class BsonDocumentSpecification extends Specification {
 
         cleanup:
         reader.close()
+    }
+
+    @Unroll
+    def 'should roundtrip each JsonMode: #outputMode'() {
+        given:
+        def original = documentWithValuesOfEveryType()
+        def expected = outputMode == JsonMode.RELAXED ? documentWithValuesOfEveryTypeRelaxed() : original
+        def json = original.toJson(JsonWriterSettings.builder().outputMode(outputMode).build())
+
+        expect:
+        expected == BsonDocument.parse(json)
+
+        where:
+        outputMode << JsonMode.values()
     }
 
     def 'should serialize and deserialize'() {

--- a/bson/src/test/unit/org/bson/BsonHelper.java
+++ b/bson/src/test/unit/org/bson/BsonHelper.java
@@ -67,6 +67,39 @@ public final class BsonHelper {
                 new BsonDocument("a", new BsonInt32(1)));
     }
 
+    private static List<BsonValue> getRelaxedBsonValues() {
+        return asList(
+                new BsonNull(),
+                new BsonInt32(42),
+                new BsonInt32(52),
+                new BsonDecimal128(Decimal128.parse("4.00")),
+                new BsonBoolean(true),
+                new BsonDateTime(DATE.getTime()),
+                new BsonDouble(62.0),
+                new BsonString("the fox ..."),
+                new BsonMinKey(),
+                new BsonMaxKey(),
+                new BsonDbPointer("test.test", OBJECT_ID),
+                new BsonJavaScript("int i = 0;"),
+                new BsonJavaScriptWithScope("x", new BsonDocument("x", new BsonInt32(1))),
+                new BsonObjectId(OBJECT_ID),
+                new BsonRegularExpression("^test.*regex.*xyz$", "i"),
+                new BsonSymbol("ruby stuff"),
+                new BsonTimestamp(0x12345678, 5),
+                new BsonUndefined(),
+                new BsonBinary((byte) 80, new byte[]{5, 4, 3, 2, 1}),
+                new BsonArray(asList(
+                        new BsonInt32(1),
+                        new BsonInt32(2),
+                        new BsonBoolean(true),
+                        new BsonArray(asList(
+                                new BsonInt32(1),
+                                new BsonInt32(2),
+                                new BsonInt32(3),
+                                new BsonDocument("a", new BsonInt32(2)))))),
+                new BsonDocument("a", new BsonInt32(1)));
+    }
+
     // fail class loading if any BSON types are not represented in BSON_VALUES.
     static {
         for (BsonType curBsonType : BsonType.values()) {
@@ -95,6 +128,15 @@ public final class BsonHelper {
     public static BsonDocument documentWithValuesOfEveryType() {
         BsonDocument document = new BsonDocument();
         List<BsonValue> bsonValues = getBsonValues();
+        for (int i = 0; i < bsonValues.size(); i++) {
+            document.append(Integer.toString(i), bsonValues.get(i));
+        }
+        return document;
+    }
+
+    public static BsonDocument documentWithValuesOfEveryTypeRelaxed() {
+        BsonDocument document = new BsonDocument();
+        List<BsonValue> bsonValues = getRelaxedBsonValues();
         for (int i = 0; i < bsonValues.size(); i++) {
             document.append(Integer.toString(i), bsonValues.get(i));
         }

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -979,7 +979,7 @@ public class JsonReaderTest {
 
     @Test
     public void testDBPointer() {
-        String json = "DBPointer(\"b\",\"5209296cd6c4e38cf96fffdc\")";
+        String json = "DBPointer(\"b\",ObjectId(\"5209296cd6c4e38cf96fffdc\"))";
         bsonReader = new JsonReader(json);
         assertEquals(BsonType.DB_POINTER, bsonReader.readBsonType());
         BsonDbPointer dbPointer = bsonReader.readDBPointer();
@@ -989,7 +989,7 @@ public class JsonReaderTest {
 
     @Test
     public void testDBPointerWithNew() {
-        String json = "new DBPointer(\"b\",\"5209296cd6c4e38cf96fffdc\")";
+        String json = "new DBPointer(\"b\", new ObjectId(\"5209296cd6c4e38cf96fffdc\"))";
         bsonReader = new JsonReader(json);
         assertEquals(BsonType.DB_POINTER, bsonReader.readBsonType());
         BsonDbPointer dbPointer = bsonReader.readDBPointer();

--- a/bson/src/test/unit/org/bson/json/JsonWriterTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonWriterTest.java
@@ -661,7 +661,8 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeDBPointer("dbPointer", new BsonDbPointer("my.test", new ObjectId("4d0ce088e447ad08b4721a37")));
         writer.writeEndDocument();
-        String expected = "{ \"dbPointer\" : { \"$ref\" : \"my.test\", \"$id\" : { \"$oid\" : \"4d0ce088e447ad08b4721a37\" } } }";
+        String expected = "{ \"dbPointer\" : { \"$dbPointer\" : { \"$ref\" : \"my.test\", \"$id\" : "
+            + "{ \"$oid\" : \"4d0ce088e447ad08b4721a37\" } } } }";
         assertEquals(expected, stringWriter.toString());
     }
 }

--- a/config/checkstyle-exclude.xml
+++ b/config/checkstyle-exclude.xml
@@ -25,6 +25,7 @@
     <suppress checks="Regexp" files="QuickTour"/>
 
     <suppress checks="MethodLength" files="PojoRoundTripTest"/>
+    <suppress checks="MethodLength" files="JsonWriterSettings"/>
 
     <suppress checks="JavadocPackage" files="com[\\/]mongodb[\\/][^\\/]*\.java"/>
     <suppress checks="JavadocPackage" files="com[\\/]mongodb[\\/]client[\\/][^\\/]*\.java"/>


### PR DESCRIPTION
Turns out it was the writer incorrectly writing the values in different modes.

JAVA-2905