### PR TITLE
J3576

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -157,6 +157,23 @@ functions:
         content_type: ${content_type|text/plain}
         display_name: "orchestration.log"
 
+  "upload working dir logs":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          find ${PROJECT_DIRECTORY} -name \*.log | xargs tar czf working-dir-logs.tar.gz
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: working-dir-logs.tar.gz
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-working-dir-logs.tar.gz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/x-gzip}
+        display_name: "working-dir-logs.tar.gz"
+
   "upload working dir":
     - command: archive.targz_pack
       params:
@@ -394,6 +411,7 @@ post:
   # Removed, causing timeouts
   # - func: "upload working dir"
   - func: "upload mo artifacts"
+  - func: "upload working dir logs"
   - func: "upload test results"
   - func: "cleanup"
 

--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ configure(javaCodeCheckedProjects) {
     /* Testing */
     tasks.withType(Test) {
         maxHeapSize = "3g"
+        jvmArgs = ['-XX:-UseCompressedOops']
         maxParallelForks = 1
 
         systemProperties(


### PR DESCRIPTION
This has consistently passed over the last few runs:
https://evergreen.mongodb.com/version/5e18a6dd9ccd4e34f84e115a