### PR TITLE
Reenabled android tests and moved ExtendedAsynchronousByteChannel

### DIFF
--- a/.evergreen/run-embedded-tests-android.sh
+++ b/.evergreen/run-embedded-tests-android.sh
@@ -7,83 +7,83 @@
 #            Main Program                  #
 ############################################
 
-#SDK_HOME=$PWD/.android
-#if [ ! -e  $SDK_HOME ]; then
-#    echo "Installing ANDROID SDK"
-#    DOWNLOAD_LOGS=${SDK_HOME}/download_logs
-#    mkdir -p $SDK_HOME
-#    mkdir -p $DOWNLOAD_LOGS
-#    (
-#        cd $SDK_HOME
-#        export JAVA_HOME="/opt/java/jdk8"
-#
-#        export ANDROID_HOME=${SDK_HOME}
-#        export ANDROID_SDK_ROOT=${SDK_HOME}
-#        export ANDROID_SDK_HOME=${SDK_HOME}
-#
-#        SDK_PACKAGE=sdk-tools-linux-4333796.zip
-#        curl -O -s https://dl.google.com/android/repository/$SDK_PACKAGE
-#        unzip -o -qq $SDK_PACKAGE
-#        yes | $SDK_HOME/tools/bin/sdkmanager --channel=0 \
-#            "platforms;android-28"  \
-#            "emulator" \
-#            "patcher;v4" \
-#            "platform-tools"  \
-#            "build-tools;28.0.0" \
-#            "system-images;android-21;google_apis;x86_64"
-#
-#        $SDK_HOME/tools/bin/sdkmanager --update
-#        PLATFORM_TOOLS=platform-tools-latest-linux.zip
-#        curl -O -s https://dl.google.com/android/repository/$PLATFORM_TOOLS
-#        unzip -o -qq $PLATFORM_TOOLS
-#    ) &> $DOWNLOAD_LOGS/download.log
-#fi
-#
-#(
-#    export JAVA_HOME="/opt/java/jdk8"
-#
-#    export ANDROID_HOME=${SDK_HOME}
-#    export ANDROID_SDK_ROOT=${SDK_HOME}
-#    export ANDROID_SDK_HOME=${SDK_HOME}
-#
-#    echo no | $SDK_HOME/tools/bin/avdmanager create avd -n embeddedTest_x86_64 -c 1000M -k "system-images;android-21;google_apis;x86_64" -f
-#    $SDK_HOME/tools/emulator -avd embeddedTest_x86_64 -no-audio -no-window -no-snapshot -wipe-data -no-accel -gpu off &
-#    $SDK_HOME/platform-tools/adb wait-for-device
-#
-#    # Belt and braces waiting for the device
-#    bootanim=""
-#    failcounter=0
-#    timeout_in_sec=360
-#
-#    until [[ "$bootanim" =~ "stopped" ]]; do
-#      bootanim=`$SDK_HOME/platform-tools/adb -e shell getprop init.svc.bootanim 2>&1 &`
-#      if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
-#        || "$bootanim" =~ "running" ]]; then
-#        let "failcounter += 1"
-#        if [[ "$failcounter" -gt timeout_in_sec ]]; then
-#          echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
-#          exit 1
-#        elif (( "$failcounter" % 10 )); then
-#           echo "Waiting for emulator to start"
-#        fi
-#      fi
-#      sleep 5
-#    done
-#    echo "Emulator is ready"
-#)
-#
-#export JAVA_HOME="/opt/java/jdk9"
-#export ANDROID_HOME=${SDK_HOME}
-#
-#function shutdownEmulators {
-#  retVal=$?
-#  $SDK_HOME/platform-tools/adb devices | grep emulator | cut -f1 | while read line; do $SDK_HOME/platform-tools/adb -s $line emu kill; done;
-#  exit $retVal
-#}
-#
-#trap shutdownEmulators EXIT
-#
-#echo "Running android tests"
-#./gradlew -version
-#./gradlew --stacktrace --info :driver-embedded-android:connectedAndroidTest -DANDROID_HOME=$SDK_HOME
-#
+SDK_HOME=$PWD/.android
+if [ ! -e  $SDK_HOME ]; then
+    echo "Installing ANDROID SDK"
+    DOWNLOAD_LOGS=${SDK_HOME}/download_logs
+    mkdir -p $SDK_HOME
+    mkdir -p $DOWNLOAD_LOGS
+    (
+        cd $SDK_HOME
+        export JAVA_HOME="/opt/java/jdk8"
+
+        export ANDROID_HOME=${SDK_HOME}
+        export ANDROID_SDK_ROOT=${SDK_HOME}
+        export ANDROID_SDK_HOME=${SDK_HOME}
+
+        SDK_PACKAGE=sdk-tools-linux-4333796.zip
+        curl -O -s https://dl.google.com/android/repository/$SDK_PACKAGE
+        unzip -o -qq $SDK_PACKAGE
+        yes | $SDK_HOME/tools/bin/sdkmanager --channel=0 \
+            "platforms;android-28"  \
+            "emulator" \
+            "patcher;v4" \
+            "platform-tools"  \
+            "build-tools;28.0.0" \
+            "system-images;android-21;google_apis;x86_64"
+
+        $SDK_HOME/tools/bin/sdkmanager --update
+        PLATFORM_TOOLS=platform-tools-latest-linux.zip
+        curl -O -s https://dl.google.com/android/repository/$PLATFORM_TOOLS
+        unzip -o -qq $PLATFORM_TOOLS
+    ) &> $DOWNLOAD_LOGS/download.log
+fi
+
+(
+    export JAVA_HOME="/opt/java/jdk8"
+
+    export ANDROID_HOME=${SDK_HOME}
+    export ANDROID_SDK_ROOT=${SDK_HOME}
+    export ANDROID_SDK_HOME=${SDK_HOME}
+
+    echo no | $SDK_HOME/tools/bin/avdmanager create avd -n embeddedTest_x86_64 -c 1000M -k "system-images;android-21;google_apis;x86_64" -f
+    $SDK_HOME/tools/emulator -avd embeddedTest_x86_64 -no-audio -no-window -no-snapshot -wipe-data -no-accel -gpu off &
+    $SDK_HOME/platform-tools/adb wait-for-device
+
+    # Belt and braces waiting for the device
+    bootanim=""
+    failcounter=0
+    timeout_in_sec=360
+
+    until [[ "$bootanim" =~ "stopped" ]]; do
+      bootanim=`$SDK_HOME/platform-tools/adb -e shell getprop init.svc.bootanim 2>&1 &`
+      if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+        || "$bootanim" =~ "running" ]]; then
+        let "failcounter += 1"
+        if [[ "$failcounter" -gt timeout_in_sec ]]; then
+          echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+          exit 1
+        elif (( "$failcounter" % 10 )); then
+           echo "Waiting for emulator to start"
+        fi
+      fi
+      sleep 5
+    done
+    echo "Emulator is ready"
+)
+
+export JAVA_HOME="/opt/java/jdk9"
+export ANDROID_HOME=${SDK_HOME}
+
+function shutdownEmulators {
+  retVal=$?
+  $SDK_HOME/platform-tools/adb devices | grep emulator | cut -f1 | while read line; do $SDK_HOME/platform-tools/adb -s $line emu kill; done;
+  exit $retVal
+}
+
+trap shutdownEmulators EXIT
+
+echo "Running android tests"
+./gradlew -version
+./gradlew --stacktrace --info :driver-embedded-android:connectedAndroidTest -DANDROID_HOME=$SDK_HOME
+

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
@@ -26,7 +26,6 @@ import com.mongodb.connection.AsyncCompletionHandler;
 import com.mongodb.connection.BufferProvider;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.Stream;
-import com.mongodb.internal.connection.tlschannel.async.ExtendedAsynchronousByteChannel;
 import org.bson.ByteBuf;
 
 import java.io.IOException;

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
@@ -23,7 +23,6 @@ import com.mongodb.connection.AsyncCompletionHandler;
 import com.mongodb.connection.BufferProvider;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.Stream;
-import com.mongodb.internal.connection.tlschannel.async.ExtendedAsynchronousByteChannel;
 
 import java.io.IOException;
 import java.net.SocketAddress;

--- a/driver-core/src/main/com/mongodb/internal/connection/ExtendedAsynchronousByteChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ExtendedAsynchronousByteChannel.java
@@ -17,7 +17,7 @@
  * https://github.com/marianobarrios/tls-channel
  */
 
-package com.mongodb.internal.connection.tlschannel.async;
+package com.mongodb.internal.connection;
 
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousByteChannel;

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannel.java
@@ -19,6 +19,7 @@
 
 package com.mongodb.internal.connection.tlschannel.async;
 
+import com.mongodb.internal.connection.ExtendedAsynchronousByteChannel;
 import com.mongodb.internal.connection.tlschannel.TlsChannel;
 import com.mongodb.internal.connection.tlschannel.impl.ByteBufferSet;
 

--- a/driver-embedded-android/build.gradle
+++ b/driver-embedded-android/build.gradle
@@ -64,6 +64,9 @@ android {
         release {
             minifyEnabled false
         }
+        debug {
+            minifyEnabled true
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Moved ExtendedAsynchronousByteChannel to com.mongodb.internal.connection
The dex'ing process didn't like it being referenced in a higher package
when the code was split across dex files.

JAVA-3142