### PR TITLE
OSGI: Mark com.mongodb.crypt.capi as optional

### DIFF
--- a/driver-reactive-streams/build.gradle
+++ b/driver-reactive-streams/build.gradle
@@ -60,7 +60,11 @@ ext {
 }
 
 afterEvaluate {
-    jar.manifest.attributes['Import-Package'] = 'org.bson.*,com.mongodb.*'
     jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.driver.reactivestreams'
     jar.manifest.attributes['Bundle-SymbolicName'] = 'org.mongodb.driver-reactivestreams'
+    jar.manifest.attributes['Import-Package'] = [
+            'org.bson.*',
+            'com.mongodb.crypt.capi.*;resolution:=optional',
+            'com.mongodb.*',
+    ].join(',')
 }

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -97,6 +97,10 @@ ext {
 }
 
 afterEvaluate {
-    jar.manifest.attributes['Import-Package'] = 'org.bson.*,com.mongodb.*'
     jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.scala.mongo-scala-driver'
+    jar.manifest.attributes['Import-Package'] = [
+            'org.bson.*',
+            'com.mongodb.crypt.capi.*;resolution:=optional',
+            'com.mongodb.*',
+    ].join(',')
 }

--- a/driver-sync/build.gradle
+++ b/driver-sync/build.gradle
@@ -42,7 +42,11 @@ tasks.withType(Checkstyle) {
 }
 
 afterEvaluate {
-    jar.manifest.attributes['Import-Package'] = 'org.bson.*,com.mongodb.*'
     jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.driver.sync.client'
     jar.manifest.attributes['Bundle-SymbolicName'] = 'org.mongodb.driver-sync'
+    jar.manifest.attributes['Import-Package'] = [
+            'org.bson.*',
+            'com.mongodb.crypt.capi.*;resolution:=optional',
+            'com.mongodb.*',
+    ].join(',')
 }


### PR DESCRIPTION
Bnd needs some help marking optional dependency packages as optional.

JAVA-3604

Now looks like@

```
Import-Package: org.bson;version="[4.0,5)",org.bson.assertions;version
 ="[4.0,5)",org.bson.codecs;version="[4.0,5)",org.bson.codecs.configur
 ation;version="[4.0,5)",org.bson.conversions;version="[4.0,5)",org.bs
 on.internal;version="[4.0,5)",org.bson.io;version="[4.0,5)",org.bson.
 types;version="[4.0,5)",com.mongodb.crypt.capi;resolution:=optional;v
 ersion="[1.0,2)",com.mongodb;version="[4.0,5)",com.mongodb.annotation
 s;version="[4.0,5)",com.mongodb.assertions;version="[4.0,5)",com.mong
 odb.bulk;version="[4.0,5)",com.mongodb.client.gridfs.model;version="[
 4.0,5)",com.mongodb.client.model;version="[4.0,5)",com.mongodb.client
 .model.changestream;version="[4.0,5)",com.mongodb.client.model.vault;
 version="[4.0,5)",com.mongodb.client.result;version="[4.0,5)",com.mon
 godb.connection;version="[4.0,5)",com.mongodb.diagnostics.logging;ver
 sion="[4.0,5)",com.mongodb.event;version="[4.0,5)",com.mongodb.intern
 al.binding;version="[4.0,5)",com.mongodb.internal.bulk;version="[4.0,
 5)",com.mongodb.internal.capi;version="[4.0,5)",com.mongodb.internal.
 client.model;version="[4.0,5)",com.mongodb.internal.client.model.chan
 gestream;version="[4.0,5)",com.mongodb.internal.connection;version="[
 4.0,5)",com.mongodb.internal.event;version="[4.0,5)",com.mongodb.inte
 rnal.operation;version="[4.0,5)",com.mongodb.internal.selector;versio
 n="[4.0,5)",com.mongodb.internal.session;version="[4.0,5)",com.mongod
 b.internal.validator;version="[4.0,5)",com.mongodb.lang;version="[4.0
 ,5)",com.mongodb.selector;version="[4.0,5)",com.mongodb.session;versi
 on="[4.0,5)"
```