### PR TITLE
Fix AsynchronousTlsChannelGroup processPendingInterests

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannelGroup.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannelGroup.java
@@ -442,7 +442,12 @@ public class AsynchronousTlsChannelGroup {
             RegisteredSocket socket = (RegisteredSocket) key.attachment();
             int pending = socket.pendingOps.getAndSet(0);
             if (pending != 0) {
-                key.interestOps(key.interestOps() | pending);
+                try {
+                    key.interestOps(key.interestOps() | pending);
+                } catch (CancelledKeyException e) {
+                    // can happen when channels are closed with pending operations
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Handle when channels are closed with pending operations when
processing pending interests.

JAVA-3579