### PR TITLE
Build: OSGI update for com.mongodb.crypt.capi

### DIFF
--- a/bson/build.gradle
+++ b/bson/build.gradle
@@ -22,4 +22,4 @@ ext {
     pomURL = 'https://bsonspec.org'
 }
 
-jar.manifest.attributes['Import-Package'] = 'org.slf4j;resolution:=optional'
+jar.manifest.attributes['Import-Package'] = 'org.slf4j.*;resolution:=optional'

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -58,19 +58,17 @@ afterEvaluate {
     jar.manifest.attributes['Import-Package'] = [
         'org.bson.*', // unfortunate that this is necessary, but if it's left out then it's not included
         'javax.crypto.*',
-        'javax.crypto.spec.*',
         'javax.management.*',
         'javax.naming.*',
-        'javax.naming.directory.*',
         'javax.net.*',
-        'javax.net.ssl.*',
         'javax.security.sasl.*',
         'javax.security.auth.callback.*',
         'org.ietf.jgss.*',
         'io.netty.*;resolution:=optional',
         'org.xerial.snappy.*;resolution:=optional',
         'com.github.luben.zstd.*;resolution:=optional',
-        'org.slf4j;resolution:=optional',
-        'jnr.unixsocket;resolution:=optional'
+        'org.slf4j.*;resolution:=optional',
+        'jnr.unixsocket.*;resolution:=optional',
+        'com.mongodb.crypt.capi.*;resolution:=optional'
     ].join(',')
 }


### PR DESCRIPTION
Also minor fix for bnd package warning

JAVA-3575


```
$ cat META-INF/MANIFEST.MF 
Manifest-Version: 1.0
Automatic-Module-Name: org.mongodb.driver.core
Bnd-LastModified: 1579084184178
Build-Version: 3.12.0-210-g17351abdf-dirty
Bundle-ManifestVersion: 2
Bundle-Name: mongodb-driver-core
Bundle-SymbolicName: org.mongodb.driver-core
Bundle-Version: 4.0.0.SNAPSHOT
Created-By: 11.0.5 (Private Build)
Export-Package: com.mongodb;uses:="com.mongodb.annotations,com.mongodb
 .bulk,com.mongodb.connection,com.mongodb.event,com.mongodb.lang,org.b
 son,org.bson.codecs,org.bson.codecs.configuration,org.bson.codecs.poj
 o.annotations,org.bson.conversions,org.bson.json,org.bson.types";vers
 ion="4.0.0.SNAPSHOT",com.mongodb.annotations;version="4.0.0.SNAPSHOT"
 ,com.mongodb.assertions;uses:="com.mongodb.internal.async";version="4
 .0.0.SNAPSHOT",com.mongodb.bulk;uses:="com.mongodb,com.mongodb.intern
 al.bulk,org.bson";version="4.0.0.SNAPSHOT",com.mongodb.client.gridfs.
 codecs;uses:="com.mongodb.client.gridfs.model,org.bson,org.bson.codec
 s,org.bson.codecs.configuration";version="4.0.0.SNAPSHOT",com.mongodb
 .client.gridfs.model;uses:="com.mongodb.lang,org.bson,org.bson.types"
 ;version="4.0.0.SNAPSHOT",com.mongodb.client.model;uses:="com.mongodb
 ,com.mongodb.annotations,com.mongodb.client.model.geojson,com.mongodb
 .lang,org.bson,org.bson.conversions";version="4.0.0.SNAPSHOT",com.mon
 godb.client.model.changestream;uses:="com.mongodb,com.mongodb.lang,or
 g.bson,org.bson.codecs,org.bson.codecs.configuration,org.bson.codecs.
 pojo.annotations";version="4.0.0.SNAPSHOT",com.mongodb.client.model.g
 eojson;uses:="com.mongodb.annotations,com.mongodb.lang";version="4.0.
 0.SNAPSHOT",com.mongodb.client.model.geojson.codecs;uses:="com.mongod
 b.client.model.geojson,org.bson,org.bson.codecs,org.bson.codecs.confi
 guration";version="4.0.0.SNAPSHOT",com.mongodb.client.model.vault;use
 s:="org.bson";version="4.0.0.SNAPSHOT",com.mongodb.client.result;uses
 :="com.mongodb.lang,org.bson";version="4.0.0.SNAPSHOT",com.mongodb.co
 nnection;uses:="com.mongodb,com.mongodb.annotations,com.mongodb.event
 ,com.mongodb.internal.connection.tlschannel.async,com.mongodb.lang,co
 m.mongodb.selector,javax.net,javax.net.ssl,org.bson,org.bson.types";v
 ersion="4.0.0.SNAPSHOT",com.mongodb.connection.netty;uses:="com.mongo
 db,com.mongodb.connection,io.netty.buffer,io.netty.channel,io.netty.c
 hannel.socket";version="4.0.0.SNAPSHOT",com.mongodb.diagnostics.loggi
 ng;version="4.0.0.SNAPSHOT",com.mongodb.event;uses:="com.mongodb.conn
 ection,org.bson";version="4.0.0.SNAPSHOT",com.mongodb.internal;versio
 n="4.0.0.SNAPSHOT",com.mongodb.internal.async;uses:="com.mongodb.diag
 nostics.logging,org.bson";version="4.0.0.SNAPSHOT",com.mongodb.intern
 al.async.client;uses:="com.mongodb,com.mongodb.annotations,com.mongod
 b.bulk,com.mongodb.client.model,com.mongodb.client.model.changestream
 ,com.mongodb.client.model.vault,com.mongodb.client.result,com.mongodb
 .internal.async,com.mongodb.internal.binding,com.mongodb.internal.con
 nection,com.mongodb.internal.session,com.mongodb.lang,com.mongodb.ses
 sion,org.bson,org.bson.codecs.configuration,org.bson.conversions";ver
 sion="4.0.0.SNAPSHOT",com.mongodb.internal.async.client.gridfs;uses:=
 "com.mongodb,com.mongodb.annotations,com.mongodb.client.gridfs.model,
 com.mongodb.client.model,com.mongodb.internal.async,com.mongodb.inter
 nal.async.client,com.mongodb.lang,org.bson,org.bson.conversions,org.b
 son.types";version="4.0.0.SNAPSHOT",com.mongodb.internal.async.client
 .vault;uses:="com.mongodb,com.mongodb.client.model.vault,com.mongodb.
 internal.async,org.bson";version="4.0.0.SNAPSHOT",com.mongodb.interna
 l.authentication;uses:="org.bson";version="4.0.0.SNAPSHOT",com.mongod
 b.internal.binding;uses:="com.mongodb,com.mongodb.connection,com.mong
 odb.internal.async,com.mongodb.internal.connection,com.mongodb.intern
 al.session";version="4.0.0.SNAPSHOT",com.mongodb.internal.build;versi
 on="4.0.0.SNAPSHOT",com.mongodb.internal.bulk;uses:="com.mongodb.clie
 nt.model,org.bson";version="4.0.0.SNAPSHOT",com.mongodb.internal.capi
 ;uses:="com.mongodb.crypt.capi,org.bson";version="4.0.0.SNAPSHOT",com
 .mongodb.internal.client.model;uses:="com.mongodb,com.mongodb.client.
 model,com.mongodb.lang,org.bson.conversions";version="4.0.0.SNAPSHOT"
 ,com.mongodb.internal.client.model.changestream;version="4.0.0.SNAPSH
 OT",com.mongodb.internal.connection;uses:="com.mongodb,com.mongodb.an
 notations,com.mongodb.bulk,com.mongodb.connection,com.mongodb.event,c
 om.mongodb.internal.async,com.mongodb.internal.binding,com.mongodb.in
 ternal.bulk,com.mongodb.internal.session,com.mongodb.lang,com.mongodb
 .selector,javax.net,javax.net.ssl,org.bson,org.bson.codecs,org.bson.i
 o,org.bson.types";version="4.0.0.SNAPSHOT",com.mongodb.internal.conne
 ction.tlschannel;uses:="javax.net.ssl,org.bson";version="4.0.0.SNAPSH
 OT",com.mongodb.internal.connection.tlschannel.async;uses:="com.mongo
 db.internal.connection,com.mongodb.internal.connection.tlschannel";ve
 rsion="4.0.0.SNAPSHOT",com.mongodb.internal.connection.tlschannel.imp
 l;uses:="com.mongodb.internal.connection.tlschannel,javax.net.ssl";ve
 rsion="4.0.0.SNAPSHOT",com.mongodb.internal.connection.tlschannel.uti
 l;uses:="javax.net.ssl";version="4.0.0.SNAPSHOT",com.mongodb.internal
 .dns;version="4.0.0.SNAPSHOT",com.mongodb.internal.event;uses:="com.m
 ongodb.connection,com.mongodb.event";version="4.0.0.SNAPSHOT",com.mon
 godb.internal.operation;uses:="com.mongodb,com.mongodb.annotations,co
 m.mongodb.bulk,com.mongodb.client.model,com.mongodb.client.model.chan
 gestream,com.mongodb.connection,com.mongodb.internal.async,com.mongod
 b.internal.binding,com.mongodb.internal.bulk,com.mongodb.internal.cli
 ent.model,com.mongodb.internal.client.model.changestream,com.mongodb.
 internal.session,com.mongodb.lang,org.bson,org.bson.codecs,org.bson.c
 odecs.configuration,org.bson.conversions";version="4.0.0.SNAPSHOT",co
 m.mongodb.internal.selector;uses:="com.mongodb,com.mongodb.connection
 ,com.mongodb.selector";version="4.0.0.SNAPSHOT",com.mongodb.internal.
 session;uses:="com.mongodb,com.mongodb.internal.connection,com.mongod
 b.lang,com.mongodb.session,org.bson";version="4.0.0.SNAPSHOT",com.mon
 godb.internal.thread;version="4.0.0.SNAPSHOT",com.mongodb.internal.va
 lidator;uses:="org.bson";version="4.0.0.SNAPSHOT",com.mongodb.lang;ve
 rsion="4.0.0.SNAPSHOT",com.mongodb.management;uses:="com.mongodb.even
 t";version="4.0.0.SNAPSHOT",com.mongodb.selector;uses:="com.mongodb.a
 nnotations,com.mongodb.connection";version="4.0.0.SNAPSHOT",com.mongo
 db.session;uses:="com.mongodb,com.mongodb.annotations,com.mongodb.lan
 g,org.bson";version="4.0.0.SNAPSHOT"
Import-Package: org.bson;version="[4.0,5)",org.bson.assertions;version
 ="[4.0,5)",org.bson.codecs;version="[4.0,5)",org.bson.codecs.configur
 ation;version="[4.0,5)",org.bson.codecs.jsr310;version="[4.0,5)",org.
 bson.codecs.pojo;version="[4.0,5)",org.bson.codecs.pojo.annotations;v
 ersion="[4.0,5)",org.bson.conversions;version="[4.0,5)",org.bson.inte
 rnal;version="[4.0,5)",org.bson.io;version="[4.0,5)",org.bson.json;ve
 rsion="[4.0,5)",org.bson.types;version="[4.0,5)",javax.crypto,javax.c
 rypto.spec,javax.management,javax.naming,javax.naming.directory,javax
 .net,javax.net.ssl,javax.security.sasl,javax.security.auth.callback,o
 rg.ietf.jgss,io.netty.bootstrap;resolution:=optional;version="[4.1,5)
 ",io.netty.buffer;resolution:=optional;version="[4.1,5)",io.netty.cha
 nnel;resolution:=optional;version="[4.1,5)",io.netty.channel.nio;reso
 lution:=optional;version="[4.1,5)",io.netty.channel.socket;resolution
 :=optional;version="[4.1,5)",io.netty.channel.socket.nio;resolution:=
 optional;version="[4.1,5)",io.netty.handler.ssl;resolution:=optional;
 version="[4.1,5)",io.netty.handler.timeout;resolution:=optional;versi
 on="[4.1,5)",io.netty.util.concurrent;resolution:=optional;version="[
 4.1,5)",org.xerial.snappy;resolution:=optional;version="[1.1,2)",com.
 github.luben.zstd;resolution:=optional;version="[1.3,2)",org.slf4j;re
 solution:=optional;version="[1.7,2)",jnr.unixsocket;resolution:=optio
 nal;version="[0.18,1)",com.mongodb.crypt.capi;resolution:=optional
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-4.3.1.201911131708
```