### PR TITLE
Expand use of error labels for RetryableWrites

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
@@ -54,6 +54,12 @@ public class MongoBulkWriteException extends MongoServerException {
         this.errors = writeErrors;
         this.writeConcernError = writeConcernError;
         this.serverAddress = serverAddress;
+
+        if (writeConcernError != null) {
+            for (final String errorLabel : writeConcernError.getErrorLabels()) {
+                addLabel(errorLabel);
+            }
+        }
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
@@ -21,7 +21,9 @@ import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.WriteConcernError;
 import com.mongodb.lang.Nullable;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * An exception that represents all errors associated with a bulk write operation.
@@ -44,16 +46,40 @@ public class MongoBulkWriteException extends MongoServerException {
      * @param writeErrors              the list of errors
      * @param writeConcernError        the write concern error
      * @param serverAddress            the server address.
+     *
+     * @deprecated Prefer {@link MongoBulkWriteException#MongoBulkWriteException(BulkWriteResult, List, WriteConcernError,
+     *      ServerAddress, Set)} instead
      */
+    @Deprecated
     public MongoBulkWriteException(final BulkWriteResult writeResult, final List<BulkWriteError> writeErrors,
                                    @Nullable final WriteConcernError writeConcernError, final ServerAddress serverAddress) {
+        this(writeResult, writeErrors, writeConcernError, serverAddress, Collections.emptySet());
+    }
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param writeResult              the write result
+     * @param writeErrors              the list of errors
+     * @param writeConcernError        the write concern error
+     * @param serverAddress            the server address.
+     * @param errorLabels              any server errorLabels
+     * @since 4.1
+     */
+    public MongoBulkWriteException(final BulkWriteResult writeResult, final List<BulkWriteError> writeErrors,
+                                   @Nullable final WriteConcernError writeConcernError, final ServerAddress serverAddress,
+                                   final Set<String> errorLabels) {
         super("Bulk write operation error on server " + serverAddress + ". "
-              + (writeErrors.isEmpty() ? "" : "Write errors: " + writeErrors + ". ")
-              + (writeConcernError == null ? "" : "Write concern error: " + writeConcernError + ". "), serverAddress);
+                + (writeErrors.isEmpty() ? "" : "Write errors: " + writeErrors + ". ")
+                + (writeConcernError == null ? "" : "Write concern error: " + writeConcernError + ". "), serverAddress);
         this.writeResult = writeResult;
         this.errors = writeErrors;
         this.writeConcernError = writeConcernError;
         this.serverAddress = serverAddress;
+
+        for (final String errorLabel : errorLabels) {
+            addLabel(errorLabel);
+        }
 
         if (writeConcernError != null) {
             for (final String errorLabel : writeConcernError.getErrorLabels()) {

--- a/driver-core/src/main/com/mongodb/MongoException.java
+++ b/driver-core/src/main/com/mongodb/MongoException.java
@@ -114,6 +114,11 @@ public class MongoException extends RuntimeException {
     public MongoException(final int code, final String msg, final Throwable t) {
         super(msg, t);
         this.code = code;
+        if (t instanceof MongoException) {
+            for (final String errorLabel : ((MongoException) t).getErrorLabels()) {
+                addLabel(errorLabel);
+            }
+        }
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/MongoWriteConcernException.java
+++ b/driver-core/src/main/com/mongodb/MongoWriteConcernException.java
@@ -57,6 +57,15 @@ public class MongoWriteConcernException extends MongoServerException {
         super(writeConcernError.getCode(), writeConcernError.getMessage(), serverAddress);
         this.writeConcernResult = writeConcernResult;
         this.writeConcernError = notNull("writeConcernError", writeConcernError);
+        for (final String errorLabel : writeConcernError.getErrorLabels()) {
+            super.addLabel(errorLabel);
+        }
+    }
+
+    @Override
+    public void addLabel(final String errorLabel) {
+        writeConcernError.addLabel(errorLabel);
+        super.addLabel(errorLabel);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
+++ b/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
@@ -16,7 +16,11 @@
 
 package com.mongodb.bulk;
 
+import com.mongodb.lang.NonNull;
 import org.bson.BsonDocument;
+
+import java.util.Collections;
+import java.util.Set;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -31,6 +35,7 @@ public class WriteConcernError {
     private final String codeName;
     private final String message;
     private final BsonDocument details;
+    private final Set<String> errorLabels;
 
 
     /**
@@ -42,10 +47,26 @@ public class WriteConcernError {
      * @param details any details
      */
     public WriteConcernError(final int code, final String codeName, final String message, final BsonDocument details) {
+        this(code, codeName, message, details, Collections.emptySet());
+    }
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param code    the error code
+     * @param codeName the error code name
+     * @param message the error message
+     * @param details any details
+     * @param errorLabels any error labels
+     * @since 4.1
+     */
+    public WriteConcernError(final int code, final String codeName, final String message, final BsonDocument details,
+                             final Set<String> errorLabels) {
         this.code = code;
         this.codeName = notNull("codeName", codeName);
         this.message = notNull("message", message);
         this.details = notNull("details", details);
+        this.errorLabels = notNull("errorLabels", errorLabels);
     }
 
     /**
@@ -86,6 +107,29 @@ public class WriteConcernError {
         return details;
     }
 
+    /**
+     * Adds the given error label to the exception.
+     *
+     * @param errorLabel the non-null error label to add to the exception
+     *
+     * @since 4.1
+     */
+    public void addLabel(final String errorLabel) {
+        notNull("errorLabel", errorLabel);
+        errorLabels.add(errorLabel);
+    }
+
+    /**
+     * Gets the set of error labels associated with this exception.
+     *
+     * @return the error labels, which may not be null but may be empty
+     * @since 4.1
+     */
+    @NonNull
+    public Set<String> getErrorLabels() {
+        return Collections.unmodifiableSet(errorLabels);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -109,6 +153,9 @@ public class WriteConcernError {
         if (!message.equals(that.message)) {
             return false;
         }
+        if (!errorLabels.equals(that.errorLabels)) {
+            return false;
+        }
 
         return true;
     }
@@ -119,6 +166,7 @@ public class WriteConcernError {
         result = 31 * result + codeName.hashCode();
         result = 31 * result + message.hashCode();
         result = 31 * result + details.hashCode();
+        result = 31 * result + errorLabels.hashCode();
         return result;
     }
 
@@ -129,6 +177,7 @@ public class WriteConcernError {
                + ", codeName='" + codeName + '\''
                + ", message='" + message + '\''
                + ", details=" + details
+               + ", errorLabels=" + errorLabels
                + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/BulkWriteBatchCombiner.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BulkWriteBatchCombiner.java
@@ -165,7 +165,7 @@ public class BulkWriteBatchCombiner {
         }
         return new MongoBulkWriteException(createResult(), new ArrayList<>(writeErrors),
                 writeConcernErrors.isEmpty() ? null : writeConcernErrors.get(writeConcernErrors.size() - 1),
-                serverAddress);
+                serverAddress, errorLabels);
     }
 
     private void mergeWriteConcernError(final WriteConcernError writeConcernError) {

--- a/driver-core/src/main/com/mongodb/internal/connection/BulkWriteBatchCombiner.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BulkWriteBatchCombiner.java
@@ -26,6 +26,7 @@ import com.mongodb.bulk.BulkWriteUpsert;
 import com.mongodb.bulk.WriteConcernError;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -49,6 +50,7 @@ public class BulkWriteBatchCombiner {
     private final Set<BulkWriteUpsert> writeUpserts = new TreeSet<>(comparingInt(BulkWriteUpsert::getIndex));
     private final Set<BulkWriteInsert> writeInserts = new TreeSet<>(comparingInt(BulkWriteInsert::getIndex));
     private final Set<BulkWriteError> writeErrors = new TreeSet<>(comparingInt(BulkWriteError::getIndex));
+    private final Set<String> errorLabels = new HashSet<>();
     private final List<WriteConcernError> writeConcernErrors = new ArrayList<>();
 
     /**
@@ -86,6 +88,7 @@ public class BulkWriteBatchCombiner {
      */
     public void addErrorResult(final MongoBulkWriteException exception, final IndexMap indexMap) {
         addResult(exception.getWriteResult());
+        errorLabels.addAll(exception.getErrorLabels());
         mergeWriteErrors(exception.getWriteErrors(), indexMap);
         mergeWriteConcernError(exception.getWriteConcernError());
     }
@@ -157,19 +160,22 @@ public class BulkWriteBatchCombiner {
      * @return the bulk write exception, or null if there were no errors
      */
     public MongoBulkWriteException getError() {
-        return hasErrors() ? new MongoBulkWriteException(createResult(),
-                                                    new ArrayList<BulkWriteError>(writeErrors),
-                                                    writeConcernErrors.isEmpty() ? null
-                                                                                 : writeConcernErrors.get(writeConcernErrors.size() - 1),
-                                                    serverAddress) : null;
+        if (!hasErrors()) {
+            return null;
+        }
+        return new MongoBulkWriteException(createResult(), new ArrayList<>(writeErrors),
+                writeConcernErrors.isEmpty() ? null : writeConcernErrors.get(writeConcernErrors.size() - 1),
+                serverAddress);
     }
 
     private void mergeWriteConcernError(final WriteConcernError writeConcernError) {
         if (writeConcernError != null) {
             if (writeConcernErrors.isEmpty()) {
                 writeConcernErrors.add(writeConcernError);
+                errorLabels.addAll(writeConcernError.getErrorLabels());
             } else if (!writeConcernError.equals(writeConcernErrors.get(writeConcernErrors.size() - 1))) {
                 writeConcernErrors.add(writeConcernError);
+                errorLabels.addAll(writeConcernError.getErrorLabels());
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
@@ -327,7 +327,8 @@ final class BulkWriteBatch {
         }
 
         return new MongoBulkWriteException(getBulkWriteResult(result), getWriteErrors(result),
-                getWriteConcernError(result), connectionDescription.getServerAddress());
+                getWriteConcernError(result), connectionDescription.getServerAddress(),
+                result.getArray("errorLabels", new BsonArray()).stream().map(i -> i.asString().getValue()).collect(Collectors.toSet()));
     }
 
     @SuppressWarnings("unchecked")

--- a/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
@@ -35,11 +35,11 @@ import com.mongodb.internal.bulk.WriteRequestWithIndex;
 import com.mongodb.internal.connection.BulkWriteBatchCombiner;
 import com.mongodb.internal.connection.IndexMap;
 import com.mongodb.internal.connection.SplittablePayload;
+import com.mongodb.internal.session.SessionContext;
 import com.mongodb.internal.validator.CollectibleDocumentFieldNameValidator;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.UpdateFieldNameValidator;
-import com.mongodb.internal.session.SessionContext;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -325,8 +325,9 @@ final class BulkWriteBatch {
         if (!hasError(result)) {
             throw new MongoInternalException("This method should not have been called");
         }
-        return new MongoBulkWriteException(getBulkWriteResult(result), getWriteErrors(result), getWriteConcernError(result),
-                connectionDescription.getServerAddress());
+
+        return new MongoBulkWriteException(getBulkWriteResult(result), getWriteErrors(result),
+                getWriteConcernError(result), connectionDescription.getServerAddress());
     }
 
     @SuppressWarnings("unchecked")

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndModifyHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndModifyHelper.java
@@ -54,7 +54,8 @@ final class FindAndModifyHelper {
 
     private static <T> T transformDocument(final BsonDocument result, final ServerAddress serverAddress) {
         if (hasWriteConcernError(result)) {
-            throw new MongoWriteConcernException(createWriteConcernError(result.getDocument("writeConcernError")),
+            throw new MongoWriteConcernException(
+                    createWriteConcernError(result.getDocument("writeConcernError")),
                     createWriteConcernResult(result.getDocument("lastErrorObject", new BsonDocument())), serverAddress);
         }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/MapReduceToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MapReduceToCollectionOperation.java
@@ -576,7 +576,8 @@ MapReduceToCollectionOperation implements AsyncWriteOperation<MapReduceStatistic
             @SuppressWarnings("unchecked")
             @Override
             public MapReduceStatistics apply(final BsonDocument result, final Connection connection) {
-                throwOnWriteConcernError(result, connection.getDescription().getServerAddress());
+                throwOnWriteConcernError(result, connection.getDescription().getServerAddress(),
+                        connection.getDescription().getMaxWireVersion());
                 return MapReduceHelper.createStatistics(result);
             }
         };
@@ -587,7 +588,8 @@ MapReduceToCollectionOperation implements AsyncWriteOperation<MapReduceStatistic
             @SuppressWarnings("unchecked")
             @Override
             public MapReduceStatistics apply(final BsonDocument result, final AsyncConnection connection) {
-                throwOnWriteConcernError(result, connection.getDescription().getServerAddress());
+                throwOnWriteConcernError(result, connection.getDescription().getServerAddress(),
+                        connection.getDescription().getMaxWireVersion());
                 return MapReduceHelper.createStatistics(result);
             }
         };

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -443,9 +443,11 @@ class OperationFunctionalSpecification extends Specification {
             }
         }
 
-        1 * connection.command(*_) >> { throw exception }
+        1 * connection.command(*_) >> {
+            throw exception
+        }
 
-        if (serverVersionSize == 1) {
+        if (serverVersionSize == 2) {
             1 * connection.release()
         } else {
             2 * connection.release()
@@ -489,7 +491,7 @@ class OperationFunctionalSpecification extends Specification {
         def callback = new FutureResultCallback()
 
         1 * connection.commandAsync(*_) >> { it.last().onResult(null, exception) }
-        if (serverVersionSize == 1) {
+        if (serverVersionSize == 2) {
             1 * connection.release()
         } else {
             2 * connection.release()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
@@ -296,7 +296,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 4, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0]],
                 [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -304,7 +304,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
 
         then:
@@ -312,7 +312,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -335,7 +335,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         exception.getMessage().startsWith('Collation not supported by wire version:')
 
         where:
-        async << [false, false]
+        async << [true, false]
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 4) })

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
@@ -428,7 +428,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 4, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0]],
                 [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -436,7 +436,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
 
         then:
@@ -444,7 +444,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY], originalException, async)
 
         then:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
@@ -548,7 +548,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 4, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0]],
                 [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -556,7 +556,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
 
         then:
@@ -564,7 +564,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY], originalException, async)
 
         then:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -1114,7 +1114,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 4, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0]],
                 [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -1122,7 +1122,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
 
         then:
@@ -1130,7 +1130,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY], originalException, async)
 
         then:

--- a/driver-core/src/test/resources/retryable-writes/README.rst
+++ b/driver-core/src/test/resources/retryable-writes/README.rst
@@ -1,0 +1,335 @@
+=====================
+Retryable Write Tests
+=====================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+The YAML and JSON files in this directory tree are platform-independent tests
+that drivers can use to prove their conformance to the Retryable Writes spec.
+
+Several prose tests, which are not easily expressed in YAML, are also presented
+in this file. Those tests will need to be manually implemented by each driver.
+
+Tests will require a MongoClient created with options defined in the tests.
+Integration tests will require a running MongoDB cluster with server versions
+3.6.0 or later. The ``{setFeatureCompatibilityVersion: 3.6}`` admin command
+will also need to have been executed to enable support for retryable writes on
+the cluster. Some tests may have more stringent version requirements depending
+on the fail points used.
+
+Server Fail Point
+=================
+
+onPrimaryTransactionalWrite
+---------------------------
+
+Some tests depend on a server fail point, ``onPrimaryTransactionalWrite``, which
+allows us to force a network error before the server would return a write result
+to the client. The fail point also allows control whether the server will
+successfully commit the write via its ``failBeforeCommitExceptionCode`` option.
+Keep in mind that the fail point only triggers for transaction writes (i.e. write
+commands including ``txnNumber`` and ``lsid`` fields). See `SERVER-29606`_ for
+more information.
+
+.. _SERVER-29606: https://jira.mongodb.org/browse/SERVER-29606
+
+The fail point may be configured like so::
+
+    db.runCommand({
+        configureFailPoint: "onPrimaryTransactionalWrite",
+        mode: <string|document>,
+        data: <document>
+    });
+
+``mode`` is a generic fail point option and may be assigned a string or document
+value. The string values ``"alwaysOn"`` and ``"off"`` may be used to enable or
+disable the fail point, respectively. A document may be used to specify either
+``times`` or ``skip``, which are mutually exclusive:
+
+- ``{ times: <integer> }`` may be used to limit the number of times the fail
+  point may trigger before transitioning to ``"off"``.
+- ``{ skip: <integer> }`` may be used to defer the first trigger of a fail
+  point, after which it will transition to ``"alwaysOn"``.
+
+The ``data`` option is a document that may be used to specify options that
+control the fail point's behavior. As noted in `SERVER-29606`_,
+``onPrimaryTransactionalWrite`` supports the following ``data`` options, which
+may be combined if desired:
+
+- ``closeConnection``: Boolean option, which defaults to ``true``. If ``true``,
+  the connection on which the write is executed will be closed before a result
+  can be returned.
+- ``failBeforeCommitExceptionCode``: Integer option, which is unset by default.
+  If set, the specified exception code will be thrown and the write will not be
+  committed. If unset, the write will be allowed to commit.
+
+failCommand
+-----------
+
+Some tests depend on a server fail point, ``failCommand``, which allows the
+client to force the server to return an error. Unlike
+``onPrimaryTransactionalWrite``, ``failCommand`` does not allow the client to
+directly control whether the server will commit the operation (execution of the
+write depends on whether the ``closeConnection`` and/or ``errorCode`` options
+are specified). See: `failCommand <../../transactions/tests#failcommand>`_ in
+the Transactions spec test suite for more information.
+
+Disabling Fail Points after Test Execution
+------------------------------------------
+
+After each test that configures a fail point, drivers should disable the fail
+point to avoid spurious failures in subsequent tests. The fail point may be
+disabled like so::
+
+    db.runCommand({
+        configureFailPoint: <fail point name>,
+        mode: "off"
+    });
+
+Use as Integration Tests
+========================
+
+Integration tests are expressed in YAML and can be run against a replica set or
+sharded cluster as denoted by the top-level ``runOn`` field. Tests that rely on
+the ``onPrimaryTransactionalWrite`` fail point cannot be run against a sharded
+cluster because the fail point is not supported by mongos.
+
+The tests exercise the following scenarios:
+
+- Single-statement write operations
+
+  - Each test expecting a write result will encounter at-most one network error
+    for the write command. Retry attempts should return without error and allow
+    operation to succeed. Observation of the collection state will assert that
+    the write occurred at-most once.
+
+  - Each test expecting an error will encounter successive network errors for
+    the write command. Observation of the collection state will assert that the
+    write was never committed on the server.
+
+- Multi-statement write operations
+
+  - Each test expecting a write result will encounter at-most one network error
+    for some write command(s) in the batch. Retry attempts should return without
+    error and allow the batch to ultimately succeed. Observation of the
+    collection state will assert that each write occurred at-most once.
+
+  - Each test expecting an error will encounter successive network errors for
+    some write command in the batch. The batch will ultimately fail with an
+    error, but observation of the collection state will assert that the failing
+    write was never committed on the server. We may observe that earlier writes
+    in the batch occurred at-most once.
+
+We cannot test a scenario where the first and second attempts both encounter
+network errors but the write does actually commit during one of those attempts.
+This is because (1) the fail point only triggers when a write would be committed
+and (2) the skip and times options are mutually exclusive. That said, such a
+test would mainly assert the server's correctness for at-most once semantics and
+is not essential to assert driver correctness.
+
+Test Format
+-----------
+
+Each YAML file has the following keys:
+
+- ``runOn`` (optional): An array of server version and/or topology requirements
+  for which the tests can be run. If the test environment satisfies one or more
+  of these requirements, the tests may be executed; otherwise, this file should
+  be skipped. If this field is omitted, the tests can be assumed to have no
+  particular requirements and should be executed. Each element will have some or
+  all of the following fields:
+
+  - ``minServerVersion`` (optional): The minimum server version (inclusive)
+    required to successfully run the tests. If this field is omitted, it should
+    be assumed that there is no lower bound on the required server version.
+
+  - ``maxServerVersion`` (optional): The maximum server version (inclusive)
+    against which the tests can be run successfully. If this field is omitted,
+    it should be assumed that there is no upper bound on the required server
+    version.
+
+  - ``topology`` (optional): An array of server topologies against which the
+    tests can be run successfully. Valid topologies are "single", "replicaset",
+    and "sharded". If this field is omitted, the default is all topologies (i.e.
+    ``["single", "replicaset", "sharded"]``).
+
+- ``data``: The data that should exist in the collection under test before each
+  test run.
+
+- ``tests``: An array of tests that are to be run independently of each other.
+  Each test will have some or all of the following fields:
+
+  - ``description``: The name of the test.
+
+  - ``clientOptions``: Parameters to pass to MongoClient().
+
+  - ``useMultipleMongoses`` (optional): If ``true``, the MongoClient for this
+    test should be initialized with multiple mongos seed addresses. If ``false``
+    or omitted, only a single mongos address should be specified. This field has
+    no effect for non-sharded topologies.
+
+  - ``failPoint`` (optional): The ``configureFailPoint`` command document to run
+    to configure a fail point on the primary server. Drivers must ensure that
+    ``configureFailPoint`` is the first field in the command. This option and
+    ``useMultipleMongoses: true`` are mutually exclusive.
+
+  - ``operation``: Document describing the operation to be executed. The
+    operation should be executed through a collection object derived from a
+    client that has been created with ``clientOptions``. The operation will have
+    some or all of the following fields:
+
+    - ``name``: The name of the operation as defined in the CRUD specification.
+
+    - ``arguments``: The names and values of arguments from the CRUD
+      specification.
+
+  - ``outcome``: Document describing the return value and/or expected state of
+    the collection after the operation is executed. This will have some or all
+    of the following fields:
+
+    - ``error``: If ``true``, the test should expect an error or exception. Note
+      that some drivers may report server-side errors as a write error within a
+      write result object.
+
+    - ``result``: The return value from the operation. This will correspond to
+      an operation's result object as defined in the CRUD specification. This
+      field may be omitted if ``error`` is ``true``. If this field is present
+      and ``error`` is ``true`` (generally for multi-statement tests), the
+      result reports information about operations that succeeded before an
+      unrecoverable failure. In that case, drivers may choose to check the
+      result object if their BulkWriteException (or equivalent) provides access
+      to a write result object.
+
+      - ``errorLabelsContain``: A list of error label strings that the
+        error is expected to have.
+
+      - ``errorLabelsOmit``: A list of error label strings that the
+        error is expected not to have.
+
+    - ``collection``:
+
+      - ``name`` (optional): The name of the collection to verify. If this isn't
+        present then use the collection under test.
+
+      - ``data``: The data that should exist in the collection after the
+        operation has been run.
+
+Split Batch Tests
+=================
+
+The YAML tests specify bulk write operations that are split by command type
+(e.g. sequence of insert, update, and delete commands). Multi-statement write
+operations may also be split due to ``maxWriteBatchSize``,
+``maxBsonObjectSize``, or ``maxMessageSizeBytes``.
+
+For instance, an insertMany operation with five 10 MiB documents executed using
+OP_MSG payload type 0 (i.e. entire command in one document) would be split into
+five insert commands in order to respect the 16 MiB ``maxBsonObjectSize`` limit.
+The same insertMany operation executed using OP_MSG payload type 1 (i.e. command
+arguments pulled out into a separate payload vector) would be split into two
+insert commands in order to respect the 48 MB ``maxMessageSizeBytes`` limit.
+
+Noting when a driver might split operations, the ``onPrimaryTransactionalWrite``
+fail point's ``skip`` option may be used to control when the fail point first
+triggers. Once triggered, the fail point will transition to the ``alwaysOn``
+state until disabled. Driver authors should also note that the server attempts
+to process all documents in a single insert command within a single commit (i.e.
+one insert command with five documents may only trigger the fail point once).
+This behavior is unique to insert commands (each statement in an update and
+delete command is processed independently).
+
+If testing an insert that is split into two commands, a ``skip`` of one will
+allow the fail point to trigger on the second insert command (because all
+documents in the first command will be processed in the same commit). When
+testing an update or delete that is split into two commands, the ``skip`` should
+be set to the number of statements in the first command to allow the fail point
+to trigger on the second command.
+
+Command Construction Tests
+==========================
+
+Drivers should also assert that command documents are properly constructed with
+or without a transaction ID, depending on whether the write operation is
+supported. `Command Monitoring`_ may be used to check for the presence of a
+``txnNumber`` field in the command document. Note that command documents may
+always include an ``lsid`` field per the `Driver Session`_ specification.
+
+.. _Command Monitoring: ../../command-monitoring/command-monitoring.rst
+.. _Driver Session: ../../sessions/driver-sessions.rst
+
+These tests may be run against both a replica set and shard cluster.
+
+Drivers should test that transaction IDs are never included in commands for
+unsupported write operations:
+
+* Write commands with unacknowledged write concerns (e.g. ``{w: 0}``)
+
+* Unsupported single-statement write operations
+
+  - ``updateMany()``
+  - ``deleteMany()``
+
+* Unsupported multi-statement write operations
+
+  - ``bulkWrite()`` that includes ``UpdateMany`` or ``DeleteMany``
+
+* Unsupported write commands
+
+  - ``aggregate`` with write stage (e.g. ``$out``, ``$merge``)
+
+Drivers should test that transactions IDs are always included in commands for
+supported write operations:
+
+* Supported single-statement write operations
+
+  - ``insertOne()``
+  - ``updateOne()``
+  - ``replaceOne()``
+  - ``deleteOne()``
+  - ``findOneAndDelete()``
+  - ``findOneAndReplace()``
+  - ``findOneAndUpdate()``
+
+* Supported multi-statement write operations
+
+  - ``insertMany()`` with ``ordered=true``
+  - ``insertMany()`` with ``ordered=false``
+  - ``bulkWrite()`` with ``ordered=true`` (no ``UpdateMany`` or ``DeleteMany``)
+  - ``bulkWrite()`` with ``ordered=false`` (no ``UpdateMany`` or ``DeleteMany``)
+
+Prose Tests
+===========
+
+The following tests ensure that retryable writes work properly with replica sets
+and sharded clusters.
+
+#. Test that retryable writes raise an exception when using the MMAPv1 storage
+   engine. For this test, execute a write operation, such as ``insertOne``,
+   which should generate an exception. Assert that the error message is the
+   replacement error message::
+
+    This MongoDB deployment does not support retryable writes. Please add
+    retryWrites=false to your connection string.
+
+   and the error code is 20.
+
+Changelog
+=========
+
+:2019-10-21: Add ``errorLabelsContain`` and ``errorLabelsContain`` fields to ``result``
+
+:2019-08-07: Add Prose Tests section
+
+:2019-06-07: Mention $merge stage for aggregate alongside $out
+
+:2019-03-01: Add top-level ``runOn`` field to denote server version and/or
+             topology requirements requirements for the test file. Removes the
+             ``minServerVersion`` and ``maxServerVersion`` top-level fields,
+             which are now expressed within ``runOn`` elements.
+
+             Add test-level ``useMultipleMongoses`` field.

--- a/driver-core/src/test/resources/retryable-writes/bulkWrite-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/bulkWrite-errorLabels.json
@@ -1,0 +1,182 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1,
+          "insertedCount": 1,
+          "insertedIds": {
+            "1": 3
+          },
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/deleteOne-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/deleteOne-errorLabels.json
@@ -1,0 +1,106 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "DeleteOne succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "delete"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "deleteOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "DeleteOne fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "delete"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "deleteOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/findOneAndDelete-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndDelete-errorLabels.json
@@ -1,0 +1,117 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndDelete succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "findOneAndDelete",
+        "arguments": {
+          "filter": {
+            "x": {
+              "$gte": 11
+            }
+          },
+          "sort": {
+            "x": 1
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "_id": 1,
+          "x": 11
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndDelete fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "findOneAndDelete",
+        "arguments": {
+          "filter": {
+            "x": {
+              "$gte": 11
+            }
+          },
+          "sort": {
+            "x": 1
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/findOneAndReplace-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndReplace-errorLabels.json
@@ -1,0 +1,121 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndReplace succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "findOneAndReplace",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
+          },
+          "returnDocument": "Before"
+        }
+      },
+      "outcome": {
+        "result": {
+          "_id": 1,
+          "x": 11
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 111
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "findOneAndReplace",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
+          },
+          "returnDocument": "Before"
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/findOneAndUpdate-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndUpdate-errorLabels.json
@@ -1,0 +1,123 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndUpdate succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "findOneAndUpdate",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          },
+          "returnDocument": "Before"
+        }
+      },
+      "outcome": {
+        "result": {
+          "_id": 1,
+          "x": 11
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "findOneAndUpdate",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          },
+          "returnDocument": "Before"
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/insertMany-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/insertMany-errorLabels.json
@@ -1,0 +1,129 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    }
+  ],
+  "tests": [
+    {
+      "description": "InsertMany succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "insertedIds": {
+            "0": 2,
+            "1": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertMany fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/insertOne-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/insertOne-errorLabels.json
@@ -1,0 +1,90 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [],
+  "tests": [
+    {
+      "description": "InsertOne succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "insertOne",
+        "arguments": {
+          "document": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "insertedId": 1
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertOne fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "insertOne",
+        "arguments": {
+          "document": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/replaceOne-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/replaceOne-errorLabels.json
@@ -1,0 +1,120 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "ReplaceOne succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "replaceOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 0
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 111
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ReplaceOne fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "replaceOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/retryable-writes/updateOne-errorLabels.json
+++ b/driver-core/src/test/resources/retryable-writes/updateOne-errorLabels.json
@@ -1,0 +1,122 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "updateOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 0
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateOne fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "updateOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/transactions/error-labels.json
+++ b/driver-core/src/test/resources/transactions/error-labels.json
@@ -408,6 +408,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -461,7 +462,7 @@
       }
     },
     {
-      "description": "add transient label to connection errors",
+      "description": "add TransientTransactionError label to connection errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -663,7 +664,7 @@
       }
     },
     {
-      "description": "add unknown commit label to connection errors",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to connection errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -699,6 +700,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -801,7 +803,7 @@
       }
     },
     {
-      "description": "add unknown commit label to retryable commit errors",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to retryable commit errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -811,7 +813,10 @@
           "failCommands": [
             "commitTransaction"
           ],
-          "errorCode": 11602
+          "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operations": [
@@ -837,6 +842,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -939,7 +945,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError ShutdownInProgress",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to writeConcernError ShutdownInProgress",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -951,7 +957,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -985,6 +994,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -1089,7 +1099,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError WriteConcernFailed",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1138,6 +1148,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1220,7 +1231,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError WriteConcernFailed with wtimeout",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1273,6 +1284,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1355,7 +1367,7 @@
       }
     },
     {
-      "description": "omit unknown commit label to writeConcernError UnsatisfiableWriteConcern",
+      "description": "omit UnknownTransactionCommitResult label from writeConcernError UnsatisfiableWriteConcern",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1401,6 +1413,7 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
             ]
@@ -1461,7 +1474,7 @@
       }
     },
     {
-      "description": "omit unknown commit label to writeConcernError UnknownReplWriteConcern",
+      "description": "omit UnknownTransactionCommitResult label from writeConcernError UnknownReplWriteConcern",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1507,6 +1520,7 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteConcern",
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
             ]
@@ -1567,7 +1581,7 @@
       }
     },
     {
-      "description": "do not add unknown commit label to MaxTimeMSExpired inside transactions",
+      "description": "do not add UnknownTransactionCommitResult label to MaxTimeMSExpired inside transactions",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1614,6 +1628,7 @@
           },
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult",
               "TransientTransactionError"
             ]
@@ -1696,7 +1711,7 @@
       }
     },
     {
-      "description": "add unknown commit label to MaxTimeMSExpired",
+      "description": "add UnknownTransactionCommitResult label to MaxTimeMSExpired",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1743,6 +1758,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1827,7 +1843,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError MaxTimeMSExpired",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError MaxTimeMSExpired",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1877,6 +1893,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }

--- a/driver-core/src/test/resources/transactions/mongos-recovery-token.json
+++ b/driver-core/src/test/resources/transactions/mongos-recovery-token.json
@@ -181,7 +181,10 @@
                 ],
                 "writeConcernError": {
                   "code": 91,
-                  "errmsg": "Replication is being shut down"
+                  "errmsg": "Replication is being shut down",
+                  "errorLabels": [
+                    "RetryableWriteError"
+                  ]
                 }
               }
             }

--- a/driver-core/src/test/resources/transactions/retryable-abort-errorLabels.json
+++ b/driver-core/src/test/resources/transactions/retryable-abort-errorLabels.json
@@ -1,0 +1,209 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "abortTransaction only retries once with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "abortTransaction"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "abortTransaction does not retry without RetryableWriteError label",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "abortTransaction"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsOmit": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/transactions/retryable-abort.json
+++ b/driver-core/src/test/resources/transactions/retryable-abort.json
@@ -413,6 +413,9 @@
             "abortTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -514,6 +517,9 @@
             "abortTransaction"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -615,6 +621,9 @@
             "abortTransaction"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -716,6 +725,9 @@
             "abortTransaction"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -817,6 +829,9 @@
             "abortTransaction"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -918,6 +933,9 @@
             "abortTransaction"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1019,6 +1037,9 @@
             "abortTransaction"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1120,6 +1141,9 @@
             "abortTransaction"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1221,6 +1245,9 @@
             "abortTransaction"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1322,6 +1349,9 @@
             "abortTransaction"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1423,6 +1453,9 @@
             "abortTransaction"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1525,6 +1558,9 @@
           ],
           "writeConcernError": {
             "code": 11600,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1639,6 +1675,9 @@
           ],
           "writeConcernError": {
             "code": 11602,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1753,6 +1792,9 @@
           ],
           "writeConcernError": {
             "code": 189,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1867,6 +1909,9 @@
           ],
           "writeConcernError": {
             "code": 91,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/driver-core/src/test/resources/transactions/retryable-commit-errorLabels.json
+++ b/driver-core/src/test/resources/transactions/retryable-commit-errorLabels.json
@@ -1,0 +1,223 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "commitTransaction does not retry error without RetryableWriteError label",
+      "clientOptions": {
+        "retryWrites": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsOmit": [
+              "RetryableWriteError",
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "commitTransaction retries once with RetryableWriteError from server",
+      "clientOptions": {
+        "retryWrites": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/transactions/retryable-commit.json
+++ b/driver-core/src/test/resources/transactions/retryable-commit.json
@@ -57,6 +57,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -207,6 +208,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -353,7 +355,9 @@
           "result": {
             "errorCodeName": "Interrupted",
             "errorLabelsOmit": [
-              "TransientTransactionError"
+              "RetryableWriteError",
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
             ]
           }
         }
@@ -406,7 +410,7 @@
       }
     },
     {
-      "description": "commitTransaction fails after WriteConcernError Interrupted",
+      "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -417,8 +421,8 @@
             "commitTransaction"
           ],
           "writeConcernError": {
-            "code": 11601,
-            "errmsg": "operation was interrupted"
+            "code": 100,
+            "errmsg": "Not enough data-bearing nodes"
           }
         }
       },
@@ -452,7 +456,9 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
-              "TransientTransactionError"
+              "RetryableWriteError",
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
             ]
           }
         }
@@ -629,6 +635,9 @@
             "commitTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -737,6 +746,9 @@
             "commitTransaction"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -845,6 +857,9 @@
             "commitTransaction"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -953,6 +968,9 @@
             "commitTransaction"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1061,6 +1079,9 @@
             "commitTransaction"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1169,6 +1190,9 @@
             "commitTransaction"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1277,6 +1301,9 @@
             "commitTransaction"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1385,6 +1412,9 @@
             "commitTransaction"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1493,6 +1523,9 @@
             "commitTransaction"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1601,6 +1634,9 @@
             "commitTransaction"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1709,6 +1745,9 @@
             "commitTransaction"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1818,6 +1857,9 @@
           ],
           "writeConcernError": {
             "code": 11600,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1937,6 +1979,9 @@
           ],
           "writeConcernError": {
             "code": 11602,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2056,6 +2101,9 @@
           ],
           "writeConcernError": {
             "code": 189,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2175,6 +2223,9 @@
           ],
           "writeConcernError": {
             "code": 91,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/driver-core/src/test/unit/com/mongodb/internal/async/client/AsyncMongoCollectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/client/AsyncMongoCollectionSpecification.groovy
@@ -725,7 +725,7 @@ class AsyncMongoCollectionSpecification extends Specification {
     def 'deleteOne should translate BulkWriteException correctly'() {
         given:
         def bulkWriteException = new MongoBulkWriteException(acknowledged(0, 0, 1, null, [], []),
-                [], new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()), new ServerAddress())
+                [], new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()), new ServerAddress(), [] as Set)
 
         def executor = new TestOperationExecutor([bulkWriteException])
         def collection = new AsyncMongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
@@ -840,7 +840,7 @@ class AsyncMongoCollectionSpecification extends Specification {
     def 'replaceOne should translate BulkWriteException correctly'() {
         given:
         def bulkWriteException = new MongoBulkWriteException(bulkWriteResult, [],
-                new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()), new ServerAddress())
+                new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()), new ServerAddress(), [] as Set)
 
         def executor = new TestOperationExecutor([bulkWriteException])
         def collection = new AsyncMongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
@@ -972,14 +972,14 @@ class AsyncMongoCollectionSpecification extends Specification {
         where:
         executor << new TestOperationExecutor([new MongoBulkWriteException(acknowledged(INSERT, 1, 0, [], []),
                 [new BulkWriteError(11000, 'oops', new BsonDocument(), 0)],
-                null, new ServerAddress())])
+                null, new ServerAddress(), [] as Set)])
     }
 
     def 'should translate MongoBulkWriteException to MongoWriteConcernException'() {
         given:
         def executor = new TestOperationExecutor([new MongoBulkWriteException(acknowledged(INSERT, 1, 0, [], []), [],
                 new WriteConcernError(42, 'codeName', 'Message', new BsonDocument()),
-                new ServerAddress())])
+                new ServerAddress(), [] as Set)])
         def collection = new AsyncMongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
                 true, true, readConcern, uuidRepresentation, executor)
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BulkWriteBatchCombinerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BulkWriteBatchCombinerSpecification.groovy
@@ -101,7 +101,8 @@ class BulkWriteBatchCombinerSpecification extends Specification {
 
         then:
         def e = thrown(MongoBulkWriteException)
-        e == new MongoBulkWriteException(BulkWriteResult.acknowledged(INSERT, 0, 0, [], []), [], writeConcernError, new ServerAddress(), [] as Set)
+        e == new MongoBulkWriteException(BulkWriteResult.acknowledged(INSERT, 0, 0, [], []), [], writeConcernError,
+                new ServerAddress(), [] as Set)
     }
 
     def 'should not stop run if no errors'() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BulkWriteBatchCombinerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BulkWriteBatchCombinerSpecification.groovy
@@ -86,7 +86,7 @@ class BulkWriteBatchCombinerSpecification extends Specification {
 
         then:
         def e = thrown(MongoBulkWriteException)
-        e == new MongoBulkWriteException(BulkWriteResult.acknowledged(INSERT, 0, 0, [], []), [error], null, new ServerAddress())
+        e == new MongoBulkWriteException(BulkWriteResult.acknowledged(INSERT, 0, 0, [], []), [error], null, new ServerAddress(), [] as Set)
     }
 
     def 'should throw last write concern error'() {
@@ -101,7 +101,7 @@ class BulkWriteBatchCombinerSpecification extends Specification {
 
         then:
         def e = thrown(MongoBulkWriteException)
-        e == new MongoBulkWriteException(BulkWriteResult.acknowledged(INSERT, 0, 0, [], []), [], writeConcernError, new ServerAddress())
+        e == new MongoBulkWriteException(BulkWriteResult.acknowledged(INSERT, 0, 0, [], []), [], writeConcernError, new ServerAddress(), [] as Set)
     }
 
     def 'should not stop run if no errors'() {

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableWritesTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableWritesTest.java
@@ -17,11 +17,15 @@
 package com.mongodb.client;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.MongoWriteConcernException;
 import com.mongodb.client.test.CollectionHelper;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
+import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.Document;
@@ -45,6 +49,8 @@ import static com.mongodb.JsonTestServerVersionChecker.skipTest;
 import static com.mongodb.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 // See https://github.com/mongodb/specifications/tree/master/source/retryable-writes/tests
@@ -87,13 +93,15 @@ public abstract class AbstractRetryableWritesTest {
         }
         mongoClient = createMongoClient(builder.build());
 
-        List<BsonDocument> documents = new ArrayList<BsonDocument>();
+        List<BsonDocument> documents = new ArrayList<>();
         for (BsonValue document : data) {
             documents.add(document.asDocument());
         }
 
         collectionHelper.drop();
-        collectionHelper.insertDocuments(documents);
+        if (!documents.isEmpty()) {
+            collectionHelper.insertDocuments(documents);
+        }
 
         MongoDatabase database = mongoClient.getDatabase(databaseName);
         collection = database.getCollection(collectionName, BsonDocument.class);
@@ -125,22 +133,114 @@ public abstract class AbstractRetryableWritesTest {
         boolean wasException = false;
         try {
             result = helper.getOperationResults(operation);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             wasException = true;
+            assertExceptionState(e, outcome.get("result", new BsonNull()), operation.getString("name").getValue());
+        }
+
+        if (outcome.getBoolean("error", BsonBoolean.FALSE).getValue()) {
+            assertEquals("Expected an error to be thrown", outcome.containsKey("error"), wasException);
+        } else {
+            BsonDocument fixedExpectedResult = outcome.getDocument("result", new BsonDocument());
+            assertEquals(fixedExpectedResult, result.getDocument("result", new BsonDocument()));
         }
 
         if (outcome.containsKey("collection")) {
             List<BsonDocument> collectionData = collection.withDocumentClass(BsonDocument.class).find().into(new ArrayList<BsonDocument>());
             assertEquals(outcome.getDocument("collection").getArray("data").getValues(), collectionData);
         }
+    }
 
-        if (outcome.getBoolean("error", BsonBoolean.FALSE).getValue()) {
-            assertEquals(outcome.containsKey("error"), wasException);
-        } else {
-            BsonDocument fixedExpectedResult = outcome.getDocument("result", new BsonDocument());
-            assertEquals(fixedExpectedResult, result.getDocument("result", new BsonDocument()));
+    private void assertExceptionState(final RuntimeException e, final BsonValue expectedResult, final String operationName) {
+        if (hasErrorLabelsContainField(expectedResult)) {
+            if (e instanceof MongoException) {
+                MongoException mongoException = (MongoException) e;
+                for (String curErrorLabel : getErrorLabelsContainField(expectedResult)) {
+                    assertTrue(String.format("Expected error label '%s but found labels '%s' for operation %s",
+                            curErrorLabel, mongoException.getErrorLabels(), operationName),
+                            mongoException.hasErrorLabel(curErrorLabel));
+                }
+            }
+        }
+        if (hasErrorLabelsOmitField(expectedResult)) {
+            if (e instanceof MongoException) {
+                MongoException mongoException = (MongoException) e;
+                for (String curErrorLabel : getErrorLabelsOmitField(expectedResult)) {
+                    assertFalse(String.format("Expected error label '%s omitted but found labels '%s' for operation %s",
+                            curErrorLabel, mongoException.getErrorLabels(), operationName),
+                            mongoException.hasErrorLabel(curErrorLabel));
+                }
+            }
+        }
+        if (hasErrorContainsField(expectedResult)) {
+            String expectedError = getErrorContainsField(expectedResult);
+            assertTrue(String.format("Expected '%s' but got '%s' for operation %s", expectedError, e.getMessage(),
+                    operationName), e.getMessage().toLowerCase().contains(expectedError.toLowerCase()));
+        }
+        if (hasErrorCodeNameField(expectedResult)) {
+            String expectedErrorCodeName = getErrorCodeNameField(expectedResult);
+            if (e instanceof MongoCommandException) {
+                assertEquals(expectedErrorCodeName, ((MongoCommandException) e).getErrorCodeName());
+            } else if (e instanceof MongoWriteConcernException) {
+                assertEquals(expectedErrorCodeName, ((MongoWriteConcernException) e).getWriteConcernError().getCodeName());
+            }
         }
     }
+
+
+    private String getErrorContainsField(final BsonValue expectedResult) {
+        return getErrorField(expectedResult, "errorContains");
+    }
+
+    private String getErrorCodeNameField(final BsonValue expectedResult) {
+        return getErrorField(expectedResult, "errorCodeName");
+    }
+
+    private String getErrorField(final BsonValue expectedResult, final String key) {
+        if (hasErrorField(expectedResult, key)) {
+            return expectedResult.asDocument().getString(key).getValue();
+        } else {
+            return "";
+        }
+    }
+
+    private boolean hasErrorLabelsContainField(final BsonValue expectedResult) {
+        return hasErrorField(expectedResult, "errorLabelsContain");
+    }
+
+    private List<String> getErrorLabelsContainField(final BsonValue expectedResult) {
+        return getListOfStringsFromBsonArrays(expectedResult.asDocument(), "errorLabelsContain");
+    }
+
+    private boolean hasErrorLabelsOmitField(final BsonValue expectedResult) {
+        return hasErrorField(expectedResult, "errorLabelsOmit");
+    }
+
+    private List<String> getErrorLabelsOmitField(final BsonValue expectedResult) {
+        return getListOfStringsFromBsonArrays(expectedResult.asDocument(), "errorLabelsOmit");
+    }
+
+
+    private List<String> getListOfStringsFromBsonArrays(final BsonDocument expectedResult, final String arrayFieldName) {
+        List<String> errorLabelContainsList = new ArrayList<String>();
+        for (BsonValue cur : expectedResult.asDocument().getArray(arrayFieldName)) {
+            errorLabelContainsList.add(cur.asString().getValue());
+        }
+        return errorLabelContainsList;
+    }
+
+    private boolean hasErrorContainsField(final BsonValue expectedResult) {
+        return hasErrorField(expectedResult, "errorContains");
+    }
+
+    private boolean hasErrorCodeNameField(final BsonValue expectedResult) {
+        return hasErrorField(expectedResult, "errorCodeName");
+    }
+
+    private boolean hasErrorField(final BsonValue expectedResult, final String key) {
+        return expectedResult != null && expectedResult.isDocument() && expectedResult.asDocument().containsKey(key);
+    }
+
 
     @Parameterized.Parameters(name = "{1}")
     public static Collection<Object[]> data() throws URISyntaxException, IOException {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -727,7 +727,7 @@ class MongoCollectionSpecification extends Specification {
     def 'deleteOne should translate BulkWriteException correctly'() {
         given:
         def bulkWriteException = new MongoBulkWriteException(acknowledged(0, 0, 1, null, [], []),
-                [], new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()), new ServerAddress())
+                [], new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()), new ServerAddress(), [] as Set)
 
         def executor = new TestOperationExecutor([bulkWriteException])
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
@@ -834,7 +834,7 @@ class MongoCollectionSpecification extends Specification {
         given:
         def bulkWriteException = new MongoBulkWriteException(bulkWriteResult, [],
                                                              new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()),
-                                                             new ServerAddress())
+                                                             new ServerAddress(), [] as Set)
 
         def executor = new TestOperationExecutor([bulkWriteException])
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
@@ -972,14 +972,14 @@ class MongoCollectionSpecification extends Specification {
         executor << new TestOperationExecutor([new MongoBulkWriteException(acknowledged(INSERT, 1, 0, [], []),
                 [new BulkWriteError(11000, 'oops',
                         new BsonDocument(), 0)],
-                null, new ServerAddress())])
+                null, new ServerAddress(), [] as Set)])
     }
 
     def 'should translate MongoBulkWriteException to MongoWriteConcernException'() {
         given:
         def executor = new TestOperationExecutor([new MongoBulkWriteException(acknowledged(INSERT, 1, 0, [], []), [],
                 new WriteConcernError(42, 'codeName', 'Message', new BsonDocument()),
-                new ServerAddress())])
+                new ServerAddress(), [] as Set)])
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
                 true, true, readConcern, JAVA_LEGACY, executor)
 


### PR DESCRIPTION
JAVA-3531

- https://evergreen.mongodb.com/version/5e4424dad6d80a50e75caa31
  - MongoDB latest all failed - missing errorLabel when creating `MongoBulkWriteException`
- https://evergreen.mongodb.com/version/5e4528c4c9ec441bdbe921f7
  - CodeNarc and MongoDB latest Sharding failed due to: SPEC-1565
- https://evergreen.mongodb.com/version/5e452eb0c9ec441bdbe92cc2


Includes test changes from: mongodb/specifications#737