### PR TITLE
Test improvements to reduce race conditions.

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -487,10 +487,14 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         when:
         expected = insertDocuments(helper, [5, 6])
         helper.killCursor(helper.getNamespace(), cursor.getWrapped().getServerCursor())
-        sleep(5000)
+
+        def results = nextAndClean(cursor, async)
+        if (results.size() < expected.size()) {
+            results.addAll(nextAndClean(cursor, async))
+        }
 
         then:
-        nextAndClean(cursor, async) == expected
+        results == expected
 
         cleanup:
         cursor?.close()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -487,6 +487,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         when:
         expected = insertDocuments(helper, [5, 6])
         helper.killCursor(helper.getNamespace(), cursor.getWrapped().getServerCursor())
+        sleep(2000)
 
         then:
         nextAndClean(cursor, async) == expected

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -487,7 +487,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         when:
         expected = insertDocuments(helper, [5, 6])
         helper.killCursor(helper.getNamespace(), cursor.getWrapped().getServerCursor())
-        sleep(2000)
+        sleep(5000)
 
         then:
         nextAndClean(cursor, async) == expected

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
@@ -166,7 +166,7 @@ public class TestSubscriber<T> implements Subscriber<T> {
      * @throws AssertionError if the sequence of items observed does not exactly match {@code items}
      */
     public void assertReceivedOnNext(final List<T> items) {
-        if (tryMultipleTimes(4, () -> getOnNextEvents().size() != items.size())) {
+        if (tryMultipleTimes(2, () -> getOnNextEvents().size() != items.size())) {
             throw new AssertionError("Number of items does not match. Provided: " + items.size() + "  Actual: " + getOnNextEvents().size());
         }
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
@@ -166,7 +166,7 @@ public class TestSubscriber<T> implements Subscriber<T> {
      * @throws AssertionError if the sequence of items observed does not exactly match {@code items}
      */
     public void assertReceivedOnNext(final List<T> items) {
-        if (tryMultipleTimes(4, () -> getOnNextEvents().size() != items.size() )) {
+        if (tryMultipleTimes(4, () -> getOnNextEvents().size() != items.size())) {
             throw new AssertionError("Number of items does not match. Provided: " + items.size() + "  Actual: " + getOnNextEvents().size());
         }
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
@@ -22,6 +22,7 @@ import org.reactivestreams.Subscription;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
 
 public class TestSubscriber<T> implements Subscriber<T> {
 
@@ -165,7 +166,7 @@ public class TestSubscriber<T> implements Subscriber<T> {
      * @throws AssertionError if the sequence of items observed does not exactly match {@code items}
      */
     public void assertReceivedOnNext(final List<T> items) {
-        if (getOnNextEvents().size() != items.size()) {
+        if (tryMultipleTimes(4, () -> getOnNextEvents().size() != items.size() )) {
             throw new AssertionError("Number of items does not match. Provided: " + items.size() + "  Actual: " + getOnNextEvents().size());
         }
 
@@ -182,6 +183,22 @@ public class TestSubscriber<T> implements Subscriber<T> {
 
             }
         }
+    }
+
+    private boolean tryMultipleTimes(final int noTimes, final Supplier<Boolean> test) {
+        int counter = noTimes;
+        while (counter > 0){
+            if (test.get()) {
+                return true;
+            }
+            counter--;
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                return false;
+            }
+        }
+        return false;
     }
 
     /**

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SingleResultSubscriber.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SingleResultSubscriber.java
@@ -33,7 +33,7 @@ class SingleResultSubscriber<T> implements Subscriber<T> {
     @Nullable
     T get() {
         try {
-            if (!latch.await(5, TimeUnit.SECONDS)) {
+            if (!latch.await(30, TimeUnit.SECONDS)) {
                 throw new MongoTimeoutException("Timeout waiting for single result");
             }
             if (exception != null) {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
@@ -64,7 +64,7 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
             }
         });
         try {
-            if (!latch.await(5, TimeUnit.SECONDS)) {
+            if (!latch.await(30, TimeUnit.SECONDS)) {
                 throw new MongoTimeoutException("Timeout waiting for subscription");
             }
         } catch (InterruptedException e) {
@@ -84,9 +84,9 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
             return true;
         }
         try {
-            Object first = results.pollFirst(5, TimeUnit.SECONDS);
+            Object first = results.pollFirst(30, TimeUnit.SECONDS);
             if (first == null) {
-                throw new MongoTimeoutException("Time out!!!");
+                throw new MongoTimeoutException("Time out waiting for result from cursor");
             } else if (first instanceof Throwable) {
                 throw translateError((Throwable) first);
             } else if (first == COMPLETED) {

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncMongoCursor.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncMongoCursor.scala
@@ -51,7 +51,7 @@ case class SyncMongoCursor[T](val observable: Observable[T]) extends MongoCursor
     }
   })
   try {
-    if (!latch.await(5, TimeUnit.SECONDS)) {
+    if (!latch.await(30, TimeUnit.SECONDS)) {
       throw new MongoTimeoutException("Timeout waiting for subscription")
     }
   } catch {
@@ -68,7 +68,7 @@ case class SyncMongoCursor[T](val observable: Observable[T]) extends MongoCursor
     if (nextResult.isDefined) {
       return true
     }
-    val first = results.pollFirst(5, TimeUnit.SECONDS)
+    val first = results.pollFirst(30, TimeUnit.SECONDS)
     first match {
       case n if n == null                 => throw new MongoTimeoutException("Time out!!!")
       case t if t.isInstanceOf[Throwable] => throw translateError(t.asInstanceOf[Throwable])


### PR DESCRIPTION
- Added a sleep after killing a cursor for the ChangeStreamOperationSpecification.
- Updated timeouts for the Sync Adapters to 30 secs to help cope with replicaset changes.
- Added a tryMultipleTimes method to allow multiple testing of a condition before failing.

JAVA-3535