### PR TITLE
Scala: Removed deprecated org.mongodb.scala.bson.codecs.DEFAULT_CODEC…

### DIFF
--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/Macros.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/Macros.scala
@@ -94,7 +94,7 @@ object Macros {
    * @return the Codec for the case class
    */
   @compileTimeOnly("Creating a Codec utilises Macros and must be run at compile time.")
-  def createCodec[T](): Codec[T] = macro CaseClassCodec.createCodecDefaultCodecRegistryEncodeNone[T]
+  def createCodec[T](): Codec[T] = macro CaseClassCodec.createCodecBasicCodecRegistryEncodeNone[T]
 
   /**
    * Creates a Codec for a case class
@@ -114,7 +114,7 @@ object Macros {
    * @since 2.1
    */
   @compileTimeOnly("Creating a Codec utilises Macros and must be run at compile time.")
-  def createCodecIgnoreNone[T](): Codec[T] = macro CaseClassCodec.createCodecDefaultCodecRegistryIgnoreNone[T]
+  def createCodecIgnoreNone[T](): Codec[T] = macro CaseClassCodec.createCodecBasicCodecRegistryIgnoreNone[T]
 
   /**
    * Creates a Codec for a case class

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
@@ -25,9 +25,9 @@ import org.mongodb.scala.bson.annotations.BsonProperty
 
 private[codecs] object CaseClassCodec {
 
-  def createCodecDefaultCodecRegistryEncodeNone[T: c.WeakTypeTag](c: whitebox.Context)(): c.Expr[Codec[T]] = {
+  def createCodecBasicCodecRegistryEncodeNone[T: c.WeakTypeTag](c: whitebox.Context)(): c.Expr[Codec[T]] = {
     import c.universe._
-    createCodecDefaultCodecRegistry[T](c)(c.Expr[Boolean](q"true"))
+    createCodecBasicCodecRegistry[T](c)(c.Expr[Boolean](q"true"))
   }
 
   def createCodecEncodeNone[T: c.WeakTypeTag](
@@ -37,9 +37,9 @@ private[codecs] object CaseClassCodec {
     createCodec[T](c)(codecRegistry, c.Expr[Boolean](q"true"))
   }
 
-  def createCodecDefaultCodecRegistryIgnoreNone[T: c.WeakTypeTag](c: whitebox.Context)(): c.Expr[Codec[T]] = {
+  def createCodecBasicCodecRegistryIgnoreNone[T: c.WeakTypeTag](c: whitebox.Context)(): c.Expr[Codec[T]] = {
     import c.universe._
-    createCodecDefaultCodecRegistry[T](c)(c.Expr[Boolean](q"false"))
+    createCodecBasicCodecRegistry[T](c)(c.Expr[Boolean](q"false"))
   }
 
   def createCodecIgnoreNone[T: c.WeakTypeTag](
@@ -49,15 +49,21 @@ private[codecs] object CaseClassCodec {
     createCodec[T](c)(codecRegistry, c.Expr[Boolean](q"false"))
   }
 
-  def createCodecDefaultCodecRegistry[T: c.WeakTypeTag](
+  def createCodecBasicCodecRegistry[T: c.WeakTypeTag](
       c: whitebox.Context
   )(encodeNone: c.Expr[Boolean]): c.Expr[Codec[T]] = {
     import c.universe._
     createCodec[T](c)(
       c.Expr[CodecRegistry](
         q"""
-         import org.mongodb.scala.bson.codecs.DEFAULT_CODEC_REGISTRY
-         DEFAULT_CODEC_REGISTRY
+         import org.bson.codecs.{ BsonValueCodecProvider, ValueCodecProvider }
+         import org.bson.codecs.configuration.CodecRegistries.fromProviders
+         fromProviders(
+              DocumentCodecProvider(),
+              IterableCodecProvider(),
+              new ValueCodecProvider(),
+              new BsonValueCodecProvider()
+            )
       """
       ),
       encodeNone

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/ImmutableDocumentCodecSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/ImmutableDocumentCodecSpec.scala
@@ -27,6 +27,7 @@ import org.bson.codecs.{ DecoderContext, EncoderContext }
 import org.bson.io.{ BasicOutputBuffer, ByteBufferBsonInput }
 import org.bson.types.ObjectId
 
+import org.mongodb.scala.bson.codecs.Registry.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.collection.immutable.Document
 import org.scalatest.{ FlatSpec, Matchers }
 

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/IterableCodecSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/IterableCodecSpec.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala.bson.codecs
 
 import org.bson.codecs.{ DecoderContext, EncoderContext }
 import org.bson.{ BsonDocumentReader, BsonDocumentWriter, Transformer }
-
+import org.mongodb.scala.bson.codecs.Registry.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.BsonDocument
 import org.scalatest.{ FlatSpec, Matchers }
 

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
@@ -28,6 +28,7 @@ import org.bson.codecs.{ Codec, DecoderContext, EncoderContext }
 import org.bson.io.{ BasicOutputBuffer, ByteBufferBsonInput, OutputBuffer }
 import org.bson.types.ObjectId
 import org.mongodb.scala.bson.annotations.BsonProperty
+import org.mongodb.scala.bson.codecs.Registry.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.codecs.Macros.{ createCodecProvider, createCodecProviderIgnoreNone }
 import org.mongodb.scala.bson.collection.immutable.Document
 import org.scalatest.{ FlatSpec, Matchers }

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MutableDocumentCodecSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MutableDocumentCodecSpec.scala
@@ -27,6 +27,7 @@ import org.bson.codecs.{ DecoderContext, EncoderContext }
 import org.bson.io.{ BasicOutputBuffer, ByteBufferBsonInput }
 import org.bson.types.ObjectId
 
+import org.mongodb.scala.bson.codecs.Registry.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.collection.mutable
 import org.mongodb.scala.bson.collection.mutable.Document
 import org.scalatest.{ FlatSpec, Matchers }

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/Registry.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/Registry.scala
@@ -14,25 +14,19 @@
  * limitations under the License.
  */
 
-package org.mongodb.scala.bson
+package org.mongodb.scala.bson.codecs
 
-package object codecs {
+import org.bson.codecs.{ BsonValueCodecProvider, ValueCodecProvider }
+import org.bson.codecs.configuration.CodecRegistries.fromProviders
+import org.bson.codecs.configuration.CodecRegistry
 
-  /**
-   * Type alias to the `BsonTypeClassMap`
-   */
-  type BsonTypeClassMap = org.bson.codecs.BsonTypeClassMap
+object Registry {
 
-  /**
-   * Companion to return the default `BsonTypeClassMap`
-   */
-  object BsonTypeClassMap {
-    def apply(): BsonTypeClassMap = new BsonTypeClassMap()
-  }
-
-  /**
-   * Type alias to the `BsonTypeCodecMap`
-   */
-  type BsonTypeCodecMap = org.bson.codecs.BsonTypeCodecMap
+  val DEFAULT_CODEC_REGISTRY: CodecRegistry = fromProviders(
+    DocumentCodecProvider(),
+    IterableCodecProvider(),
+    new ValueCodecProvider(),
+    new BsonValueCodecProvider()
+  )
 
 }

--- a/docs/reference/content/driver-scala/getting-started/quick-start-case-class.md
+++ b/docs/reference/content/driver-scala/getting-started/quick-start-case-class.md
@@ -48,7 +48,7 @@ time. In the following example we create a new `CodecRegistry` that includes a c
 
 ```scala
 import org.mongodb.scala.bson.codecs.Macros._
-import org.mongodb.scala.bson.codecs.DEFAULT_CODEC_REGISTRY
+import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
 import org.bson.codecs.configuration.CodecRegistries.{fromRegistries, fromProviders}
 
 val codecRegistry = fromRegistries(fromProviders(classOf[Person]), DEFAULT_CODEC_REGISTRY )

--- a/driver-scala/src/it/scala/tour/QuickTourCaseClass.scala
+++ b/driver-scala/src/it/scala/tour/QuickTourCaseClass.scala
@@ -45,7 +45,7 @@ object QuickTourCaseClass {
 
     // Create a codec for the Person case class
     import org.mongodb.scala.bson.codecs.Macros._
-    import org.mongodb.scala.bson.codecs.DEFAULT_CODEC_REGISTRY
+    import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
     import org.bson.codecs.configuration.CodecRegistries.{ fromProviders, fromRegistries }
     val codecRegistry = fromRegistries(fromProviders(classOf[Person]), DEFAULT_CODEC_REGISTRY)
 


### PR DESCRIPTION
…_REGISTRY

JAVA-3609

https://evergreen.mongodb.com/patch/5e2f187cd6d80a6a29ad52cf