### PR TITLE
Fix javadoc search js

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -42,7 +42,7 @@ allprojects {
             options {
                 author = true
                 version = true
-                links 'https://docs.oracle.com/javase/9/docs/api/'
+                links 'https://docs.oracle.com/en/java/javase/11/docs/api/'
                 tagletPath single(utilProject.sourceSets.main.output.classesDirs)
                 taglets 'ManualTaglet'
                 taglets 'DochubTaglet'
@@ -53,26 +53,43 @@ allprojects {
                 addBooleanOption("html5", true)
                 addBooleanOption("-allow-script-in-comments", true)
                 header = '''
-            | <script type="text/javascript">
-            | <!-- Set the location hash in the classFrame -->
-            | try {
-            |   locationHash = top.location.hash;
-            |   if (window.name == "classFrame" && locationHash != "") {
-            |     window.location.hash = locationHash;
-            |   }
-            | } catch (error) {}
-            | <!-- GA Tracking code -->
-            | if (window.name == "" || window.name == "classFrame") {
-            |     var _elqQ = _elqQ || [];
-            |     _elqQ.push(["elqSetSiteId", "413370795"]);
-            |     _elqQ.push(["elqTrackPageView"]);
-            |     (function () {
-            |     function async_load() { var s = document.createElement("script"); s.type = "text/javascript"; s.async = true; s.src = "//img03.en25.com/i/elqCfg.min.js"; var x = document.getElementsByTagName("script")[0]; x.parentNode.insertBefore(s, x); }
-            |     if (window.addEventListener) window.addEventListener("DOMContentLoaded", async_load, false);
-            |     else if (window.attachEvent) window.attachEvent("onload", async_load);
-            |     })();
-            | }
-            | </script>'''.stripMargin()
+                    | <script type="text/javascript">
+                    | function setLocationHash() {
+                    |   try {
+                    |     locationHash = top.location.hash;
+                    |     if (window.name == "classFrame" && locationHash != "") {
+                    |       window.location.hash = locationHash;
+                    |     }
+                    |   } catch (error) {}
+                    | };
+                    | function setGATrackingCode() {
+                    |   if (window.name == "" || window.name == "classFrame") {
+                    |       var _elqQ = _elqQ || [];
+                    |       _elqQ.push(["elqSetSiteId", "413370795"]);
+                    |       _elqQ.push(["elqTrackPageView"]);
+                    |       (function () {
+                    |       function async_load() { var s = document.createElement("script"); s.type = "text/javascript"; s.async = true; s.src = "//img03.en25.com/i/elqCfg.min.js"; var x = document.getElementsByTagName("script")[0]; x.parentNode.insertBefore(s, x); }
+                    |       if (window.addEventListener) window.addEventListener("DOMContentLoaded", async_load, false);
+                    |       else if (window.attachEvent) window.attachEvent("onload", async_load);
+                    |       })();
+                    |   }
+                    | };
+                    | function setSearchUrlPrefix() {
+                    |   if (typeof getURLPrefix === 'function') {
+                    |     var getURLPrefixOri = getURLPrefix;
+                    |     getURLPrefix = function(ui) {
+                    |       var urlPrefix = getURLPrefixOri(ui);
+                    |       return (urlPrefix && urlPrefix != "undefined/"  ? urlPrefix: "");
+                    |     };
+                    |   } else {
+                    |     window.setTimeout(setSearchUrlPrefix, 500 );
+                    |   }
+                    | };
+                    | setLocationHash();
+                    | setGATrackingCode();
+                    | setSearchUrlPrefix();
+                    |
+                    | </script>'''.stripMargin()
             }
         }
     }


### PR DESCRIPTION
Cannot use --no-module-directories as that would break any links
to the main java documentation

JAVA-3329