### PR TITLE
Added db.aggregate method

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
@@ -29,6 +29,7 @@ import com.mongodb.WriteError;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.WriteRequest;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
 import com.mongodb.internal.client.model.CountStrategy;
@@ -346,7 +347,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                                                          final List<? extends Bson> pipeline,
                                                                          final Class<TResult> resultClass) {
         return new AggregateIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
-                readPreference, readConcern, writeConcern, executor, pipeline);
+                readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION);
     }
 
     @Override

--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabase.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabase.java
@@ -502,4 +502,58 @@ public interface MongoDatabase {
      */
     <TResult> ChangeStreamIterable<TResult> watch(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
 
+    /**
+     * Runs an aggregation framework pipeline on the database for pipeline stages
+     * that do not require an underlying collection, such as {@code $currentOp} and {@code $listLocalSessions}.
+     *
+     * @param pipeline the aggregation pipeline
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.10
+     * @mongodb.driver.manual reference/command/aggregate/#dbcmd.aggregate Aggregate Command
+     * @mongodb.server.release 3.6
+     */
+    AggregateIterable<Document> aggregate(List<? extends Bson> pipeline);
+
+    /**
+     * Runs an aggregation framework pipeline on the database for pipeline stages
+     * that do not require an underlying collection, such as {@code $currentOp} and {@code $listLocalSessions}.
+     *
+     * @param pipeline    the aggregation pipeline
+     * @param resultClass the class to decode each document into
+     * @param <TResult>   the target document type of the iterable.
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.10
+     * @mongodb.driver.manual reference/command/aggregate/#dbcmd.aggregate Aggregate Command
+     * @mongodb.server.release 3.6
+     */
+    <TResult> AggregateIterable<TResult> aggregate(List<? extends Bson> pipeline, Class<TResult> resultClass);
+
+    /**
+     * Runs an aggregation framework pipeline on the database for pipeline stages
+     * that do not require an underlying collection, such as {@code $currentOp} and {@code $listLocalSessions}.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param pipeline the aggregation pipeline
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.10
+     * @mongodb.driver.manual reference/command/aggregate/#dbcmd.aggregate Aggregate Command
+     * @mongodb.server.release 3.6
+     */
+    AggregateIterable<Document> aggregate(ClientSession clientSession, List<? extends Bson> pipeline);
+
+    /**
+     * Runs an aggregation framework pipeline on the database for pipeline stages
+     * that do not require an underlying collection, such as {@code $currentOp} and {@code $listLocalSessions}.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param pipeline    the aggregation pipeline
+     * @param resultClass the class to decode each document into
+     * @param <TResult>   the target document type of the iterable.
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.10
+     * @mongodb.driver.manual reference/command/aggregate/#dbcmd.aggregate Aggregate Command
+     * @mongodb.server.release 3.6
+     */
+    <TResult> AggregateIterable<TResult> aggregate(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
+
 }

--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
@@ -23,6 +23,7 @@ import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.CreateViewOptions;
 import com.mongodb.client.model.IndexOptionDefaults;
@@ -366,6 +367,34 @@ class MongoDatabaseImpl implements MongoDatabase {
                                                          final Class<TResult> resultClass) {
         notNull("clientSession", clientSession);
         return createChangeStreamIterable(clientSession, pipeline, resultClass);
+    }
+
+    @Override
+    public AggregateIterable<Document> aggregate(final List<? extends Bson> pipeline) {
+        return aggregate(pipeline, Document.class);
+    }
+
+    @Override
+    public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass) {
+        return createAggregateIterable(null, pipeline, resultClass);
+    }
+
+    @Override
+    public AggregateIterable<Document> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline) {
+        return aggregate(clientSession, pipeline, Document.class);
+    }
+
+    @Override
+    public <TResult> AggregateIterable<TResult> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline,
+                                                          final Class<TResult> resultClass) {
+        return createAggregateIterable(notNull("clientSession", clientSession), pipeline, resultClass);
+    }
+
+    private <TResult> AggregateIterable<TResult> createAggregateIterable(@Nullable final ClientSession clientSession,
+                                                                         final List<? extends Bson> pipeline,
+                                                                         final Class<TResult> resultClass) {
+        return new AggregateIterableImpl<Document, TResult>(clientSession, name, Document.class, resultClass, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE);
     }
 
     private <TResult> ChangeStreamIterable<TResult> createChangeStreamIterable(@Nullable final ClientSession clientSession,

--- a/driver-async/src/test/functional/com/mongodb/async/client/JsonPoweredCrudTestHelper.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/JsonPoweredCrudTestHelper.java
@@ -57,6 +57,7 @@ import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonNull;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.junit.AssumptionViolatedException;
 
@@ -66,7 +67,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.mongodb.async.client.Fixture.isSharded;
 import static java.lang.String.format;
+import static org.junit.Assume.assumeTrue;
 
 public class JsonPoweredCrudTestHelper {
     private final String description;
@@ -85,11 +88,11 @@ public class JsonPoweredCrudTestHelper {
     }
 
     BsonDocument getOperationResults(final BsonDocument operation, @Nullable final ClientSession clientSession) {
-        String name = operation.getString("name").getValue();
         BsonDocument collectionOptions = operation.getDocument("collectionOptions", new BsonDocument());
         BsonDocument arguments = operation.getDocument("arguments");
 
-        String methodName = "get" + name.substring(0, 1).toUpperCase() + name.substring(1) + "Result";
+        String methodName = createMethodName(operation.getString("name").getValue(),
+                operation.getString("object", new BsonString("")).getValue());
         try {
             Method method = getClass().getDeclaredMethod(methodName, BsonDocument.class, BsonDocument.class, ClientSession.class);
             return (BsonDocument) method.invoke(this, collectionOptions, arguments, clientSession);
@@ -106,6 +109,19 @@ public class JsonPoweredCrudTestHelper {
         } catch (IllegalAccessException e) {
             throw new UnsupportedOperationException("Invalid handler access for operation " + methodName);
         }
+    }
+
+    private String createMethodName(final String name, final String object) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("get");
+        if (!object.isEmpty() && !object.equals("collection")) {
+            builder.append(object.substring(0, 1).toUpperCase());
+            builder.append(object.substring(1));
+        }
+        builder.append(name.substring(0, 1).toUpperCase());
+        builder.append(name.substring(1));
+        builder.append("Result");
+        return builder.toString();
     }
 
     <T> T futureResult(final FutureResultCallback<T> callback) {
@@ -195,6 +211,11 @@ public class JsonPoweredCrudTestHelper {
         return new BsonDocument("result", results != null ? results : BsonNull.VALUE);
     }
 
+    BsonDocument getDatabaseRunCommandResult(final BsonDocument collectionOptions, final BsonDocument arguments,
+                                             @Nullable final ClientSession clientSession) {
+        return getRunCommandResult(collectionOptions, arguments, clientSession);
+    }
+
     BsonDocument getRunCommandResult(final BsonDocument collectionOptions, final BsonDocument arguments,
                                      @Nullable final ClientSession clientSession) {
         BsonDocument command = arguments.getDocument("command");
@@ -245,6 +266,44 @@ public class JsonPoweredCrudTestHelper {
             iterable.collation(getCollation(arguments.getDocument("collation")));
         }
         return toResult(iterable);
+    }
+
+    BsonDocument getDatabaseAggregateResult(final BsonDocument collectionOptions, final BsonDocument arguments,
+                                            @Nullable final ClientSession clientSession) {
+        assumeTrue(!isSharded());
+        List<BsonDocument> pipeline = new ArrayList<BsonDocument>();
+        for (BsonValue stage : arguments.getArray("pipeline")) {
+            pipeline.add(stage.asDocument());
+        }
+
+        AggregateIterable<BsonDocument> iterable;
+        if (clientSession == null) {
+            iterable = database.aggregate(pipeline, BsonDocument.class);
+        } else {
+            iterable = database.aggregate(clientSession, pipeline, BsonDocument.class);
+        }
+
+        if (arguments.containsKey("allowDiskUse")) {
+            iterable.allowDiskUse(arguments.getBoolean("allowDiskUse").getValue());
+        }
+        if (arguments.containsKey("batchSize")) {
+            iterable.batchSize(arguments.getNumber("batchSize").intValue());
+        }
+        if (arguments.containsKey("collation")) {
+            iterable.collation(getCollation(arguments.getDocument("collation")));
+        }
+
+        BsonDocument results = toResult(iterable);
+        for (BsonValue result : results.getArray("result", new BsonArray())) {
+            if (result.isDocument()) {
+                BsonDocument command = result.asDocument().getDocument("command", new BsonDocument());
+                command.remove("$readPreference");
+                command.remove("$clusterTime");
+                command.remove("signature");
+                command.remove("keyId");
+            }
+        }
+        return results;
     }
 
     @SuppressWarnings("deprecation")

--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
@@ -37,6 +37,7 @@ import com.mongodb.bulk.UpdateRequest
 import com.mongodb.bulk.WriteConcernError
 import com.mongodb.client.ImmutableDocument
 import com.mongodb.client.ImmutableDocumentCodecProvider
+import com.mongodb.client.model.AggregationLevel
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CountOptions
@@ -390,14 +391,14 @@ class MongoCollectionSpecification extends Specification {
 
         then:
         expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(session, namespace, Document, Document, codecRegistry,
-                readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)]))
+                readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)], AggregationLevel.COLLECTION))
 
         when:
         aggregateIterable = execute(aggregateMethod, session, [new Document('$match', 1)], BsonDocument)
 
         then:
         expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(session, namespace, Document, BsonDocument, codecRegistry,
-                readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)]))
+                readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)], AggregationLevel.COLLECTION))
 
         where:
         session << [null, Stub(ClientSession)]

--- a/driver-core/src/main/com/mongodb/client/model/AggregationLevel.java
+++ b/driver-core/src/main/com/mongodb/client/model/AggregationLevel.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.mongodb.client.model;
+
+/**
+ * The aggregation level
+ *
+ * Where an aggregation command should take place.
+ *
+ * @since 3.10
+ */
+public enum AggregationLevel {
+
+    /**
+     * Database level aggregation
+     */
+    DATABASE,
+
+    /**
+     * Collection level aggregation
+     */
+    COLLECTION
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
@@ -21,6 +21,7 @@ import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.async.AsyncBatchCursor;
 import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.CountOptions;
@@ -100,15 +101,18 @@ public final class AsyncOperations<TDocument> {
                                                                              final long maxTimeMS, final long maxAwaitTimeMS,
                                                                              final Integer batchSize, final Collation collation,
                                                                              final Bson hint, final String comment,
-                                                                             final Boolean allowDiskUse, final Boolean useCursor) {
+                                                                             final Boolean allowDiskUse, final Boolean useCursor,
+                                                                             final AggregationLevel aggregationLevel) {
         return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, comment, allowDiskUse,
-                useCursor);
+                useCursor, aggregationLevel);
     }
 
     public AsyncWriteOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
                                                            final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
-                                                           final Collation collation, final Bson hint, final String comment) {
-        return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, comment);
+                                                           final Collation collation, final Bson hint, final String comment,
+                                                           final AggregationLevel aggregationLevel) {
+        return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, comment,
+                aggregationLevel);
     }
 
     public AsyncWriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -24,6 +24,7 @@ import com.mongodb.bulk.IndexRequest;
 import com.mongodb.bulk.InsertRequest;
 import com.mongodb.bulk.UpdateRequest;
 import com.mongodb.bulk.WriteRequest;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.CountOptions;
@@ -175,11 +176,11 @@ final class Operations<TDocument> {
 
     @SuppressWarnings("deprecation")
     <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
-                                                           final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
-                                                           final Collation collation,
-                                                           final Bson hint, final String comment, final Boolean allowDiskUse,
-                                                           final Boolean useCursor) {
-        return new AggregateOperation<TResult>(namespace, toBsonDocumentList(pipeline), codecRegistry.get(resultClass))
+                                                    final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
+                                                    final Collation collation, final Bson hint, final String comment,
+                                                    final Boolean allowDiskUse, final Boolean useCursor,
+                                                    final AggregationLevel aggregationLevel) {
+        return new AggregateOperation<TResult>(namespace, toBsonDocumentList(pipeline), codecRegistry.get(resultClass), aggregationLevel)
                 .maxTime(maxTimeMS, MILLISECONDS)
                 .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
                 .allowDiskUse(allowDiskUse)
@@ -192,9 +193,10 @@ final class Operations<TDocument> {
     }
 
     AggregateToCollectionOperation aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
-                                                                final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
-                                                                final Collation collation, final Bson hint, final String comment) {
-        return new AggregateToCollectionOperation(namespace, toBsonDocumentList(pipeline), writeConcern)
+                                                         final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
+                                                         final Collation collation, final Bson hint, final String comment,
+                                                         final AggregationLevel aggregationLevel) {
+        return new AggregateToCollectionOperation(namespace, toBsonDocumentList(pipeline), writeConcern, aggregationLevel)
                 .maxTime(maxTimeMS, MILLISECONDS)
                 .allowDiskUse(allowDiskUse)
                 .bypassDocumentValidation(bypassDocumentValidation)

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -23,6 +23,7 @@ import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.client.model.CreateIndexOptions;
 import com.mongodb.client.model.DeleteOptions;
@@ -98,15 +99,18 @@ public final class SyncOperations<TDocument> {
     public <TResult> ReadOperation<BatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
                                                                    final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
                                                                    final Collation collation, final Bson hint, final String comment,
-                                                                   final Boolean allowDiskUse, final Boolean useCursor) {
+                                                                   final Boolean allowDiskUse, final Boolean useCursor,
+                                                                   final AggregationLevel aggregationLevel) {
         return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, comment, allowDiskUse,
-                useCursor);
+                useCursor, aggregationLevel);
     }
 
     public WriteOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
                                                       final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
-                                                      final Collation collation, final Bson hint, final String comment) {
-        return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, comment);
+                                                      final Collation collation, final Bson hint, final String comment,
+                                                      final AggregationLevel aggregationLevel) {
+        return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, comment,
+                aggregationLevel);
     }
 
     public WriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,

--- a/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
@@ -23,6 +23,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.binding.AsyncReadBinding;
 import com.mongodb.binding.ReadBinding;
 import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.AggregationLevel;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.codecs.Decoder;
@@ -49,7 +50,21 @@ public class AggregateOperation<T> implements AsyncReadOperation<AsyncBatchCurso
      * @param decoder the decoder for the result documents.
      */
     public AggregateOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder) {
-        this.wrapped = new AggregateOperationImpl<T>(namespace, pipeline, decoder);
+        this(namespace, pipeline, decoder, AggregationLevel.COLLECTION);
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param namespace the database and collection namespace for the operation.
+     * @param pipeline the aggregation pipeline.
+     * @param decoder the decoder for the result documents.
+     * @param aggregationLevel the aggregation level
+     * @since 3.10
+     */
+    public AggregateOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder,
+                              final AggregationLevel aggregationLevel) {
+        this.wrapped = new AggregateOperationImpl<T>(namespace, pipeline, decoder, aggregationLevel);
     }
 
     /**

--- a/driver-core/src/test/resources/crud/db/db-aggregate.json
+++ b/driver-core/src/test/resources/crud/db/db-aggregate.json
@@ -1,0 +1,149 @@
+{
+  "database_name": "admin",
+  "data": [],
+  "minServerVersion": "3.6",
+  "tests": [
+    {
+      "description": "Aggregate with $currentOp",
+      "operation": {
+        "name": "aggregate",
+        "object": "database",
+        "arguments": {
+          "pipeline": [
+            {
+              "$currentOp": {
+                "allUsers": false,
+                "idleConnections": false
+              }
+            },
+            {
+              "$match": {
+                "command.aggregate": {
+                  "$eq": 1
+                }
+              }
+            },
+            {
+              "$project": {
+                "command": 1
+              }
+            },
+            {
+              "$project": {
+                "command.lsid": 0
+              }
+            }
+          ]
+        }
+      },
+      "outcome": {
+        "result": [
+          {
+            "command": {
+              "aggregate": 1,
+              "pipeline": [
+                {
+                  "$currentOp": {
+                    "allUsers": false,
+                    "idleConnections": false
+                  }
+                },
+                {
+                  "$match": {
+                    "command.aggregate": {
+                      "$eq": 1
+                    }
+                  }
+                },
+                {
+                  "$project": {
+                    "command": 1
+                  }
+                },
+                {
+                  "$project": {
+                    "command.lsid": 0
+                  }
+                }
+              ],
+              "cursor": {},
+              "$db": "admin"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "description": "Aggregate with $currentOp and allowDiskUse",
+      "operation": {
+        "name": "aggregate",
+        "object": "database",
+        "arguments": {
+          "pipeline": [
+            {
+              "$currentOp": {
+                "allUsers": true,
+                "idleConnections": true
+              }
+            },
+            {
+              "$match": {
+                "command.aggregate": {
+                  "$eq": 1
+                }
+              }
+            },
+            {
+              "$project": {
+                "command": 1
+              }
+            },
+            {
+              "$project": {
+                "command.lsid": 0
+              }
+            }
+          ],
+          "allowDiskUse": true
+        }
+      },
+      "outcome": {
+        "result": [
+          {
+            "command": {
+              "aggregate": 1,
+              "pipeline": [
+                {
+                  "$currentOp": {
+                    "allUsers": true,
+                    "idleConnections": true
+                  }
+                },
+                {
+                  "$match": {
+                    "command.aggregate": {
+                      "$eq": 1
+                    }
+                  }
+                },
+                {
+                  "$project": {
+                    "command": 1
+                  }
+                },
+                {
+                  "$project": {
+                    "command.lsid": 0
+                  }
+                }
+              ],
+              "allowDiskUse": true,
+              "cursor": {},
+              "$db": "admin"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/driver-embedded/src/test/functional/com/mongodb/embedded/client/CrudTest.java
+++ b/driver-embedded/src/test/functional/com/mongodb/embedded/client/CrudTest.java
@@ -21,6 +21,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.junit.After;
 import org.junit.Before;
@@ -36,6 +37,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
+import static com.mongodb.embedded.client.Fixture.getMongoClient;
 import static com.mongodb.embedded.client.Fixture.serverVersionGreaterThan;
 import static com.mongodb.embedded.client.Fixture.serverVersionLessThan;
 import static org.junit.Assert.assertEquals;
@@ -45,22 +48,25 @@ import static org.junit.Assert.assertEquals;
 public class CrudTest extends DatabaseTestCase {
     private final String filename;
     private final String description;
+    private final String databaseName;
     private final BsonArray data;
     private final BsonDocument definition;
     private MongoDatabase database;
     private MongoCollection<BsonDocument> collection;
     private JsonPoweredCrudTestHelper helper;
 
-    public CrudTest(final String filename, final String description, final BsonArray data, final BsonDocument definition) {
+    public CrudTest(final String filename, final String description, final String databaseName, final BsonArray data,
+                    final BsonDocument definition) {
         this.filename = filename;
         this.description = description;
+        this.databaseName = databaseName;
         this.data = data;
         this.definition = definition;
     }
 
     @Before
     public void setUp() {
-        database = Fixture.getDefaultDatabase();
+        database = getMongoClient().getDatabase(databaseName);
         collection = database.getCollection(getClass().getName(), BsonDocument.class);
         if (!data.isEmpty()) {
             List<BsonDocument> documents = new ArrayList<BsonDocument>();
@@ -130,6 +136,7 @@ public class CrudTest extends DatabaseTestCase {
             }
             for (BsonValue test: testDocument.getArray("tests")) {
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
+                        testDocument.getString("database_name", new BsonString(getDefaultDatabaseName())).getValue(),
                         testDocument.getArray("data"), test.asDocument()});
             }
         }

--- a/driver-legacy/src/test/functional/com/mongodb/client/LegacyCrudTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/client/LegacyCrudTest.java
@@ -18,6 +18,7 @@ package com.mongodb.client;
 
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import java.util.List;
 
 import static com.mongodb.ClusterFixture.serverVersionGreaterThan;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
 import static org.junit.Assert.assertEquals;
 
 // See https://github.com/mongodb/specifications/tree/master/source/crud/tests
@@ -41,14 +43,17 @@ import static org.junit.Assert.assertEquals;
 public class LegacyCrudTest extends LegacyDatabaseTestCase {
     private final String filename;
     private final String description;
+    private final String databaseName;
     private final BsonArray data;
     private final BsonDocument definition;
     private MongoCollection<BsonDocument> collection;
     private JsonPoweredCrudTestHelper helper;
 
-    public LegacyCrudTest(final String filename, final String description, final BsonArray data, final BsonDocument definition) {
+    public LegacyCrudTest(final String filename, final String description, final String databaseName, final BsonArray data,
+                          final BsonDocument definition) {
         this.filename = filename;
         this.description = description;
+        this.databaseName = databaseName;
         this.data = data;
         this.definition = definition;
     }
@@ -63,6 +68,7 @@ public class LegacyCrudTest extends LegacyDatabaseTestCase {
             }
             getCollectionHelper().insertDocuments(documents);
         }
+        database = client.getDatabase(databaseName);
         collection = database.getCollection(getClass().getName(), BsonDocument.class);
         helper = new JsonPoweredCrudTestHelper(description, database, collection);
     }
@@ -114,6 +120,7 @@ public class LegacyCrudTest extends LegacyDatabaseTestCase {
             }
             for (BsonValue test: testDocument.getArray("tests")) {
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
+                        testDocument.getString("database_name", new BsonString(getDefaultDatabaseName())).getValue(),
                         testDocument.getArray("data"), test.asDocument()});
             }
         }

--- a/driver-sync/src/main/com/mongodb/client/MongoDatabase.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoDatabase.java
@@ -485,4 +485,58 @@ public interface MongoDatabase {
      */
     <TResult> ChangeStreamIterable<TResult> watch(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
 
+    /**
+     * Runs an aggregation framework pipeline on the database for pipeline stages
+     * that do not require an underlying collection, such as {@code $currentOp} and {@code $listLocalSessions}.
+     *
+     * @param pipeline the aggregation pipeline
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.10
+     * @mongodb.driver.manual reference/command/aggregate/#dbcmd.aggregate Aggregate Command
+     * @mongodb.server.release 3.6
+     */
+    AggregateIterable<Document> aggregate(List<? extends Bson> pipeline);
+
+    /**
+     * Runs an aggregation framework pipeline on the database for pipeline stages
+     * that do not require an underlying collection, such as {@code $currentOp} and {@code $listLocalSessions}.
+     *
+     * @param pipeline    the aggregation pipeline
+     * @param resultClass the class to decode each document into
+     * @param <TResult>   the target document type of the iterable.
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.10
+     * @mongodb.driver.manual reference/command/aggregate/#dbcmd.aggregate Aggregate Command
+     * @mongodb.server.release 3.6
+     */
+    <TResult> AggregateIterable<TResult> aggregate(List<? extends Bson> pipeline, Class<TResult> resultClass);
+
+    /**
+     * Runs an aggregation framework pipeline on the database for pipeline stages
+     * that do not require an underlying collection, such as {@code $currentOp} and {@code $listLocalSessions}.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param pipeline the aggregation pipeline
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.10
+     * @mongodb.driver.manual reference/command/aggregate/#dbcmd.aggregate Aggregate Command
+     * @mongodb.server.release 3.6
+     */
+    AggregateIterable<Document> aggregate(ClientSession clientSession, List<? extends Bson> pipeline);
+
+    /**
+     * Runs an aggregation framework pipeline on the database for pipeline stages
+     * that do not require an underlying collection, such as {@code $currentOp} and {@code $listLocalSessions}.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param pipeline    the aggregation pipeline
+     * @param resultClass the class to decode each document into
+     * @param <TResult>   the target document type of the iterable.
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.10
+     * @mongodb.driver.manual reference/command/aggregate/#dbcmd.aggregate Aggregate Command
+     * @mongodb.server.release 3.6
+     */
+    <TResult> AggregateIterable<TResult> aggregate(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
+
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/FallbackMongoIterableFactory.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FallbackMongoIterableFactory.java
@@ -30,6 +30,7 @@ import com.mongodb.client.ListDatabasesIterable;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.model.changestream.ChangeStreamLevel;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.lang.Nullable;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -48,14 +49,27 @@ class FallbackMongoIterableFactory implements MongoIterableFactory {
     }
 
     @Override
-    public <TDocument, TResult>
-    AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession, final MongoNamespace namespace,
-                                           final Class<TDocument> documentClass, final Class<TResult> resultClass,
-                                           final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                                           final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
-                                           final List<? extends Bson> pipeline) {
+    public <TDocument, TResult> AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession,
+                                                                       final MongoNamespace namespace, final Class<TDocument> documentClass,
+                                                                       final Class<TResult> resultClass, final CodecRegistry codecRegistry,
+                                                                       final ReadPreference readPreference, final ReadConcern readConcern,
+                                                                       final WriteConcern writeConcern, final OperationExecutor executor,
+                                                                       final List<? extends Bson> pipeline,
+                                                                       final AggregationLevel aggregationLevel) {
         return new AggregateIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
-                readPreference, readConcern, writeConcern, executor, pipeline);
+                readPreference, readConcern, writeConcern, executor, pipeline, aggregationLevel);
+    }
+
+    @Override
+    public <TDocument, TResult> AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession,
+                                                                       final String databaseName, final Class<TDocument> documentClass,
+                                                                       final Class<TResult> resultClass, final CodecRegistry codecRegistry,
+                                                                       final ReadPreference readPreference, final ReadConcern readConcern,
+                                                                       final WriteConcern writeConcern, final OperationExecutor executor,
+                                                                       final List<? extends Bson> pipeline,
+                                                                       final AggregationLevel aggregationLevel) {
+        return new AggregateIterableImpl<TDocument, TResult>(clientSession, databaseName, documentClass, resultClass, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, aggregationLevel);
     }
 
     @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/Java8AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Java8AggregateIterableImpl.java
@@ -21,6 +21,7 @@ import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.lang.Nullable;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -29,12 +30,23 @@ import java.util.List;
 import java.util.function.Consumer;
 
 class Java8AggregateIterableImpl<TDocument, TResult> extends AggregateIterableImpl<TDocument, TResult> {
+
+    Java8AggregateIterableImpl(@Nullable final ClientSession clientSession, final String databaseName,
+                               final Class<TDocument> documentClass, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
+                               final ReadPreference readPreference, final ReadConcern readConcern, final WriteConcern writeConcern,
+                               final OperationExecutor executor, final List<? extends Bson> pipeline,
+                               final AggregationLevel aggregationLevel) {
+        super(clientSession, databaseName, documentClass, resultClass, codecRegistry, readPreference, readConcern, writeConcern, executor,
+                pipeline, aggregationLevel);
+    }
+
     Java8AggregateIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace,
                                final Class<TDocument> documentClass, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
                                final ReadPreference readPreference, final ReadConcern readConcern, final WriteConcern writeConcern,
-                               final OperationExecutor executor, final List<? extends Bson> pipeline) {
+                               final OperationExecutor executor, final List<? extends Bson> pipeline,
+                               final AggregationLevel aggregationLevel) {
         super(clientSession, namespace, documentClass, resultClass, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline);
+                pipeline, aggregationLevel);
     }
 
     @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/Java8MongoIterableFactory.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Java8MongoIterableFactory.java
@@ -30,6 +30,7 @@ import com.mongodb.client.ListDatabasesIterable;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.model.changestream.ChangeStreamLevel;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.lang.Nullable;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -49,14 +50,27 @@ class Java8MongoIterableFactory implements MongoIterableFactory {
     }
 
     @Override
-    public <TDocument, TResult>
-    AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession, final MongoNamespace namespace,
-                                           final Class<TDocument> documentClass, final Class<TResult> resultClass,
-                                           final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                                           final ReadConcern readConcern, final WriteConcern writeConcern,
-                                           final OperationExecutor executor, final List<? extends Bson> pipeline) {
+    public <TDocument, TResult> AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession,
+                                                                       final MongoNamespace namespace, final Class<TDocument> documentClass,
+                                                                       final Class<TResult> resultClass, final CodecRegistry codecRegistry,
+                                                                       final ReadPreference readPreference, final ReadConcern readConcern,
+                                                                       final WriteConcern writeConcern, final OperationExecutor executor,
+                                                                       final List<? extends Bson> pipeline,
+                                                                       final AggregationLevel aggregationLevel) {
         return new Java8AggregateIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
-                readPreference, readConcern, writeConcern, executor, pipeline);
+                readPreference, readConcern, writeConcern, executor, pipeline, aggregationLevel);
+    }
+
+    @Override
+    public <TDocument, TResult> AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession,
+                                                                       final String databaseName, final Class<TDocument> documentClass,
+                                                                       final Class<TResult> resultClass, final CodecRegistry codecRegistry,
+                                                                       final ReadPreference readPreference, final ReadConcern readConcern,
+                                                                       final WriteConcern writeConcern, final OperationExecutor executor,
+                                                                       final List<? extends Bson> pipeline,
+                                                                       final AggregationLevel aggregationLevel) {
+        return new Java8AggregateIterableImpl<TDocument, TResult>(clientSession, databaseName, documentClass, resultClass, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, aggregationLevel);
     }
 
     @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -36,6 +36,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
 import com.mongodb.client.model.CreateIndexOptions;
@@ -354,7 +355,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                                                          final List<? extends Bson> pipeline,
                                                                          final Class<TResult> resultClass) {
         return MongoIterables.aggregateOf(clientSession, namespace, documentClass, resultClass, codecRegistry,
-                readPreference, readConcern, writeConcern, executor, pipeline);
+                readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION);
     }
 
     @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
@@ -22,6 +22,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
+import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.ListCollectionsIterable;
@@ -33,6 +34,7 @@ import com.mongodb.client.model.CreateViewOptions;
 import com.mongodb.client.model.IndexOptionDefaults;
 import com.mongodb.client.model.ValidationOptions;
 import com.mongodb.client.model.changestream.ChangeStreamLevel;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.lang.Nullable;
 import com.mongodb.operation.CommandReadOperation;
 import com.mongodb.operation.CreateCollectionOperation;
@@ -364,6 +366,35 @@ public class MongoDatabaseImpl implements MongoDatabase {
                                                          final Class<TResult> resultClass) {
         notNull("clientSession", clientSession);
         return createChangeStreamIterable(clientSession, pipeline, resultClass);
+    }
+
+    @Override
+    public AggregateIterable<Document> aggregate(final List<? extends Bson> pipeline) {
+        return aggregate(pipeline, Document.class);
+    }
+
+    @Override
+    public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass) {
+        return createAggregateIterable(null, pipeline, resultClass);
+    }
+
+    @Override
+    public AggregateIterable<Document> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline) {
+        return aggregate(clientSession, pipeline, Document.class);
+    }
+
+    @Override
+    public <TResult> AggregateIterable<TResult> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline,
+                                                          final Class<TResult> resultClass) {
+        notNull("clientSession", clientSession);
+        return createAggregateIterable(clientSession, pipeline, resultClass);
+    }
+
+    private <TResult> AggregateIterable<TResult> createAggregateIterable(@Nullable final ClientSession clientSession,
+                                                                         final List<? extends Bson> pipeline,
+                                                                         final Class<TResult> resultClass) {
+        return MongoIterables.aggregateOf(clientSession, name, Document.class, resultClass, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE);
     }
 
     private <TResult> ChangeStreamIterable<TResult> createChangeStreamIterable(@Nullable final ClientSession clientSession,

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterableFactory.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterableFactory.java
@@ -30,6 +30,7 @@ import com.mongodb.client.ListDatabasesIterable;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.model.changestream.ChangeStreamLevel;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.lang.Nullable;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -46,7 +47,13 @@ interface MongoIterableFactory {
     AggregateIterable<TResult> aggregateOf(@Nullable ClientSession clientSession, MongoNamespace namespace, Class<TDocument> documentClass,
                                            Class<TResult> resultClass, CodecRegistry codecRegistry, ReadPreference readPreference,
                                            ReadConcern readConcern, WriteConcern writeConcern, OperationExecutor executor,
-                                           List<? extends Bson> pipeline);
+                                           List<? extends Bson> pipeline, AggregationLevel aggregationLevel);
+
+    <TDocument, TResult>
+    AggregateIterable<TResult> aggregateOf(@Nullable ClientSession clientSession, String databaseName, Class<TDocument> documentClass,
+                                           Class<TResult> resultClass, CodecRegistry codecRegistry, ReadPreference readPreference,
+                                           ReadConcern readConcern, WriteConcern writeConcern, OperationExecutor executor,
+                                           List<? extends Bson> pipeline, AggregationLevel aggregationLevel);
 
     <TResult>
     ChangeStreamIterable<TResult> changeStreamOf(@Nullable ClientSession clientSession, String databaseName, CodecRegistry codecRegistry,

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterables.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterables.java
@@ -30,6 +30,7 @@ import com.mongodb.client.ListDatabasesIterable;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.model.changestream.ChangeStreamLevel;
+import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.lang.Nullable;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -72,9 +73,19 @@ public final class MongoIterables {
                                            final Class<TDocument> documentClass, final Class<TResult> resultClass,
                                            final CodecRegistry codecRegistry, final ReadPreference readPreference,
                                            final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
-                                           final List<? extends Bson> pipeline) {
+                                           final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel) {
         return factory.aggregateOf(clientSession, namespace, documentClass, resultClass, codecRegistry,
-                readPreference, readConcern, writeConcern, executor, pipeline);
+                readPreference, readConcern, writeConcern, executor, pipeline, aggregationLevel);
+    }
+
+    public static <TDocument, TResult>
+    AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession, final String databaseName,
+                                           final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                                           final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                                           final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
+                                           final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel) {
+        return factory.aggregateOf(clientSession, databaseName, documentClass, resultClass, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, aggregationLevel);
     }
 
     public static <TResult>

--- a/driver-sync/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -22,10 +22,11 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.test.CollectionHelper;
 import com.mongodb.connection.ServerVersion;
-import com.mongodb.internal.connection.TestCommandListener;
 import com.mongodb.event.CommandEvent;
+import com.mongodb.internal.connection.TestCommandListener;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.codecs.DocumentCodec;
@@ -49,6 +50,7 @@ import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.isStandalone;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.CommandMonitoringTestHelper.getExpectedEvents;
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
 import static org.junit.Assume.assumeFalse;
 
@@ -171,9 +173,8 @@ public class CommandMonitoringTest {
             BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
             for (BsonValue test : testDocument.getArray("tests")) {
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
-                                      testDocument.getString("database_name").getValue(),
-                                      testDocument.getString("collection_name").getValue(),
-                                      testDocument.getArray("data"), test.asDocument()});
+                        testDocument.getString("database_name", new BsonString(getDefaultDatabaseName())).getValue(),
+                        testDocument.getString("collection_name").getValue(), testDocument.getArray("data"), test.asDocument()});
             }
         }
         return data;

--- a/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
@@ -18,6 +18,7 @@ package com.mongodb.client;
 
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.mongodb.ClusterFixture.getDefaultDatabaseName;
 import static com.mongodb.ClusterFixture.serverVersionGreaterThan;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static org.junit.Assert.assertEquals;
@@ -41,14 +43,17 @@ import static org.junit.Assert.assertEquals;
 public class CrudTest extends DatabaseTestCase {
     private final String filename;
     private final String description;
+    private final String databaseName;
     private final BsonArray data;
     private final BsonDocument definition;
     private MongoCollection<BsonDocument> collection;
     private JsonPoweredCrudTestHelper helper;
 
-    public CrudTest(final String filename, final String description, final BsonArray data, final BsonDocument definition) {
+    public CrudTest(final String filename, final String description, final String databaseName, final BsonArray data,
+                    final BsonDocument definition) {
         this.filename = filename;
         this.description = description;
+        this.databaseName = databaseName;
         this.data = data;
         this.definition = definition;
     }
@@ -63,6 +68,7 @@ public class CrudTest extends DatabaseTestCase {
             }
             getCollectionHelper().insertDocuments(documents);
         }
+        database = client.getDatabase(databaseName);
         collection = database.getCollection(getClass().getName(), BsonDocument.class);
         helper = new JsonPoweredCrudTestHelper(description, database, collection);
     }
@@ -70,7 +76,6 @@ public class CrudTest extends DatabaseTestCase {
     @Test
     public void shouldPassAllOutcomes() {
         BsonDocument expectedOutcome = definition.getDocument("outcome");
-
         BsonDocument outcome = helper.getOperationResults(definition.getDocument("operation"));
 
         if (expectedOutcome.containsKey("error")) {
@@ -114,6 +119,7 @@ public class CrudTest extends DatabaseTestCase {
             }
             for (BsonValue test : testDocument.getArray("tests")) {
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
+                        testDocument.getString("database_name", new BsonString(getDefaultDatabaseName())).getValue(),
                         testDocument.getArray("data"), test.asDocument()});
             }
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesTest.java
@@ -68,10 +68,11 @@ public class RetryableWritesTest {
     private MongoCollection<BsonDocument> collection;
     private JsonPoweredCrudTestHelper helper;
 
-    public RetryableWritesTest(final String filename, final String description, final BsonArray data, final BsonDocument definition) {
+    public RetryableWritesTest(final String filename, final String description, final String databaseName, final BsonArray data,
+                               final BsonDocument definition) {
         this.filename = filename;
         this.description = description;
-        this.databaseName = getDefaultDatabaseName();
+        this.databaseName = databaseName;
         this.collectionName = filename.substring(0, filename.lastIndexOf("."));
         this.data = data;
         this.definition = definition;
@@ -182,6 +183,7 @@ public class RetryableWritesTest {
             }
             for (BsonValue test : testDocument.getArray("tests")) {
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
+                        testDocument.getString("database_name", new BsonString(getDefaultDatabaseName())).getValue(),
                         testDocument.getArray("data"), test.asDocument()});
             }
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
@@ -94,10 +94,11 @@ public class TransactionsTest {
     public static void afterClass() {
     }
 
-    public TransactionsTest(final String filename, final String description, final BsonArray data, final BsonDocument definition) {
+    public TransactionsTest(final String filename, final String description, final String databaseName, final BsonArray data,
+                            final BsonDocument definition) {
         this.filename = filename;
         this.description = description;
-        this.databaseName = getDefaultDatabaseName();
+        this.databaseName = databaseName;
         this.data = data;
         this.definition = definition;
         this.commandListener = new TestCommandListener();
@@ -411,6 +412,7 @@ public class TransactionsTest {
             BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
             for (BsonValue test : testDocument.getArray("tests")) {
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
+                        testDocument.getString("database_name", new BsonString(getDefaultDatabaseName())).getValue(),
                         testDocument.getArray("data"), test.asDocument()});
             }
         }

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/Java8MongoIterablesSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/Java8MongoIterablesSpecification.groovy
@@ -22,6 +22,7 @@ import com.mongodb.MongoInternalException
 import com.mongodb.MongoNamespace
 import com.mongodb.ReadConcern
 import com.mongodb.WriteConcern
+import com.mongodb.client.model.AggregationLevel
 import com.mongodb.client.model.changestream.ChangeStreamLevel
 import com.mongodb.operation.BatchCursor
 import org.bson.BsonBoolean
@@ -123,7 +124,7 @@ class Java8MongoIterablesSpecification extends Specification {
                 },
                 { executor ->
                     new Java8AggregateIterableImpl(null, namespace, Document, Document, codecRegistry,
-                            readPreference, readConcern, writeConcern, executor, pipeline)
+                            readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION)
                 },
                 { executor ->
                     new Java8ChangeStreamIterableImpl<>(null, namespace, codecRegistry, readPreference, readConcern, executor, pipeline,

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -34,6 +34,7 @@ import com.mongodb.bulk.UpdateRequest
 import com.mongodb.client.ClientSession
 import com.mongodb.client.ImmutableDocument
 import com.mongodb.client.ImmutableDocumentCodecProvider
+import com.mongodb.client.model.AggregationLevel
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CountOptions
@@ -388,14 +389,14 @@ class MongoCollectionSpecification extends Specification {
 
         then:
         expect aggregateIterable, isTheSameAs(MongoIterables.aggregateOf(session, namespace, Document, Document, codecRegistry,
-                readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)]))
+                readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)], AggregationLevel.COLLECTION))
 
         when:
         aggregateIterable = execute(aggregateMethod, session, [new Document('$match', 1)], BsonDocument)
 
         then:
         expect aggregateIterable, isTheSameAs(MongoIterables.aggregateOf(session, namespace, Document, BsonDocument, codecRegistry,
-                readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)]))
+                readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)], AggregationLevel.COLLECTION))
 
         where:
         session << [null, Stub(ClientSession)]

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoIterablesSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoIterablesSpecification.groovy
@@ -21,6 +21,7 @@ import com.mongodb.MongoNamespace
 import com.mongodb.ReadConcern
 import com.mongodb.WriteConcern
 import com.mongodb.client.ClientSession
+import com.mongodb.client.model.AggregationLevel
 import com.mongodb.client.model.changestream.ChangeStreamLevel
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
@@ -55,12 +56,22 @@ class MongoIterablesSpecification extends Specification {
                 BsonDocument, codecRegistry, readPreference, readConcern, executor, filter))
 
         when:
-        def aggregateIterable = MongoIterables.aggregateOf(clientSession, namespace, Document, BsonDocument, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline)
+        def aggregateIterable = MongoIterables.aggregateOf(clientSession, namespace, Document, BsonDocument, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION)
 
         then:
-        expect aggregateIterable, isTheSameAs(new Java8AggregateIterableImpl<Document, BsonDocument>(clientSession, namespace, Document,
-                BsonDocument, codecRegistry, readPreference, readConcern, writeConcern, executor, pipeline))
+        expect aggregateIterable, isTheSameAs(new Java8AggregateIterableImpl<Document, BsonDocument>(clientSession, namespace,
+                Document, BsonDocument, codecRegistry, readPreference, readConcern, writeConcern, executor, pipeline,
+                AggregationLevel.COLLECTION))
+
+        when:
+        aggregateIterable = MongoIterables.aggregateOf(clientSession, namespace.databaseName, Document, BsonDocument, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE)
+
+        then:
+        expect aggregateIterable, isTheSameAs(new Java8AggregateIterableImpl<Document, BsonDocument>(clientSession, namespace.databaseName,
+                Document, BsonDocument, codecRegistry, readPreference, readConcern, writeConcern, executor, pipeline,
+                AggregationLevel.DATABASE))
 
         when:
         def changeStreamIterable = MongoIterables.changeStreamOf(clientSession, namespace, codecRegistry,
@@ -128,12 +139,22 @@ class MongoIterablesSpecification extends Specification {
                 BsonDocument, codecRegistry, readPreference, readConcern, executor, filter))
 
         when:
-        def aggregateIterable = MongoIterables.aggregateOf(clientSession, namespace, Document, BsonDocument, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline)
+        def aggregateIterable = MongoIterables.aggregateOf(clientSession, namespace, Document, BsonDocument, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION)
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<Document, BsonDocument>(clientSession, namespace, Document,
-                BsonDocument, codecRegistry, readPreference, readConcern, writeConcern, executor, pipeline))
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<Document, BsonDocument>(clientSession, namespace,
+                Document, BsonDocument, codecRegistry, readPreference, readConcern, writeConcern, executor, pipeline,
+                AggregationLevel.COLLECTION))
+
+        when:
+        aggregateIterable = MongoIterables.aggregateOf(clientSession, namespace.databaseName, Document, BsonDocument, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE)
+
+        then:
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<Document, BsonDocument>(clientSession, namespace.databaseName,
+                Document, BsonDocument, codecRegistry, readPreference, readConcern, writeConcern, executor, pipeline,
+                AggregationLevel.DATABASE))
 
         when:
         def changeStreamIterable = MongoIterables.changeStreamOf(clientSession, namespace, codecRegistry,


### PR DESCRIPTION
JAVA-3116

Took the same approach as the watch method and introduced a new enum to describe the level at which the operation takes place.

This includes the updated json that was approved in SPEC-1184.

Patch Build: https://evergreen.mongodb.com/version/5c334fbb2a60ed24ead2f23a