### PR TITLE
Ensure GridFS index checking supports indexes created in the shell

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/gridfs/GridFSIndexCheckImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/gridfs/GridFSIndexCheckImpl.java
@@ -27,6 +27,7 @@ import com.mongodb.lang.Nullable;
 import org.bson.Document;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
@@ -85,8 +86,14 @@ final class GridFSIndexCheckImpl implements GridFSIndexCheck {
                     callback.onResult(null, t);
                 } else {
                     boolean hasIndex = false;
-                    for (Document indexDoc : indexes) {
-                        if (indexDoc.get("key", Document.class).equals(index)) {
+                    for (Document result : indexes) {
+                        Document indexDoc = result.get("key", new Document());
+                        for (final Map.Entry<String, Object> entry : indexDoc.entrySet()) {
+                            if (entry.getValue() instanceof Number) {
+                                entry.setValue(((Number) entry.getValue()).intValue());
+                            }
+                        }
+                        if (indexDoc.equals(index)) {
                             hasIndex = true;
                             break;
                         }

--- a/driver-sync/src/main/com/mongodb/client/gridfs/GridFSBucketImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/gridfs/GridFSBucketImpl.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Map;
 
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
@@ -496,8 +497,14 @@ final class GridFSBucketImpl implements GridFSBucket {
         }
 
         ArrayList<Document> indexes = listIndexesIterable.into(new ArrayList<Document>());
-        for (Document indexDoc : indexes) {
-            if (indexDoc.get("key", Document.class).equals(index)) {
+        for (Document result : indexes) {
+            Document indexDoc = result.get("key", new Document());
+            for (final Map.Entry<String, Object> entry : indexDoc.entrySet()) {
+                if (entry.getValue() instanceof Number) {
+                    entry.setValue(((Number) entry.getValue()).intValue());
+                }
+            }
+            if (indexDoc.equals(index)) {
                 hasIndex = true;
                 break;
             }


### PR DESCRIPTION
JAVA-3599

master: https://evergreen.mongodb.com/version/5e382d7d2a60ed64e9fb89bb
3.12.x cherry-picked: https://evergreen.mongodb.com/version/5e382d3830661575b251a181