### PR TITLE
Extended support for $out aggregations

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -429,7 +429,6 @@ public final class Aggregates {
      * @param destination the destination details
      * @return the $out pipeline stage
      * @mongodb.driver.manual reference/operator/aggregation/out/  $out
-     * @mongodb.server.release 4.4
      * @since 4.1
      */
     public static Bson out(final Bson destination) {

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -424,6 +424,19 @@ public final class Aggregates {
     }
 
     /**
+     * Creates a $out pipeline stage that writes out to the specified destination
+     *
+     * @param destination the destination details
+     * @return the $out pipeline stage
+     * @mongodb.driver.manual reference/operator/aggregation/out/  $out
+     * @mongodb.server.release 4.4
+     * @since 4.1
+     */
+    public static Bson out(final Bson destination) {
+        return new SimplePipelineStage("$out", destination);
+    }
+
+    /**
      * Creates a $merge pipeline stage that merges into the specified collection
      *
      * @param collectionName the name of the collection to merge into

--- a/driver-core/src/main/com/mongodb/internal/async/client/AsyncAggregateIterableImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/AsyncAggregateIterableImpl.java
@@ -56,7 +56,6 @@ class AsyncAggregateIterableImpl<TDocument, TResult> extends AsyncMongoIterableI
     private Collation collation;
     private String comment;
     private Bson hint;
-    private BsonDocument lastPipelineStage;
 
     AsyncAggregateIterableImpl(@Nullable final AsyncClientSession clientSession, final String databaseName,
                                final Class<TDocument> documentClass, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
@@ -85,7 +84,8 @@ class AsyncAggregateIterableImpl<TDocument, TResult> extends AsyncMongoIterableI
 
     @Override
     public void toCollection(final SingleResultCallback<Void> callback) {
-        if (!getLastPipelineStage().containsKey("$out") && !getLastPipelineStage().containsKey("$merge")) {
+        BsonDocument lastPipelineStage = getLastPipelineStage();
+        if (lastPipelineStage == null || !lastPipelineStage.containsKey("$out") && !lastPipelineStage.containsKey("$merge")) {
             throw new IllegalStateException("The last stage of the aggregation pipeline must be $out or $merge");
         }
 
@@ -168,29 +168,29 @@ class AsyncAggregateIterableImpl<TDocument, TResult> extends AsyncMongoIterableI
 
     }
 
+    @Nullable
     private BsonDocument getLastPipelineStage() {
-        if (lastPipelineStage == null) {
-            if (pipeline.isEmpty()) {
-                lastPipelineStage = new BsonDocument();
-            } else {
-                Bson lastStage = notNull("last pipeline stage", pipeline.get(pipeline.size() - 1));
-                lastPipelineStage = lastStage.toBsonDocument(documentClass, codecRegistry);
-            }
+        if (pipeline.isEmpty()) {
+            return null;
+        } else {
+            Bson lastStage = notNull("last pipeline stage", pipeline.get(pipeline.size() - 1));
+            return lastStage.toBsonDocument(documentClass, codecRegistry);
         }
-        return lastPipelineStage;
     }
 
     @Nullable
     private MongoNamespace getOutNamespace() {
-        BsonDocument lastStageDocument = getLastPipelineStage();
-
-        if (lastStageDocument.containsKey("$out")) {
-            if (!lastStageDocument.get("$out").isString()) {
+        BsonDocument lastPipelineStage = getLastPipelineStage();
+        if (lastPipelineStage == null) {
+            return null;
+        }
+        if (lastPipelineStage.containsKey("$out")) {
+            if (!lastPipelineStage.get("$out").isString()) {
                 throw new IllegalStateException("Cannot return a cursor when the value for $out stage is not a string");
             }
-            return new MongoNamespace(namespace.getDatabaseName(), lastStageDocument.getString("$out").getValue());
-        } else if (lastStageDocument.containsKey("$merge")) {
-            BsonDocument mergeDocument = lastStageDocument.getDocument("$merge");
+            return new MongoNamespace(namespace.getDatabaseName(), lastPipelineStage.getString("$out").getValue());
+        } else if (lastPipelineStage.containsKey("$merge")) {
+            BsonDocument mergeDocument = lastPipelineStage.getDocument("$merge");
             if (mergeDocument.isDocument("into")) {
                 BsonDocument intoDocument = mergeDocument.getDocument("into");
                 return new MongoNamespace(intoDocument.getString("db", new BsonString(namespace.getDatabaseName())).getValue(),

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -309,6 +309,8 @@ class AggregatesSpecification extends Specification {
     def 'should render $out'() {
         expect:
         toBson(out('authors')) == parse('{ $out : "authors" }')
+        toBson(out(Document.parse('{ s3: "s3://bucket/path/to/file…?format=json&maxFileSize=100MiB"}'))) ==
+                parse('{ $out : { s3: "s3://bucket/path/to/file…?format=json&maxFileSize=100MiB"} }')
     }
 
     def 'should render merge'() {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
@@ -29,6 +29,7 @@ import com.mongodb.internal.operation.AggregateOperation
 import com.mongodb.internal.operation.AggregateToCollectionOperation
 import com.mongodb.internal.operation.BatchCursor
 import com.mongodb.internal.operation.FindOperation
+import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonString
@@ -329,6 +330,68 @@ class AggregateIterableSpecification extends Specification {
                 .collation(collation)
                 .hint(new BsonDocument('a', new BsonInt32(1)))
                 .comment('this is a comment'))
+    }
+
+    def 'should build the expected AggregateToCollectionOperation for $out as a document'() {
+        given:
+        def executor = new TestOperationExecutor([null, null, null, null, null])
+        def pipeline = [new Document('$match', 1), new Document('$out', new Document('s3', true))]
+
+        when: 'aggregation includes $out'
+        def aggregateIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false)
+
+        aggregateIterable.toCollection()
+        def operation = executor.getWriteOperation() as AggregateToCollectionOperation
+
+        then:
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
+                [new BsonDocument('$match', new BsonInt32(1)), BsonDocument.parse('{$out: {s3: true}}')],
+                readConcern, writeConcern, AggregationLevel.COLLECTION)
+        )
+
+        when: 'Trying to iterate it should fail'
+        aggregateIterable.iterator()
+
+        then:
+        thrown(IllegalStateException)
+
+        when: 'aggregation includes $out and is at the database level'
+        aggregateIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE, false)
+        aggregateIterable.toCollection()
+
+        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+
+        then:
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
+                [new BsonDocument('$match', new BsonInt32(1)), BsonDocument.parse('{$out: {s3: true}}')],
+                readConcern, writeConcern, AggregationLevel.DATABASE)
+        )
+
+        when: 'Trying to iterate it should fail'
+        aggregateIterable.iterator()
+
+        then:
+        thrown(IllegalStateException)
+
+        when: 'toCollection should work as expected'
+        aggregateIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false)
+        aggregateIterable.toCollection()
+
+        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+
+        then:
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
+                [new BsonDocument('$match', new BsonInt32(1)), BsonDocument.parse('{$out: {s3: true}}')],
+                readConcern, writeConcern))
+
+        when: 'Trying to iterate it should fail'
+        aggregateIterable.iterator()
+
+        then:
+        thrown(IllegalStateException)
     }
 
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
@@ -16,20 +16,18 @@
 
 package com.mongodb.client.internal
 
-
 import com.mongodb.Function
 import com.mongodb.MongoException
 import com.mongodb.MongoNamespace
 import com.mongodb.ReadConcern
 import com.mongodb.WriteConcern
 import com.mongodb.client.ClientSession
-import com.mongodb.internal.client.model.AggregationLevel
 import com.mongodb.client.model.Collation
+import com.mongodb.internal.client.model.AggregationLevel
 import com.mongodb.internal.operation.AggregateOperation
 import com.mongodb.internal.operation.AggregateToCollectionOperation
 import com.mongodb.internal.operation.BatchCursor
 import com.mongodb.internal.operation.FindOperation
-import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonString


### PR DESCRIPTION
Now supports the syntax describing alternative destinations eg: s3

JAVA-3440

https://evergreen.mongodb.com/version/5e3add8257e85a0edd187e8f