### PR TITLE
Perf: ByteBufferBsonInput performance improvements

### DIFF
--- a/bson/src/test/unit/org/bson/BsonBinaryReaderTest.java
+++ b/bson/src/test/unit/org/bson/BsonBinaryReaderTest.java
@@ -67,7 +67,7 @@ public class BsonBinaryReaderTest {
             reader.readBsonType();
             fail("Should have thrown BsonSerializationException");
         } catch (BsonSerializationException e) {
-            assertEquals("While decoding a BSON document 1 bytes were required, but only 0 remain", e.getMessage());
+            assertEquals("Found a BSON string that is not null-terminated", e.getMessage());
         }
     }
 

--- a/bson/src/test/unit/org/bson/io/ByteBufferBsonInputSpecification.groovy
+++ b/bson/src/test/unit/org/bson/io/ByteBufferBsonInputSpecification.groovy
@@ -207,6 +207,26 @@ class ByteBufferBsonInputSpecification extends Specification {
         stream.position == 4
     }
 
+    def 'should handle invalid CString not null terminated'() {
+        when:
+        def stream = new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap([0xe0, 0xa4, 0x80] as byte[])))
+        stream.readCString()
+
+        then:
+        def e = thrown(BsonSerializationException)
+        e.getMessage() == 'Found a BSON string that is not null-terminated'
+    }
+
+    def 'should handle invalid CString not null terminated when skipping value'() {
+        when:
+        def stream = new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap([0xe0, 0xa4, 0x80] as byte[])))
+        stream.skipCString()
+
+        then:
+        def e = thrown(BsonSerializationException)
+        e.getMessage() == 'Found a BSON string that is not null-terminated'
+    }
+
     def 'should read from position'() {
         given:
         def stream = new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap([4, 3, 2, 1] as byte[])))


### PR DESCRIPTION
Improve readCStrings performance.

JAVA-3612

- Inlined readCString logic - no longer uses a mark and position then calls readString to iterate the buffer again. 
- Simplified skipCString - so it just loops the buffer.