### PR TITLE
Added more driver name information

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoClients.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClients.java
@@ -189,9 +189,11 @@ public final class MongoClients {
     private static Cluster createCluster(final MongoClientSettings settings, @Nullable final MongoDriverInformation mongoDriverInformation,
                                          final StreamFactory streamFactory, final StreamFactory heartbeatStreamFactory) {
         notNull("settings", settings);
+        MongoDriverInformation.Builder builder = mongoDriverInformation == null ? MongoDriverInformation.builder()
+                : MongoDriverInformation.builder(mongoDriverInformation);
         return new DefaultClusterFactory().createCluster(settings.getClusterSettings(), settings.getServerSettings(),
                 settings.getConnectionPoolSettings(), streamFactory, heartbeatStreamFactory, settings.getCredentialList(),
-                getCommandListener(settings.getCommandListeners()), settings.getApplicationName(), mongoDriverInformation,
+                getCommandListener(settings.getCommandListeners()), settings.getApplicationName(), builder.driverName("async").build(),
                 settings.getCompressorList());
     }
 

--- a/driver-async/src/main/com/mongodb/async/client/NettyMongoClients.java
+++ b/driver-async/src/main/com/mongodb/async/client/NettyMongoClients.java
@@ -34,7 +34,9 @@ final class NettyMongoClients {
         StreamFactory streamFactory = new NettyStreamFactory(settings.getSocketSettings(), settings.getSslSettings(), eventLoopGroup);
         StreamFactory heartbeatStreamFactory = new NettyStreamFactory(settings.getHeartbeatSocketSettings(), settings.getSslSettings(),
                                                                              eventLoopGroup);
-        return MongoClients.createMongoClient(settings, mongoDriverInformation, streamFactory, heartbeatStreamFactory,
+        MongoDriverInformation.Builder builder = mongoDriverInformation == null ? MongoDriverInformation.builder()
+                : MongoDriverInformation.builder(mongoDriverInformation);
+        return MongoClients.createMongoClient(settings, builder.driverName("netty").build(), streamFactory, heartbeatStreamFactory,
                 new Closeable() {
                     @Override
                     public void close() {

--- a/driver-legacy/src/main/com/mongodb/Mongo.java
+++ b/driver-legacy/src/main/com/mongodb/Mongo.java
@@ -746,6 +746,8 @@ public class Mongo {
 
     private static Cluster createCluster(final ClusterSettings clusterSettings, final List<MongoCredential> credentialsList,
                                          final MongoClientOptions options, @Nullable final MongoDriverInformation mongoDriverInformation) {
+        MongoDriverInformation.Builder builder = mongoDriverInformation == null ? MongoDriverInformation.builder()
+                    : MongoDriverInformation.builder(mongoDriverInformation);
         return new DefaultClusterFactory().createCluster(clusterSettings,
                 options.getServerSettings(),
                 options.getConnectionPoolSettings(),
@@ -758,7 +760,7 @@ public class Mongo {
                 credentialsList,
                 getCommandListener(options.getCommandListeners()),
                 options.getApplicationName(),
-                mongoDriverInformation,
+                builder.driverName("legacy").build(),
                 options.getCompressorList());
     }
 

--- a/driver-sync/src/main/com/mongodb/client/MongoClients.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoClients.java
@@ -109,7 +109,9 @@ public final class MongoClients {
      * @return the client
      */
     public static MongoClient create(final MongoClientSettings settings, @Nullable final MongoDriverInformation mongoDriverInformation) {
-        return new MongoClientImpl(settings, mongoDriverInformation);
+        MongoDriverInformation.Builder builder = mongoDriverInformation == null ? MongoDriverInformation.builder()
+                : MongoDriverInformation.builder(mongoDriverInformation);
+        return new MongoClientImpl(settings, builder.driverName("sync").build());
     }
 
     private MongoClients() {


### PR DESCRIPTION
Previously, all drivers (legacy, sync, async) would just report the driver name "mongo-java-driver".
This update appends extra information to the driver name:

* legacy    : mongo-java-driver|legacy
* sync      : mongo-java-driver|sync
* async     : mongo-java-driver|async
* netty     : mongo-java-driver|async|netty

JAVA-3131