### PR TITLE
OSGI: Mark com.mongodb.crypt.capi as optional

### DIFF
--- a/driver-async/build.gradle
+++ b/driver-async/build.gradle
@@ -50,6 +50,7 @@ jar {
         instruction 'Build-Version', project.gitVersion
         instruction 'Import-Package',
                 'org.bson.*',
+                'com.mongodb.crypt.capi.*;resolution:=optional;',
                 'com.mongodb.*',
                 'io.netty.*;resolution:=optional'
     }

--- a/driver-sync/build.gradle
+++ b/driver-sync/build.gradle
@@ -53,6 +53,7 @@ jar {
         instruction 'Build-Version', project.gitVersion
         instruction 'Import-Package',
                 'org.bson.*',
+                'com.mongodb.crypt.capi.*;resolution:=optional',
                 'com.mongodb.*'
     }
 }


### PR DESCRIPTION
The OSGI plugin needs some help marking optional dependency packages as optional.

JAVA-3604

Now looks like:

```
Import-Package: org.bson;version="[3.12,4)",org.bson.assertions;version=
 "[3.12,4)",org.bson.codecs;version="[3.12,4)",org.bson.codecs.configura
 tion;version="[3.12,4)",org.bson.conversions;version="[3.12,4)",org.bso
 n.internal;version="[3.12,4)",org.bson.io;version="[3.12,4)",org.bson.t
 ypes;version="[3.12,4)",com.mongodb.crypt.capi;resolution:=optional;ver
 sion="[1.0,2)",com.mongodb;version="[3.12,4)",com.mongodb.annotations;v
 ersion="[3.12,4)",com.mongodb.assertions;version="[3.12,4)",com.mongodb
 .binding;version="[3.12,4)",com.mongodb.bulk;version="[3.12,4)",com.mon
 godb.client;version="[3.12,4)",com.mongodb.client.gridfs.model;version=
 "[3.12,4)",com.mongodb.client.internal;version="[3.12,4)",com.mongodb.c
 lient.model;version="[3.12,4)",com.mongodb.client.model.changestream;ve
 rsion="[3.12,4)",com.mongodb.client.model.vault;version="[3.12,4)",com.
 mongodb.client.result;version="[3.12,4)",com.mongodb.client.vault;versi
 on="[3.12,4)",com.mongodb.connection;version="[3.12,4)",com.mongodb.dia
 gnostics.logging;version="[3.12,4)",com.mongodb.event;version="[3.12,4)
 ",com.mongodb.internal;version="[3.12,4)",com.mongodb.internal.binding;
 version="[3.12,4)",com.mongodb.internal.capi;version="[3.12,4)",com.mon
 godb.internal.client.model;version="[3.12,4)",com.mongodb.internal.conn
 ection;version="[3.12,4)",com.mongodb.internal.event;version="[3.12,4)"
 ,com.mongodb.internal.operation;version="[3.12,4)",com.mongodb.internal
 .session;version="[3.12,4)",com.mongodb.internal.validator;version="[3.
 12,4)",com.mongodb.lang;version="[3.12,4)",com.mongodb.operation;versio
 n="[3.12,4)",com.mongodb.selector;version="[3.12,4)",com.mongodb.sessio
 n;version="[3.12,4)"
```