### PR TITLE
Ensure async bindings are released before calling callback

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/OperationExecutorImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/OperationExecutorImpl.java
@@ -86,13 +86,10 @@ class OperationExecutorImpl implements OperationExecutor {
                                             operation.executeAsync(binding, new SingleResultCallback<T>() {
                                                 @Override
                                                 public void onResult(final T result, final Throwable t) {
-                                                    try {
-                                                        labelException(t, session);
-                                                        unpinServerAddressOnTransientTransactionError(session, t);
-                                                        errHandlingCallback.onResult(result, t);
-                                                    } finally {
-                                                        binding.release();
-                                                    }
+                                                    labelException(session, t);
+                                                    unpinServerAddressOnTransientTransactionError(session, t);
+                                                    binding.release();
+                                                    errHandlingCallback.onResult(result, t);
                                                 }
                                             });
                                         }
@@ -132,13 +129,10 @@ class OperationExecutorImpl implements OperationExecutor {
                                         operation.executeAsync(binding, new SingleResultCallback<T>() {
                                             @Override
                                             public void onResult(final T result, final Throwable t) {
-                                                try {
-                                                    labelException(t, session);
-                                                    unpinServerAddressOnTransientTransactionError(session, t);
-                                                    errHandlingCallback.onResult(result, t);
-                                                } finally {
-                                                    binding.release();
-                                                }
+                                                labelException(session, t);
+                                                unpinServerAddressOnTransientTransactionError(session, t);
+                                                binding.release();
+                                                errHandlingCallback.onResult(result, t);
                                             }
                                         });
                                     }
@@ -149,7 +143,7 @@ class OperationExecutorImpl implements OperationExecutor {
         });
     }
 
-    private void labelException(final Throwable t, final AsyncClientSession session) {
+    private void labelException(@Nullable final AsyncClientSession session, @Nullable final Throwable t) {
         if (session != null && session.hasActiveTransaction()
                 && (t instanceof MongoSocketException || t instanceof MongoTimeoutException
                 || (t instanceof MongoQueryException && ((MongoQueryException) t).getErrorCode() == 91))
@@ -158,8 +152,9 @@ class OperationExecutorImpl implements OperationExecutor {
         }
     }
 
-    private void unpinServerAddressOnTransientTransactionError(final @Nullable AsyncClientSession session, final Throwable throwable) {
-        if (session != null && throwable != null && throwable instanceof MongoException
+    private void unpinServerAddressOnTransientTransactionError(@Nullable final AsyncClientSession session,
+                                                               @Nullable final Throwable throwable) {
+        if (session != null && throwable instanceof MongoException
                 && ((MongoException) throwable).hasErrorLabel(TRANSIENT_TRANSACTION_ERROR_LABEL)) {
             session.setPinnedServerAddress(null);
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractUnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractUnifiedTest.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.mongodb.ClusterFixture.getConnectionString;
 import static com.mongodb.ClusterFixture.getMultiMongosConnectionString;
@@ -414,11 +415,18 @@ public abstract class AbstractUnifiedTest {
                         }
                     } else if (operationName.equals("assertDifferentLsidOnLastTwoCommands")) {
                         List<CommandEvent> events = lastTwoCommandEvents();
-                        assertNotEquals(((CommandStartedEvent) events.get(0)).getCommand().getDocument("lsid"),
+                        String eventsJson = commandListener.getCommandStartedEvents().stream()
+                                .map(e -> ((CommandStartedEvent) e).getCommand().toJson())
+                                .collect(Collectors.joining(", "));
+
+                        assertNotEquals(eventsJson, ((CommandStartedEvent) events.get(0)).getCommand().getDocument("lsid"),
                                 ((CommandStartedEvent) events.get(1)).getCommand().getDocument("lsid"));
                     } else if (operationName.equals("assertSameLsidOnLastTwoCommands")) {
                         List<CommandEvent> events = lastTwoCommandEvents();
-                        assertEquals(((CommandStartedEvent) events.get(0)).getCommand().getDocument("lsid"),
+                        String eventsJson = commandListener.getCommandStartedEvents().stream()
+                                        .map(e -> ((CommandStartedEvent) e).getCommand().toJson())
+                                        .collect(Collectors.joining(", "));
+                        assertEquals(eventsJson, ((CommandStartedEvent) events.get(0)).getCommand().getDocument("lsid"),
                                 ((CommandStartedEvent) events.get(1)).getCommand().getDocument("lsid"));
                     } else if (operationName.equals("assertSessionDirty")) {
                         assertNotNull(clientSession);


### PR DESCRIPTION
JAVA-3662

https://evergreen.mongodb.com/version/5eaa98830ae60654f81ad5e3

Took me a while to nail the cause, but if you want to replicate just add a sleep in the original code before the binding.release() is called.

There is a race condition. Two threads:

| Scenario |
| --- |
| _t1_ - Subscribe to Publisher from the SyncMongoCollection implementation and wait on a countdownlatch before continuing. |
| _t2_ - Calls the callback with the result, which sets the result and counts down the latch. |

**RACE** Now a race happens, with either scenario happening:

| Scenario A | Scenario B |
| --- | --- |
| _t2_ - the binding is released. | _t1_ latch counted down and continues to next operation |
| _t1_ latch counted down and continues to next operation | _t2_ - the binding is released. |

The test fails when _Scenario B_ occurs