### PR TITLE
Add native-image.properties

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -27,6 +27,9 @@ ext {
     pomName = 'MongoDB Java Driver Core'
 }
 
+// Add native-image.properties
+sourceSets.main.resources.srcDirs = ['src/resources']
+
 dependencies {
     compile project(':bson')
 

--- a/driver-core/src/resources/META-INF/native-image/org.mongodb/mongodb-driver-core/native-image.properties
+++ b/driver-core/src/resources/META-INF/native-image/org.mongodb/mongodb-driver-core/native-image.properties
@@ -1,0 +1,16 @@
+#
+# Copyright 2008-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+Args = --initialize-at-run-time=com.mongodb.UnixServerAddress,com.mongodb.internal.connection.SnappyCompressor


### PR DESCRIPTION
To support GraalVM, defer the initialization of classes
com.mongodb.UnixServerAddress and
com.mongodb.internal.connection.SnappyCompressor to the run-time

JAVA-3537