### PR TITLE
Added Projections.meta to support future $meta projections

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Projections.java
+++ b/driver-core/src/main/com/mongodb/client/model/Projections.java
@@ -133,6 +133,19 @@ public final class Projections {
     }
 
     /**
+     * Creates a $meta projection to the given field name for the given meta field name.
+     *
+     * @param fieldName the field name
+     * @param metaFieldName the meta field name
+     * @return the projection
+     * @mongodb.driver.manual reference/operator/projection/meta/#projection
+     * @since 4.1
+     */
+    public static Bson meta(final String fieldName, final String metaFieldName) {
+        return new BsonDocument(fieldName, new BsonDocument("$meta", new BsonString(metaFieldName)));
+    }
+
+    /**
      * Creates a projection to the given field name of the textScore, for use with text queries.
      *
      * @param fieldName the field name
@@ -140,7 +153,7 @@ public final class Projections {
      * @mongodb.driver.manual reference/operator/projection/meta/#projection textScore
      */
     public static Bson metaTextScore(final String fieldName) {
-        return new BsonDocument(fieldName, new BsonDocument("$meta", new BsonString("textScore")));
+        return meta(fieldName, "textScore");
     }
 
     /**

--- a/driver-core/src/test/unit/com/mongodb/client/model/ProjectionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/ProjectionsSpecification.groovy
@@ -28,6 +28,7 @@ import static com.mongodb.client.model.Projections.exclude
 import static com.mongodb.client.model.Projections.excludeId
 import static com.mongodb.client.model.Projections.fields
 import static com.mongodb.client.model.Projections.include
+import static com.mongodb.client.model.Projections.meta
 import static com.mongodb.client.model.Projections.metaTextScore
 import static com.mongodb.client.model.Projections.slice
 import static org.bson.BsonDocument.parse
@@ -69,6 +70,12 @@ class ProjectionsSpecification extends Specification {
         expect:
         toBson(slice('x', 5)) == parse('{x : {$slice : 5}}')
         toBson(slice('x', 5, 10)) == parse('{x : {$slice : [5, 10]}}')
+    }
+
+    def 'meta'() {
+        expect:
+        toBson(meta('x', 'textScore')) == parse('{x : {$meta : "textScore"}}')
+        toBson(meta('x', 'recordId')) == parse('{x : {$meta : "recordId"}}')
     }
 
     def 'metaTextScore'() {

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Projections.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Projections.scala
@@ -90,6 +90,17 @@ object Projections {
   def elemMatch(fieldName: String, filter: Bson): Bson = JProjections.elemMatch(fieldName, filter)
 
   /**
+   * Creates a \$meta projection to the given field name for the given meta field name.
+   *
+   * @param fieldName the field name
+   * @param metaFieldName the meta field name
+   * @return the projection
+   * @see [[http://http://docs.mongodb.org/manual/reference/operator/projection/meta/#projection meta]]
+   * @since 4.1
+   */
+  def meta(fieldName: String, metaFieldName: String): Bson = JProjections.meta(fieldName, metaFieldName)
+
+  /**
    * Creates a projection to the given field name of the textScore, for use with text queries.
    *
    * @param fieldName the field name


### PR DESCRIPTION
JAVA-3445

Rather than adding support for all different meta projections (https://github.com/mongodb/mongo/blob/0e6b9119f4d3a0fae681ed28220bc55ed1469f81/src/mongo/db/pipeline/expression.cpp#L2528-L2536) I added a simple meta one.