### PR TITLE
Revendored tlschannel

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -107,27 +107,33 @@ https://github.com/mongodb/mongo-java-driver.
 
 7) The following files (originally from https://github.com/marianobarrios/tls-channel):
 
-       AsynchronousTlsChannel.java
-       AsynchronousTlsChannelGroup.java
-       ExtendedAsynchronousByteChannel.java
-       BufferHolder.java
-       ByteBufferSet.java
-       ByteBufferUtil.java
-       TlsChannelImpl.java
-       TlsChannelCallbackException.java
-       Util.java
-       BufferAllocator.java
-       ClientTlsChannel.java
-       NeedsReadException.java
-       NeedsTaskException.java
-       NeedsWriteException.java
-       TlsChannel.java
-       TlsChannelBuilder.java
-       TlsChannelFlowControlException.java
-       TrackingAllocator.java
-       WouldBlockException.java
+        AsynchronousTlsChannel.java
+        AsynchronousTlsChannelGroup.java
+        BufferAllocator.java
+        BufferHolder.java
+        ByteBufferSet.java
+        ByteBufferUtil.java
+        ClientTlsChannel.java
+        DirectBufferAllocator.java
+        DirectBufferDeallocator.java
+        ExtendedAsynchronousByteChannel.java
+        HeapBufferAllocator.java
+        NeedsReadException.java
+        NeedsTaskException.java
+        NeedsWriteException.java
+        ServerTlsChannel.java
+        SniSslContextFactory.java
+        TlsChannel.java
+        TlsChannelBuilder.java
+        TlsChannelCallbackException.java
+        TlsChannelFlowControlException.java
+        TlsChannelImpl.java
+        TlsExplorer.java
+        TrackingAllocator.java
+        Util.java
+        WouldBlockException.java
 
-     Copyright (c) [2015-2018] all contributors
+     Copyright (c) [2015-2020] all contributors
 
      MIT License
 

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,11 @@ configure(javaMainProjects) {
         options.fork = true
         options.debug = true
         options.compilerArgs = ['-Xlint:all']
+
+        // http://openjdk.java.net/jeps/247
+        if (JavaVersion.current().ordinal() > JavaVersion.VERSION_1_8.ordinal()) {
+            options.compilerArgs.addAll(['--release', '8'])
+        }
     }
 }
 

--- a/config/checkstyle-exclude.xml
+++ b/config/checkstyle-exclude.xml
@@ -22,7 +22,7 @@
 
 <suppressions>
 
-    <suppress checks="VisibilityModifier" files="com[\\/]mongodb[\\/]internal[\\/]connection[\\/]tlschannel[\\/]"/>
+    <suppress checks="[a-zA-Z0-9]*" files="com[\\/]mongodb[\\/]internal[\\/]connection[\\/]tlschannel[\\/]"/>
 
     <suppress checks="MethodLength" files="QuickTour"/>
     <suppress checks="Regexp" files="Tour"/>

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/ClientTlsChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/ClientTlsChannel.java
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
 package com.mongodb.internal.connection.tlschannel;
 
-import com.mongodb.internal.connection.tlschannel.impl.BufferHolder;
 import com.mongodb.internal.connection.tlschannel.impl.ByteBufferSet;
 import com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl;
 
@@ -34,196 +33,199 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-/**
- * A client-side {@link TlsChannel}.
- */
-public final class ClientTlsChannel implements TlsChannel {
+/** A client-side {@link TlsChannel}. */
+public class ClientTlsChannel implements TlsChannel {
 
-    /**
-     * Builder of {@link ClientTlsChannel}
-     */
-    public static final class Builder extends TlsChannelBuilder<Builder> {
+  /** Builder of {@link ClientTlsChannel} */
+  public static class Builder extends TlsChannelBuilder<Builder> {
 
-        private Supplier<SSLEngine> sslEngineFactory;
+    private final Supplier<SSLEngine> sslEngineFactory;
 
-        private Builder(final ByteChannel underlying, final SSLEngine sslEngine) {
-            super(underlying);
-            this.sslEngineFactory = new Supplier<SSLEngine>() {
-                @Override
-                public SSLEngine get() {
-                    return sslEngine;
-                }
-            };
-        }
-
-        private Builder(final ByteChannel underlying, final SSLContext sslContext) {
-            super(underlying);
-            this.sslEngineFactory = new Supplier<SSLEngine>() {
-                @Override
-                public SSLEngine get() {
-                    return defaultSSLEngineFactory(sslContext);
-                }
-            };
-        }
-
-        @Override
-        Builder getThis() {
-            return this;
-        }
-
-        public ClientTlsChannel build() {
-            return new ClientTlsChannel(underlying, sslEngineFactory.get(), sessionInitCallback, runTasks,
-                    plainBufferAllocator, encryptedBufferAllocator, releaseBuffers, waitForCloseConfirmation);
-        }
-
+    private Builder(ByteChannel underlying, SSLEngine sslEngine) {
+      super(underlying);
+      this.sslEngineFactory = () -> sslEngine;
     }
 
-    private static SSLEngine defaultSSLEngineFactory(final SSLContext sslContext) {
-        SSLEngine engine = sslContext.createSSLEngine();
-        engine.setUseClientMode(true);
-        return engine;
-    }
-
-    /**
-     * Create a new {@link Builder}, configured with a underlying
-     * {@link Channel} and a fixed {@link SSLEngine}.
-     *
-     * @param underlying a reference to the underlying {@link ByteChannel}
-     * @param sslEngine  the engine to use with this channel
-     */
-    public static Builder newBuilder(final ByteChannel underlying, final SSLEngine sslEngine) {
-        return new Builder(underlying, sslEngine);
-    }
-
-    /**
-     * Create a new {@link Builder}, configured with a underlying
-     * {@link Channel} and a {@link SSLContext}.
-     *
-     * @param underlying a reference to the underlying {@link ByteChannel}
-     * @param sslContext a context to use with this channel, it will be used to create a client {@link SSLEngine}.
-     */
-    public static Builder newBuilder(final ByteChannel underlying, final SSLContext sslContext) {
-        return new Builder(underlying, sslContext);
-    }
-
-    private final ByteChannel underlying;
-    private final TlsChannelImpl impl;
-
-    private ClientTlsChannel(
-            final ByteChannel underlying,
-            final SSLEngine engine,
-            final Consumer<SSLSession> sessionInitCallback,
-            final boolean runTasks,
-            final BufferAllocator plainBufAllocator,
-            final BufferAllocator encryptedBufAllocator,
-            final boolean releaseBuffers,
-            final boolean waitForCloseNotifyOnClose) {
-        if (!engine.getUseClientMode()) {
-            throw new IllegalArgumentException("SSLEngine must be in client mode");
-        }
-        this.underlying = underlying;
-        TrackingAllocator trackingPlainBufAllocator = new TrackingAllocator(plainBufAllocator);
-        TrackingAllocator trackingEncryptedAllocator = new TrackingAllocator(encryptedBufAllocator);
-        impl = new TlsChannelImpl(underlying, underlying, engine, Optional.<BufferHolder>empty(), sessionInitCallback, runTasks,
-                trackingPlainBufAllocator, trackingEncryptedAllocator, releaseBuffers, waitForCloseNotifyOnClose);
+    private Builder(ByteChannel underlying, SSLContext sslContext) {
+      super(underlying);
+      this.sslEngineFactory = () -> defaultSSLEngineFactory(sslContext);
     }
 
     @Override
-    public ByteChannel getUnderlying() {
-        return underlying;
+    Builder getThis() {
+      return this;
     }
 
-    @Override
-    public SSLEngine getSslEngine() {
-        return impl.engine();
+    public ClientTlsChannel build() {
+      return new ClientTlsChannel(
+          underlying,
+          sslEngineFactory.get(),
+          sessionInitCallback,
+          runTasks,
+          plainBufferAllocator,
+          encryptedBufferAllocator,
+          releaseBuffers,
+          waitForCloseConfirmation);
     }
+  }
 
-    @Override
-    public Consumer<SSLSession> getSessionInitCallback() {
-        return impl.getSessionInitCallback();
-    }
+  private static SSLEngine defaultSSLEngineFactory(SSLContext sslContext) {
+    SSLEngine engine = sslContext.createSSLEngine();
+    engine.setUseClientMode(true);
+    return engine;
+  }
 
-    @Override
-    public TrackingAllocator getPlainBufferAllocator() {
-        return impl.getPlainBufferAllocator();
-    }
+  /**
+   * Create a new {@link Builder}, configured with a underlying {@link Channel} and a fixed {@link
+   * SSLEngine}.
+   *
+   * @param underlying a reference to the underlying {@link ByteChannel}
+   * @param sslEngine the engine to use with this channel
+   * @return the new builder
+   */
+  public static Builder newBuilder(ByteChannel underlying, SSLEngine sslEngine) {
+    return new Builder(underlying, sslEngine);
+  }
 
-    @Override
-    public TrackingAllocator getEncryptedBufferAllocator() {
-        return impl.getEncryptedBufferAllocator();
-    }
+  /**
+   * Create a new {@link Builder}, configured with a underlying {@link Channel} and a {@link
+   * SSLContext}.
+   *
+   * @param underlying a reference to the underlying {@link ByteChannel}
+   * @param sslContext a context to use with this channel, it will be used to create a client {@link
+   *     SSLEngine}.
+   * @return the new builder
+   */
+  public static Builder newBuilder(ByteChannel underlying, SSLContext sslContext) {
+    return new Builder(underlying, sslContext);
+  }
 
-    @Override
-    public boolean getRunTasks() {
-        return impl.getRunTasks();
-    }
+  private final ByteChannel underlying;
+  private final TlsChannelImpl impl;
 
-    @Override
-    public long read(final ByteBuffer[] dstBuffers, final int offset, final int length) throws IOException {
-        ByteBufferSet dest = new ByteBufferSet(dstBuffers, offset, length);
-        TlsChannelImpl.checkReadBuffer(dest);
-        return impl.read(dest);
-    }
+  private ClientTlsChannel(
+      ByteChannel underlying,
+      SSLEngine engine,
+      Consumer<SSLSession> sessionInitCallback,
+      boolean runTasks,
+      BufferAllocator plainBufAllocator,
+      BufferAllocator encryptedBufAllocator,
+      boolean releaseBuffers,
+      boolean waitForCloseNotifyOnClose) {
+    if (!engine.getUseClientMode())
+      throw new IllegalArgumentException("SSLEngine must be in client mode");
+    this.underlying = underlying;
+    TrackingAllocator trackingPlainBufAllocator = new TrackingAllocator(plainBufAllocator);
+    TrackingAllocator trackingEncryptedAllocator = new TrackingAllocator(encryptedBufAllocator);
+    impl =
+        new TlsChannelImpl(
+            underlying,
+            underlying,
+            engine,
+            Optional.empty(),
+            sessionInitCallback,
+            runTasks,
+            trackingPlainBufAllocator,
+            trackingEncryptedAllocator,
+            releaseBuffers,
+            waitForCloseNotifyOnClose);
+  }
 
-    @Override
-    public long read(final ByteBuffer[] dstBuffers) throws IOException {
-        return read(dstBuffers, 0, dstBuffers.length);
-    }
+  @Override
+  public ByteChannel getUnderlying() {
+    return underlying;
+  }
 
-    @Override
-    public int read(final ByteBuffer dstBuffer) throws IOException {
-        return (int) read(new ByteBuffer[]{dstBuffer});
-    }
+  @Override
+  public SSLEngine getSslEngine() {
+    return impl.engine();
+  }
 
-    @Override
-    public long write(final ByteBuffer[] srcBuffers, final int offset, final int length) throws IOException {
-        ByteBufferSet source = new ByteBufferSet(srcBuffers, offset, length);
-        return impl.write(source);
-    }
+  @Override
+  public Consumer<SSLSession> getSessionInitCallback() {
+    return impl.getSessionInitCallback();
+  }
 
-    @Override
-    public long write(final ByteBuffer[] outs) throws IOException {
-        return write(outs, 0, outs.length);
-    }
+  @Override
+  public TrackingAllocator getPlainBufferAllocator() {
+    return impl.getPlainBufferAllocator();
+  }
 
-    @Override
-    public int write(final ByteBuffer srcBuffer) throws IOException {
-        return (int) write(new ByteBuffer[]{srcBuffer});
-    }
+  @Override
+  public TrackingAllocator getEncryptedBufferAllocator() {
+    return impl.getEncryptedBufferAllocator();
+  }
 
-    @Override
-    public void renegotiate() throws IOException {
-        impl.renegotiate();
-    }
+  @Override
+  public boolean getRunTasks() {
+    return impl.getRunTasks();
+  }
 
-    @Override
-    public void handshake() throws IOException {
-        impl.handshake();
-    }
+  @Override
+  public long read(ByteBuffer[] dstBuffers, int offset, int length) throws IOException {
+    ByteBufferSet dest = new ByteBufferSet(dstBuffers, offset, length);
+    TlsChannelImpl.checkReadBuffer(dest);
+    return impl.read(dest);
+  }
 
-    @Override
-    public void close() throws IOException {
-        impl.close();
-    }
+  @Override
+  public long read(ByteBuffer[] dstBuffers) throws IOException {
+    return read(dstBuffers, 0, dstBuffers.length);
+  }
 
-    @Override
-    public boolean isOpen() {
-        return impl.isOpen();
-    }
+  @Override
+  public int read(ByteBuffer dstBuffer) throws IOException {
+    return (int) read(new ByteBuffer[] {dstBuffer});
+  }
 
-    @Override
-    public boolean shutdown() throws IOException {
-        return impl.shutdown();
-    }
+  @Override
+  public long write(ByteBuffer[] srcBuffers, int offset, int length) throws IOException {
+    ByteBufferSet source = new ByteBufferSet(srcBuffers, offset, length);
+    return impl.write(source);
+  }
 
-    @Override
-    public boolean shutdownReceived() {
-        return impl.shutdownReceived();
-    }
+  @Override
+  public long write(ByteBuffer[] outs) throws IOException {
+    return write(outs, 0, outs.length);
+  }
 
-    @Override
-    public boolean shutdownSent() {
-        return impl.shutdownSent();
-    }
+  @Override
+  public int write(ByteBuffer srcBuffer) throws IOException {
+    return (int) write(new ByteBuffer[] {srcBuffer});
+  }
 
+  @Override
+  public void renegotiate() throws IOException {
+    impl.renegotiate();
+  }
+
+  @Override
+  public void handshake() throws IOException {
+    impl.handshake();
+  }
+
+  @Override
+  public void close() throws IOException {
+    impl.close();
+  }
+
+  @Override
+  public boolean isOpen() {
+    return impl.isOpen();
+  }
+
+  @Override
+  public boolean shutdown() throws IOException {
+    return impl.shutdown();
+  }
+
+  @Override
+  public boolean shutdownReceived() {
+    return impl.shutdownReceived();
+  }
+
+  @Override
+  public boolean shutdownSent() {
+    return impl.shutdownSent();
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/ClientTlsChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/ClientTlsChannel.java
@@ -21,6 +21,8 @@ package com.mongodb.internal.connection.tlschannel;
 
 import com.mongodb.internal.connection.tlschannel.impl.ByteBufferSet;
 import com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl;
+import com.mongodb.internal.connection.tlschannel.mongo.ByteBufAllocator;
+import com.mongodb.internal.connection.tlschannel.mongo.TrackingByteBufAllocator;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -108,15 +110,15 @@ public class ClientTlsChannel implements TlsChannel {
       SSLEngine engine,
       Consumer<SSLSession> sessionInitCallback,
       boolean runTasks,
-      BufferAllocator plainBufAllocator,
-      BufferAllocator encryptedBufAllocator,
+      ByteBufAllocator plainBufAllocator,
+      ByteBufAllocator encryptedBufAllocator,
       boolean releaseBuffers,
       boolean waitForCloseNotifyOnClose) {
     if (!engine.getUseClientMode())
       throw new IllegalArgumentException("SSLEngine must be in client mode");
     this.underlying = underlying;
-    TrackingAllocator trackingPlainBufAllocator = new TrackingAllocator(plainBufAllocator);
-    TrackingAllocator trackingEncryptedAllocator = new TrackingAllocator(encryptedBufAllocator);
+    TrackingByteBufAllocator trackingPlainBufAllocator = new TrackingByteBufAllocator(plainBufAllocator);
+    TrackingByteBufAllocator trackingEncryptedAllocator = new TrackingByteBufAllocator(encryptedBufAllocator);
     impl =
         new TlsChannelImpl(
             underlying,
@@ -147,12 +149,12 @@ public class ClientTlsChannel implements TlsChannel {
   }
 
   @Override
-  public TrackingAllocator getPlainBufferAllocator() {
+  public TrackingByteBufAllocator getPlainBufferAllocator() {
     return impl.getPlainBufferAllocator();
   }
 
   @Override
-  public TrackingAllocator getEncryptedBufferAllocator() {
+  public TrackingByteBufAllocator getEncryptedBufferAllocator() {
     return impl.getEncryptedBufferAllocator();
   }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/DirectBufferAllocator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/DirectBufferAllocator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel;
+
+import com.mongodb.internal.connection.tlschannel.util.DirectBufferDeallocator;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Allocator that creates direct buffers. The {@link #free(ByteBuffer)} method, if called,
+ * deallocates the buffer immediately, without having to wait for GC (and the finalizer) to run.
+ * Calling {@link #free(ByteBuffer)} is actually optional, but should result in reduced memory
+ * consumption.
+ *
+ * <p>Direct buffers are generally preferred for using with I/O, to avoid an extra user-space copy,
+ * or to reduce garbage collection overhead.
+ */
+public class DirectBufferAllocator implements BufferAllocator {
+
+  private final DirectBufferDeallocator deallocator = new DirectBufferDeallocator();
+
+  @Override
+  public ByteBuffer allocate(int size) {
+    return ByteBuffer.allocateDirect(size);
+  }
+
+  @Override
+  public void free(ByteBuffer buffer) {
+    // do not wait for GC (and finalizer) to run
+    deallocator.deallocate(buffer);
+  }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/HeapBufferAllocator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/HeapBufferAllocator.java
@@ -22,24 +22,20 @@ package com.mongodb.internal.connection.tlschannel;
 import java.nio.ByteBuffer;
 
 /**
- * A factory for {@link ByteBuffer}s. Implementations are free to return heap or direct buffers, or
- * to do any kind of pooling. They are also expected to be thread-safe.
+ * Allocator that creates heap buffers. The {@link #free(ByteBuffer)} method is a no-op, as heap
+ * buffers are handled completely by the garbage collector.
+ *
+ * <p>Direct buffers are generally used as a simple and generally good enough default solution.
  */
-public interface BufferAllocator {
+public class HeapBufferAllocator implements BufferAllocator {
 
-  /**
-   * Allocate a {@link ByteBuffer} with the given initial capacity.
-   *
-   * @param size the size to allocate
-   * @return the newly created buffer
-   */
-  ByteBuffer allocate(int size);
+  @Override
+  public ByteBuffer allocate(int size) {
+    return ByteBuffer.allocate(size);
+  }
 
-  /**
-   * Deallocate the given {@link ByteBuffer}.
-   *
-   * @param buffer the buffer to deallocate, that should have been allocated using the same {@link
-   *     BufferAllocator} instance
-   */
-  void free(ByteBuffer buffer);
+  @Override
+  public void free(ByteBuffer buffer) {
+    // GC does it
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/NeedsReadException.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/NeedsReadException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
@@ -24,26 +24,23 @@ import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 
 /**
- * This exception signals the caller that the operation cannot continue because
- * bytesProduced need to be read from the underlying {@link ByteChannel}, the channel is
- * non-blocking and there are no bytesProduced available. The caller should try the
- * operation again, either with the channel in blocking mode of after ensuring
- * that bytesProduced are ready.
- * <p>
- * For {@link SocketChannel}s, a {@link Selector} can be used to find out when
- * the method should be retried.
- * <p>
- * Caveat: Any {@link TlsChannel} I/O method can throw this exception. In
- * particular, <code>write</code> may want to read data. This is because TLS
- * handshakes may occur at any time (initiated by either the client or the
- * server).
- * <p>
- * This exception is akin to the SSL_ERROR_WANT_READ error code used by OpenSSL.
+ * This exception signals the caller that the operation cannot continue because bytesProduced need
+ * to be read from the underlying {@link ByteChannel}, the channel is non-blocking and there are no
+ * bytesProduced available. The caller should try the operation again, either with the channel in
+ * blocking mode of after ensuring that bytesProduced are ready.
  *
- * @see <a href="https://www.openssl.org/docs/man1.1.0/ssl/SSL_get_error.html">
- * OpenSSL error documentation</a>
+ * <p>For {@link SocketChannel}s, a {@link Selector} can be used to find out when the method should
+ * be retried.
+ *
+ * <p>Caveat: Any {@link TlsChannel} I/O method can throw this exception. In particular, <code>write
+ * </code> may want to read data. This is because TLS handshakes may occur at any time (initiated by
+ * either the client or the server).
+ *
+ * <p>This exception is akin to the SSL_ERROR_WANT_READ error code used by OpenSSL.
+ *
+ * @see <a href="https://www.openssl.org/docs/man1.1.0/ssl/SSL_get_error.html">OpenSSL error
+ *     documentation</a>
  */
 public class NeedsReadException extends WouldBlockException {
-
-    private static final long serialVersionUID = 13846137963119227L;
+  private static final long serialVersionUID = 1419735639675146947L;
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/NeedsTaskException.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/NeedsTaskException.java
@@ -13,41 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
 package com.mongodb.internal.connection.tlschannel;
 
 /**
- * This exception signals the caller that the operation could not continue
- * because a CPU-intensive operation (typically a TLS handshaking) needs to be
- * executed and the {@link TlsChannel} is configured to not run tasks.
- * This allows the application to run these tasks in some other threads, in
- * order to not slow the selection loop. The method that threw the exception
- * should be retried once the task supplied by {@link #getTask()} is executed
- * and finished.
- * <p>
- * This exception is akin to the SSL_ERROR_WANT_ASYNC error code used by OpenSSL
- * (but note that in OpenSSL, the task is executed by the library, while with
- * the {@link TlsChannel}, the calling code is responsible for the
- * execution).
+ * This exception signals the caller that the operation could not continue because a CPU-intensive
+ * operation (typically a TLS handshaking) needs to be executed and the {@link TlsChannel} is
+ * configured to not run tasks. This allows the application to run these tasks in some other
+ * threads, in order to not slow the selection loop. The method that threw the exception should be
+ * retried once the task supplied by {@link #getTask()} is executed and finished.
  *
- * @see <a href="https://www.openssl.org/docs/man1.1.0/ssl/SSL_get_error.html">
- * OpenSSL error documentation</a>
+ * <p>This exception is akin to the SSL_ERROR_WANT_ASYNC error code used by OpenSSL (but note that
+ * in OpenSSL, the task is executed by the library, while with the {@link TlsChannel}, the calling
+ * code is responsible for the execution).
+ *
+ * @see <a href="https://www.openssl.org/docs/man1.1.0/ssl/SSL_get_error.html">OpenSSL error
+ *     documentation</a>
  */
 public class NeedsTaskException extends TlsChannelFlowControlException {
 
-    private static final long serialVersionUID = -7869448883241411803L;
+  private static final long serialVersionUID = -936451835836926915L;
+  private final Runnable task;
 
-    private Runnable task;
+  public NeedsTaskException(Runnable task) {
+    this.task = task;
+  }
 
-    public NeedsTaskException(final Runnable task) {
-        this.task = task;
-    }
-
-    public Runnable getTask() {
-        return task;
-    }
-
+  public Runnable getTask() {
+    return task;
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/NeedsWriteException.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/NeedsWriteException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
@@ -24,28 +24,23 @@ import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 
 /**
- * This exception signals the caller that the operation cannot continue because
- * bytesProduced need to be write to the underlying {@link ByteChannel}, the channel is
- * non-blocking and there are no buffer space available. The caller should try
- * the operation again, either with the channel in blocking mode of after
- * ensuring that buffer space exists.
- * <p>
- * For {@link SocketChannel}s, a {@link Selector} can be used to find out when
- * the method should be retried.
- * <p>
- * Caveat: Any {@link TlsChannel} I/O method can throw this exception. In
- * particular, <code>read</code> may want to write data. This is because TLS
- * handshakes may occur at any time (initiated by either the client or the
- * server).
- * <p>
- * This exception is akin to the SSL_ERROR_WANT_WRITE error code used by
- * OpenSSL.
+ * This exception signals the caller that the operation cannot continue because bytesProduced need
+ * to be write to the underlying {@link ByteChannel}, the channel is non-blocking and there are no
+ * buffer space available. The caller should try the operation again, either with the channel in
+ * blocking mode of after ensuring that buffer space exists.
  *
- * @see <a href="https://www.openssl.org/docs/man1.1.0/ssl/SSL_get_error.html">
- * OpenSSL error documentation</a>
+ * <p>For {@link SocketChannel}s, a {@link Selector} can be used to find out when the method should
+ * be retried.
+ *
+ * <p>Caveat: Any {@link TlsChannel} I/O method can throw this exception. In particular, <code>read
+ * </code> may want to write data. This is because TLS handshakes may occur at any time (initiated
+ * by either the client or the server).
+ *
+ * <p>This exception is akin to the SSL_ERROR_WANT_WRITE error code used by OpenSSL.
+ *
+ * @see <a href="https://www.openssl.org/docs/man1.1.0/ssl/SSL_get_error.html">OpenSSL error
+ *     documentation</a>
  */
-
 public class NeedsWriteException extends WouldBlockException {
-
-    private static final long serialVersionUID = -7789167281232559166L;
+  private static final long serialVersionUID = -3737940476382846413L;
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/ServerTlsChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/ServerTlsChannel.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel;
+
+import com.mongodb.internal.connection.tlschannel.impl.BufferHolder;
+import com.mongodb.internal.connection.tlschannel.impl.ByteBufferSet;
+import com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl;
+import com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl.EofException;
+import com.mongodb.internal.connection.tlschannel.impl.TlsExplorer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.StandardConstants;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.Channel;
+import java.nio.channels.ClosedChannelException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/** A server-side {@link TlsChannel}. */
+public class ServerTlsChannel implements TlsChannel {
+
+  private static final Logger logger = LoggerFactory.getLogger(ServerTlsChannel.class);
+
+  private interface SslContextStrategy {
+
+    @FunctionalInterface
+    interface SniReader {
+      Optional<SNIServerName> readSni() throws IOException, EofException;
+    }
+
+    SSLContext getSslContext(SniReader sniReader) throws IOException, EofException;
+  }
+
+  private static class SniSslContextStrategy implements SslContextStrategy {
+
+    private SniSslContextFactory sniSslContextFactory;
+
+    public SniSslContextStrategy(SniSslContextFactory sniSslContextFactory) {
+      this.sniSslContextFactory = sniSslContextFactory;
+    }
+
+    @Override
+    public SSLContext getSslContext(SniReader sniReader) throws IOException, EofException {
+      // IO block
+      Optional<SNIServerName> nameOpt = sniReader.readSni();
+      // call client code
+      Optional<SSLContext> chosenContext;
+      try {
+        chosenContext = sniSslContextFactory.getSslContext(nameOpt);
+      } catch (Exception e) {
+        logger.trace("client code threw exception during evaluation of server name indication", e);
+        throw new TlsChannelCallbackException("SNI callback failed", e);
+      }
+      return chosenContext.orElseThrow(
+          () -> new SSLHandshakeException("No ssl context available for received SNI: " + nameOpt));
+    }
+  }
+
+  private static class FixedSslContextStrategy implements SslContextStrategy {
+
+    private final SSLContext sslContext;
+
+    public FixedSslContextStrategy(SSLContext sslContext) {
+      this.sslContext = sslContext;
+    }
+
+    @Override
+    public SSLContext getSslContext(SniReader sniReader) {
+      /*
+       * Avoid SNI parsing (using the supplied sniReader) when no decision
+       * would be made based on it.
+       */
+      return sslContext;
+    }
+  }
+
+  private static SSLEngine defaultSSLEngineFactory(SSLContext sslContext) {
+    SSLEngine engine = sslContext.createSSLEngine();
+    engine.setUseClientMode(false);
+    return engine;
+  }
+
+  /** Builder of {@link ServerTlsChannel} */
+  public static class Builder extends TlsChannelBuilder<Builder> {
+
+    private final SslContextStrategy internalSslContextFactory;
+    private Function<SSLContext, SSLEngine> sslEngineFactory =
+        ServerTlsChannel::defaultSSLEngineFactory;
+
+    private Builder(ByteChannel underlying, SSLContext sslContext) {
+      super(underlying);
+      this.internalSslContextFactory = new FixedSslContextStrategy(sslContext);
+    }
+
+    private Builder(ByteChannel wrapped, SniSslContextFactory sslContextFactory) {
+      super(wrapped);
+      this.internalSslContextFactory = new SniSslContextStrategy(sslContextFactory);
+    }
+
+    @Override
+    Builder getThis() {
+      return this;
+    }
+
+    public Builder withEngineFactory(Function<SSLContext, SSLEngine> sslEngineFactory) {
+      this.sslEngineFactory = sslEngineFactory;
+      return this;
+    }
+
+    public ServerTlsChannel build() {
+      return new ServerTlsChannel(
+          underlying,
+          internalSslContextFactory,
+          sslEngineFactory,
+          sessionInitCallback,
+          runTasks,
+          plainBufferAllocator,
+          encryptedBufferAllocator,
+          releaseBuffers,
+          waitForCloseConfirmation);
+    }
+  }
+
+  /**
+   * Create a new {@link Builder}, configured with a underlying {@link Channel} and a fixed {@link
+   * SSLContext}, which will be used to create the {@link SSLEngine}.
+   *
+   * @param underlying a reference to the underlying {@link ByteChannel}
+   * @param sslContext a fixed {@link SSLContext} to be used
+   * @return the new builder
+   */
+  public static Builder newBuilder(ByteChannel underlying, SSLContext sslContext) {
+    return new Builder(underlying, sslContext);
+  }
+
+  /**
+   * Create a new {@link Builder}, configured with a underlying {@link Channel} and a custom {@link
+   * SSLContext} factory, which will be used to create the context (in turn used to create the
+   * {@link SSLEngine}, as a function of the SNI received at the TLS connection start.
+   *
+   * <p><b>Implementation note:</b><br>
+   * Due to limitations of {@link SSLEngine}, configuring a {@link ServerTlsChannel} to select the
+   * {@link SSLContext} based on the SNI value implies parsing the first TLS frame (ClientHello)
+   * independently of the SSLEngine.
+   *
+   * @param underlying a reference to the underlying {@link ByteChannel}
+   * @param sslContextFactory a function from an optional SNI to the {@link SSLContext} to be used
+   * @return the new builder
+   * @see <a href="https://tools.ietf.org/html/rfc6066#section-3">Server Name Indication</a>
+   */
+  public static Builder newBuilder(ByteChannel underlying, SniSslContextFactory sslContextFactory) {
+    return new Builder(underlying, sslContextFactory);
+  }
+
+  private final ByteChannel underlying;
+  private final SslContextStrategy sslContextStrategy;
+  private final Function<SSLContext, SSLEngine> engineFactory;
+  private final Consumer<SSLSession> sessionInitCallback;
+  private final boolean runTasks;
+  private final TrackingAllocator plainBufAllocator;
+  private final TrackingAllocator encryptedBufAllocator;
+  private final boolean releaseBuffers;
+  private final boolean waitForCloseConfirmation;
+
+  private final Lock initLock = new ReentrantLock();
+
+  private BufferHolder inEncrypted;
+
+  private volatile boolean sniRead = false;
+  private SSLContext sslContext = null;
+  private TlsChannelImpl impl = null;
+
+  // @formatter:off
+  private ServerTlsChannel(
+      ByteChannel underlying,
+      SslContextStrategy internalSslContextFactory,
+      Function<SSLContext, SSLEngine> engineFactory,
+      Consumer<SSLSession> sessionInitCallback,
+      boolean runTasks,
+      BufferAllocator plainBufAllocator,
+      BufferAllocator encryptedBufAllocator,
+      boolean releaseBuffers,
+      boolean waitForCloseConfirmation) {
+    this.underlying = underlying;
+    this.sslContextStrategy = internalSslContextFactory;
+    this.engineFactory = engineFactory;
+    this.sessionInitCallback = sessionInitCallback;
+    this.runTasks = runTasks;
+    this.plainBufAllocator = new TrackingAllocator(plainBufAllocator);
+    this.encryptedBufAllocator = new TrackingAllocator(encryptedBufAllocator);
+    this.releaseBuffers = releaseBuffers;
+    this.waitForCloseConfirmation = waitForCloseConfirmation;
+    inEncrypted =
+        new BufferHolder(
+            "inEncrypted",
+            Optional.empty(),
+            encryptedBufAllocator,
+            TlsChannelImpl.buffersInitialSize,
+            TlsChannelImpl.maxTlsPacketSize,
+            false /* plainData */,
+            releaseBuffers);
+  }
+
+  // @formatter:on
+
+  @Override
+  public ByteChannel getUnderlying() {
+    return underlying;
+  }
+
+  /**
+   * Return the used {@link SSLContext}.
+   *
+   * @return if context if present, of null if the TLS connection as not been initializer, or the
+   *     SNI not received yet.
+   */
+  public SSLContext getSslContext() {
+    return sslContext;
+  }
+
+  @Override
+  public SSLEngine getSslEngine() {
+    return impl == null ? null : impl.engine();
+  }
+
+  @Override
+  public Consumer<SSLSession> getSessionInitCallback() {
+    return sessionInitCallback;
+  }
+
+  @Override
+  public boolean getRunTasks() {
+    return impl.getRunTasks();
+  }
+
+  @Override
+  public TrackingAllocator getPlainBufferAllocator() {
+    return plainBufAllocator;
+  }
+
+  @Override
+  public TrackingAllocator getEncryptedBufferAllocator() {
+    return encryptedBufAllocator;
+  }
+
+  @Override
+  public long read(ByteBuffer[] dstBuffers, int offset, int length) throws IOException {
+    ByteBufferSet dest = new ByteBufferSet(dstBuffers, offset, length);
+    TlsChannelImpl.checkReadBuffer(dest);
+    if (!sniRead) {
+      try {
+        initEngine();
+      } catch (EofException e) {
+        return -1;
+      }
+    }
+    return impl.read(dest);
+  }
+
+  @Override
+  public long read(ByteBuffer[] dstBuffers) throws IOException {
+    return read(dstBuffers, 0, dstBuffers.length);
+  }
+
+  @Override
+  public int read(ByteBuffer dstBuffer) throws IOException {
+    return (int) read(new ByteBuffer[] {dstBuffer});
+  }
+
+  @Override
+  public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+    ByteBufferSet source = new ByteBufferSet(srcs, offset, length);
+    if (!sniRead) {
+      try {
+        initEngine();
+      } catch (EofException e) {
+        throw new ClosedChannelException();
+      }
+    }
+    return impl.write(source);
+  }
+
+  @Override
+  public long write(ByteBuffer[] srcs) throws IOException {
+    return write(srcs, 0, srcs.length);
+  }
+
+  @Override
+  public int write(ByteBuffer srcBuffer) throws IOException {
+    return (int) write(new ByteBuffer[] {srcBuffer});
+  }
+
+  @Override
+  public void renegotiate() throws IOException {
+    if (!sniRead) {
+      try {
+        initEngine();
+      } catch (EofException e) {
+        throw new ClosedChannelException();
+      }
+    }
+    impl.renegotiate();
+  }
+
+  @Override
+  public void handshake() throws IOException {
+    if (!sniRead) {
+      try {
+        initEngine();
+      } catch (EofException e) {
+        throw new ClosedChannelException();
+      }
+    }
+    impl.handshake();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (impl != null) impl.close();
+    if (inEncrypted != null) inEncrypted.dispose();
+    underlying.close();
+  }
+
+  @Override
+  public boolean isOpen() {
+    return underlying.isOpen();
+  }
+
+  private void initEngine() throws IOException, EofException {
+    initLock.lock();
+    try {
+      if (!sniRead) {
+        sslContext = sslContextStrategy.getSslContext(this::getServerNameIndication);
+        // call client code
+        SSLEngine engine;
+        try {
+          engine = engineFactory.apply(sslContext);
+        } catch (Exception e) {
+          logger.trace("client threw exception in SSLEngine factory", e);
+          throw new TlsChannelCallbackException("SSLEngine creation callback failed", e);
+        }
+        impl =
+            new TlsChannelImpl(
+                underlying,
+                underlying,
+                engine,
+                Optional.of(inEncrypted),
+                sessionInitCallback,
+                runTasks,
+                plainBufAllocator,
+                encryptedBufAllocator,
+                releaseBuffers,
+                waitForCloseConfirmation);
+        inEncrypted = null;
+        sniRead = true;
+      }
+    } finally {
+      initLock.unlock();
+    }
+  }
+
+  private Optional<SNIServerName> getServerNameIndication() throws IOException, EofException {
+    inEncrypted.prepare();
+    try {
+      int recordHeaderSize = readRecordHeaderSize();
+      while (inEncrypted.buffer.position() < recordHeaderSize) {
+        if (!inEncrypted.buffer.hasRemaining()) {
+          inEncrypted.enlarge();
+        }
+        TlsChannelImpl.readFromChannel(underlying, inEncrypted.buffer); // IO block
+      }
+      inEncrypted.buffer.flip();
+      Map<Integer, SNIServerName> serverNames = TlsExplorer.explore(inEncrypted.buffer);
+      inEncrypted.buffer.compact();
+      SNIServerName hostName = serverNames.get(StandardConstants.SNI_HOST_NAME);
+      if (hostName != null && hostName instanceof SNIHostName) {
+        SNIHostName sniHostName = (SNIHostName) hostName;
+        return Optional.of(sniHostName);
+      } else {
+        return Optional.empty();
+      }
+    } finally {
+      inEncrypted.release();
+    }
+  }
+
+  private int readRecordHeaderSize() throws IOException, EofException {
+    while (inEncrypted.buffer.position() < TlsExplorer.RECORD_HEADER_SIZE) {
+      if (!inEncrypted.buffer.hasRemaining()) {
+        throw new IllegalStateException("inEncrypted too small");
+      }
+      TlsChannelImpl.readFromChannel(underlying, inEncrypted.buffer); // IO block
+    }
+    inEncrypted.buffer.flip();
+    int recordHeaderSize = TlsExplorer.getRequiredSize(inEncrypted.buffer);
+    inEncrypted.buffer.compact();
+    return recordHeaderSize;
+  }
+
+  @Override
+  public boolean shutdown() throws IOException {
+    return impl != null && impl.shutdown();
+  }
+
+  @Override
+  public boolean shutdownReceived() {
+    return impl != null && impl.shutdownReceived();
+  }
+
+  @Override
+  public boolean shutdownSent() {
+    return impl != null && impl.shutdownSent();
+  }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/SniSslContextFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/SniSslContextFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel;
+
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLContext;
+import java.util.Optional;
+
+/**
+ * Factory for {@link SSLContext}s, based in an optional {@link SNIServerName}. Implementations of
+ * this interface are supplied to {@link ServerTlsChannel} instances, to select the correct context
+ * (and so the correct certificate) based on the server name provided by the client.
+ */
+@FunctionalInterface
+public interface SniSslContextFactory {
+
+  /**
+   * Return a proper {@link SSLContext}.
+   *
+   * @param sniServerName an optional {@link SNIServerName}; an empty value means that the client
+   *     did not send and SNI value.
+   * @return the chosen context, or an empty value, indicating that no context is supplied and the
+   *     connection should be aborted.
+   */
+  Optional<SSLContext> getSslContext(Optional<SNIServerName> sniServerName);
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannel.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
@@ -34,497 +34,435 @@ import java.util.function.Consumer;
 /**
  * A ByteChannel interface to a TLS (Transport Layer Security) connection.
  *
- * <p>
- * Instances that implement this interface delegate all cryptographic operations
- * to the standard Java TLS implementation: SSLEngine; effectively hiding it
- * behind an easy-to-use streaming API, that allows to securitize JVM
- * applications with minimal added complexity.
+ * <p>Instances that implement this interface delegate all cryptographic operations to the standard
+ * Java TLS implementation: SSLEngine; effectively hiding it behind an easy-to-use streaming API,
+ * that allows to securitize JVM applications with minimal added complexity.
  *
- * <p>
- * In other words, an interface that allows the programmer to have TLS using the
- * same standard socket API used for plaintext, just like OpenSSL does for C,
- * only for Java.
+ * <p>In other words, an interface that allows the programmer to have TLS using the same standard
+ * socket API used for plaintext, just like OpenSSL does for C, only for Java.
  *
- * <p>
- * Note that this is an API adapter, not a cryptographic implementation: with
- * the exception of a few bytesProduced of parsing at the beginning of the connection,
- * to look for the SNI, the whole protocol implementation is done by the
- * SSLEngine. Both the SSLContext and SSLEngine are supplied by the client;
- * these classes are the ones responsible for protocol configuration, including
+ * <p>Note that this is an API adapter, not a cryptographic implementation: with the exception of a
+ * few bytesProduced of parsing at the beginning of the connection, to look for the SNI, the whole
+ * protocol implementation is done by the SSLEngine. Both the SSLContext and SSLEngine are supplied
+ * by the client; these classes are the ones responsible for protocol configuration, including
  * hostname validation, client-side authentication, etc.
  *
- * <p>
- * A TLS channel is created by using one of its subclasses. They will
- * take an existing {@link ByteChannel} (typically, but not necessarily, a
- * {@link SocketChannel}) and a {@link SSLEngine}.
+ * <p>A TLS channel is created by using one of its subclasses. They will take an existing {@link
+ * ByteChannel} (typically, but not necessarily, a {@link SocketChannel}) and a {@link SSLEngine}.
  *
- * <p>
- * It should be noted that this interface extends {@link ByteChannel} as a
- * design compromise, but it does not follow its interface completely. In
- * particular, in case of underlying non-blocking channels, when it is not
- * possible to complete an operation, no zero is returned, but an
- * {@link WouldBlockException}. This divergence from the base interface is
- * needed because both a <code>read</code> and a <code>write</code> operation
- * can run out of both bytesProduced for reading and buffer space for writing, as a
- * handshake (a bidirectional operation) can happen at any moment. The user
- * would use a {@link Selector} to wait for the expected condition
- * <em>of the underlying channel</em>, and should know which operation to
- * register.
+ * <p>It should be noted that this interface extends {@link ByteChannel} as a design compromise, but
+ * it does not follow its interface completely. In particular, in case of underlying non-blocking
+ * channels, when it is not possible to complete an operation, no zero is returned, but an {@link
+ * WouldBlockException}. This divergence from the base interface is needed because both a <code>read
+ * </code> and a <code>write</code> operation can run out of both bytesProduced for reading and
+ * buffer space for writing, as a handshake (a bidirectional operation) can happen at any moment.
+ * The user would use a {@link Selector} to wait for the expected condition <em>of the underlying
+ * channel</em>, and should know which operation to register.
  *
- * <p>
- * On top of that, operations can also fail to complete due to asynchronous
- * tasks; this is communicated using a {@link NeedsTaskException}. This behavior
- * is controlled by the {@link #getRunTasks()} attribute. This allows the user
- * to execute CPU-intensive tasks out of the selector loop.
+ * <p>On top of that, operations can also fail to complete due to asynchronous tasks; this is
+ * communicated using a {@link NeedsTaskException}. This behavior is controlled by the {@link
+ * #getRunTasks()} attribute. This allows the user to execute CPU-intensive tasks out of the
+ * selector loop.
  */
 public interface TlsChannel extends ByteChannel, GatheringByteChannel, ScatteringByteChannel {
 
-    /**
-     * Return a reference to the underlying {@link ByteChannel}.
-     */
-    ByteChannel getUnderlying();
+  BufferAllocator defaultPlainBufferAllocator = new HeapBufferAllocator();
+  BufferAllocator defaultEncryptedBufferAllocator = new DirectBufferAllocator();
 
-    /**
-     * Return a reference to the {@link SSLEngine} used.
-     *
-     * @return the engine reference if present, or <code>null</code> if unknown
-     * (that can happen in server-side channels before the SNI is
-     * parsed).
-     */
-    SSLEngine getSslEngine();
+  /**
+   * Return a reference to the underlying {@link ByteChannel}.
+   *
+   * @return the underlying channel
+   */
+  ByteChannel getUnderlying();
 
-    /**
-     * Return the callback function to be executed when the TLS session is
-     * established (or re-established).
-     *
-     * @see TlsChannelBuilder#withSessionInitCallback(Consumer)
-     */
-    Consumer<SSLSession> getSessionInitCallback();
+  /**
+   * Return a reference to the {@link SSLEngine} used.
+   *
+   * @return the engine reference if present, or <code>null</code> if unknown (that can happen in
+   *     server-side channels before the SNI is parsed).
+   */
+  SSLEngine getSslEngine();
 
-    /**
-     * Return the {@link BufferAllocator} to use for unencrypted data. Actually, a decorating subclass is returned,
-     * which contains allocation statistics for this channel.
-     *
-     * @see TlsChannelBuilder#withPlainBufferAllocator(BufferAllocator)
-     * @see TrackingAllocator
-     */
-    TrackingAllocator getPlainBufferAllocator();
+  /**
+   * Return the callback function to be executed when the TLS session is established (or
+   * re-established).
+   *
+   * @return the callback function
+   * @see TlsChannelBuilder#withSessionInitCallback(Consumer)
+   */
+  Consumer<SSLSession> getSessionInitCallback();
 
-    /**
-     * Return the {@link BufferAllocator} to use for encrypted data. Actually, a decorating subclass is returned,
-     * which contains allocation statistics for this channel.
-     *
-     * @see TlsChannelBuilder#withEncryptedBufferAllocator(BufferAllocator)
-     * @see TrackingAllocator
-     */
-    TrackingAllocator getEncryptedBufferAllocator();
+  /**
+   * Return the {@link BufferAllocator} to use for unencrypted data. Actually, a decorating subclass
+   * is returned, which contains allocation statistics for this channel.
+   *
+   * @return the buffer allocator
+   * @see TlsChannelBuilder#withPlainBufferAllocator(BufferAllocator)
+   * @see TrackingAllocator
+   */
+  TrackingAllocator getPlainBufferAllocator();
 
-    /**
-     * Return whether CPU-intensive tasks are run or not.
-     *
-     * @see TlsChannelBuilder#withRunTasks(boolean)
-     */
-    boolean getRunTasks();
+  /**
+   * Return the {@link BufferAllocator} to use for encrypted data. Actually, a decorating subclass
+   * is returned, which contains allocation statistics for this channel.
+   *
+   * @return the buffer allocator
+   * @see TlsChannelBuilder#withEncryptedBufferAllocator(BufferAllocator)
+   * @see TrackingAllocator
+   */
+  TrackingAllocator getEncryptedBufferAllocator();
 
-    /**
-     * Reads a sequence of bytesProduced from this channel into the given buffer.
-     *
-     * <p>
-     * An attempt is made to read up to <i>r</i> bytesProduced from the channel, where
-     * <i>r</i> is the number of bytesProduced remaining in the buffer, that is,
-     * <tt>dst.remaining()</tt>, at the moment this method is invoked.
-     *
-     * <p>
-     * Suppose that a byte sequence of length <i>n</i> is read, where <tt>0</tt>
-     * &nbsp;<tt>&lt;=</tt>&nbsp;<i>n</i>&nbsp;<tt>&lt;=</tt>&nbsp;<i>r</i>.
-     * This byte sequence will be transferred into the buffer so that the first
-     * byte in the sequence is at index <i>p</i> and the last byte is at index
-     * <i>p</i>&nbsp;<tt>+</tt>&nbsp;<i>n</i>&nbsp;<tt>-</tt>&nbsp;<tt>1</tt>,
-     * where <i>p</i> is the buffer's position at the moment this method is
-     * invoked. Upon return the buffer's position will be equal to <i>p</i>
-     * &nbsp;<tt>+</tt>&nbsp;<i>n</i>; its limit will not have changed.
-     *
-     * <p>
-     * A read operation might not fill the buffer, and in fact it might not read
-     * any bytesProduced at all. Whether or not it does so depends upon the nature and
-     * state of the underlying channel. It is guaranteed, however, that if a
-     * channel is in blocking mode and there is at least one byte remaining in
-     * the buffer then this method will block until at least one byte is read.
-     * On the other hand, if the underlying channel is in non-blocking mode then
-     * a {@link WouldBlockException} may be thrown. Note that this also includes
-     * the possibility of a {@link NeedsWriteException}, due to the fact that,
-     * during a TLS handshake, bytesProduced need to be written to the underlying
-     * channel. In any case, after a {@link WouldBlockException}, the operation
-     * should be retried when the underlying channel is ready (for reading or
-     * writing, depending on the subclass).
-     *
-     * <p>
-     * If the channel is configured to not run tasks and one is due to run, a
-     * {@link NeedsTaskException} will be thrown. In this case the operation
-     * should be retried after the task is run.
-     *
-     * <p>
-     * This method may be invoked at any time. If another thread has already
-     * initiated a read or handshaking operation upon this channel, however,
-     * then an invocation of this method will block until the first operation is
-     * complete.
-     *
-     * @param dst The buffer into which bytesProduced are to be transferred
-     * @return The number of bytesProduced read, or <tt>-1</tt> if the channel has
-     * reached end-of-stream; contrary to the behavior specified in
-     * {@link ByteChannel}, this method never returns 0, but throws
-     * {@link WouldBlockException}
-     * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation
-     *                             cannot be completed immediately
-     * @throws NeedsTaskException  if the channel is not configured to run tasks automatically
-     *                             and a task needs to be executed to complete the operation
-     * @throws SSLException        if the {@link SSLEngine} throws a SSLException
-     * @throws IOException         if the underlying channel throws an IOException
-     */
-    int read(ByteBuffer dst) throws IOException;
+  /**
+   * Return whether CPU-intensive tasks are run or not.
+   *
+   * @return whether tasks are run
+   * @see TlsChannelBuilder#withRunTasks(boolean)
+   */
+  boolean getRunTasks();
 
-    /**
-     * Writes a sequence of bytesProduced to this channel from the given buffer.
-     *
-     * <p>
-     * An attempt is made to write up to <i>r</i> bytesProduced to the channel, where
-     * <i>r</i> is the number of bytesProduced remaining in the buffer, that is,
-     * <tt>src.remaining()</tt>, at the moment this method is invoked.
-     *
-     * <p>
-     * Suppose that a byte sequence of length <i>n</i> is written, where
-     * <tt>0</tt>&nbsp;<tt>&lt;=</tt>&nbsp;<i>n</i>&nbsp;<tt>&lt;=</tt>&nbsp;
-     * <i>r</i>. This byte sequence will be transferred from the buffer starting
-     * at index <i>p</i>, where <i>p</i> is the buffer's position at the moment
-     * this method is invoked; the index of the last byte written will be
-     * <i>p</i>&nbsp;<tt>+</tt>&nbsp;<i>n</i>&nbsp;<tt>-</tt>&nbsp;<tt>1</tt>.
-     * Upon return the buffer's position will be equal to <i>p</i>&nbsp;
-     * <tt>+</tt>&nbsp;<i>n</i>; its limit will not have changed.
-     *
-     * <p>
-     * If the underlying channel is in blocking mode, a write operation will
-     * return only after writing all of the <i>r</i> requested bytesProduced. On the
-     * other hand, if it is in non-blocking mode, this operation may write only
-     * some of the bytesProduced or possibly none at all, in this case a
-     * {@link WouldBlockException} will be thrown. Note that this also includes
-     * the possibility of a {@link NeedsReadException}, due to the fact that,
-     * during a TLS handshake, bytes need to be read from the underlying channel.
-     * In any case, after a {@link WouldBlockException}, the operation should be
-     * retried when the underlying channel is ready (for reading or writing,
-     * depending on the subclass).
-     *
-     * <p>
-     * If the channel is configured to not run tasks and one is due to run, a
-     * {@link NeedsTaskException} will be thrown. In this case the operation
-     * should be retried after the task is run.
-     *
-     * <p>
-     * This method may be invoked at any time. If another thread has already
-     * initiated a write or handshaking operation upon this channel, however,
-     * then an invocation of this method will block until the first operation is
-     * complete.
-     *
-     * @param src The buffer from which bytesProduced are to be retrieved
-     * @return The number of bytesProduced written, contrary to the behavior specified
-     * in {@link ByteChannel}, this method never returns 0, but throws
-     * {@link WouldBlockException}
-     * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation
-     *                             cannot be completed immediately
-     * @throws NeedsTaskException  if the channel is not configured to run tasks automatically
-     *                             and a task needs to be executed to complete the operation
-     * @throws SSLException        if the {@link SSLEngine} throws a SSLException
-     * @throws IOException         if the underlying channel throws an IOException
-     */
-    int write(ByteBuffer src) throws IOException;
+  /**
+   * Reads a sequence of bytesProduced from this channel into the given buffer.
+   *
+   * <p>An attempt is made to read up to <i>r</i> bytesProduced from the channel, where <i>r</i> is
+   * the number of bytesProduced remaining in the buffer, that is, <code>dst.remaining()</code>, at
+   * the moment this method is invoked.
+   *
+   * <p>Suppose that a byte sequence of length <i>n</i> is read, where <code>0</code> &nbsp;<code>
+   * &lt;=</code>&nbsp;<i>n</i>&nbsp;<code>&lt;=</code>&nbsp;<i>r</i>. This byte sequence will be
+   * transferred into the buffer so that the first byte in the sequence is at index <i>p</i> and the
+   * last byte is at index <i>p</i>&nbsp;<code>+</code>&nbsp;<i>n</i>&nbsp;<code>-</code>&nbsp;
+   * <code>1</code>, where <i>p</i> is the buffer's position at the moment this method is invoked.
+   * Upon return the buffer's position will be equal to <i>p</i> &nbsp;<code>+</code>&nbsp;<i>n</i>;
+   * its limit will not have changed.
+   *
+   * <p>A read operation might not fill the buffer, and in fact it might not read any bytesProduced
+   * at all. Whether or not it does so depends upon the nature and state of the underlying channel.
+   * It is guaranteed, however, that if a channel is in blocking mode and there is at least one byte
+   * remaining in the buffer then this method will block until at least one byte is read. On the
+   * other hand, if the underlying channel is in non-blocking mode then a {@link
+   * WouldBlockException} may be thrown. Note that this also includes the possibility of a {@link
+   * NeedsWriteException}, due to the fact that, during a TLS handshake, bytesProduced need to be
+   * written to the underlying channel. In any case, after a {@link WouldBlockException}, the
+   * operation should be retried when the underlying channel is ready (for reading or writing,
+   * depending on the subclass).
+   *
+   * <p>If the channel is configured to not run tasks and one is due to run, a {@link
+   * NeedsTaskException} will be thrown. In this case the operation should be retried after the task
+   * is run.
+   *
+   * <p>This method may be invoked at any time. If another thread has already initiated a read or
+   * handshaking operation upon this channel, however, then an invocation of this method will block
+   * until the first operation is complete.
+   *
+   * @param dst The buffer into which bytesProduced are to be transferred
+   * @return The number of bytesProduced read, or <code>-1</code> if the channel has reached
+   *     end-of-stream; contrary to the behavior specified in {@link ByteChannel}, this method never
+   *     returns 0, but throws {@link WouldBlockException}
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @throws NeedsTaskException if the channel is not configured to run tasks automatically and a
+   *     task needs to be executed to complete the operation
+   * @throws SSLException if the {@link SSLEngine} throws a SSLException
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  int read(ByteBuffer dst) throws IOException;
 
-    /**
-     * Initiates a handshake (initial or renegotiation) on this channel. This
-     * method is not needed for the initial handshake, as the
-     * <code>read()</code> and <code>write()</code> methods will implicitly do
-     * the initial handshake if needed.
-     *
-     * <p>
-     * This method may block if the underlying channel if in blocking mode.
-     *
-     * <p>
-     * Note that renegotiation is a problematic feature of the TLS protocol,
-     * that should only be initiated at quiet point of the protocol.
-     *
-     * <p>
-     * This method may block if the underlying channel is in blocking mode,
-     * otherwise a {@link WouldBlockException} can be thrown. In this case the
-     * operation should be retried when the underlying channel is ready (for
-     * reading or writing, depending on the subclass).
-     *
-     * <p>
-     * If the channel is configured to not run tasks and one is due to run, a
-     * {@link NeedsTaskException} will be thrown, with a reference to the task.
-     * In this case the operation should be retried after the task is run.
-     *
-     * <p>
-     * This method may be invoked at any time. If another thread has already
-     * initiated a read, write, or handshaking operation upon this channel,
-     * however, then an invocation of this method will block until the first
-     * operation is complete.
-     *
-     * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation
-     *                             cannot be completed immediately
-     * @throws NeedsTaskException  if the channel is not configured to run tasks automatically
-     *                             and a task needs to be executed to complete the operation
-     * @throws SSLException        if the {@link SSLEngine} throws a SSLException
-     * @throws IOException         if the underlying channel throws an IOException
-     */
-    void renegotiate() throws IOException;
+  /**
+   * Writes a sequence of bytesProduced to this channel from the given buffer.
+   *
+   * <p>An attempt is made to write up to <i>r</i> bytesProduced to the channel, where <i>r</i> is
+   * the number of bytesProduced remaining in the buffer, that is, <code>src.remaining()</code>, at
+   * the moment this method is invoked.
+   *
+   * <p>Suppose that a byte sequence of length <i>n</i> is written, where <code>0</code>&nbsp;<code>
+   * &lt;=</code>&nbsp;<i>n</i>&nbsp;<code>&lt;=</code>&nbsp; <i>r</i>. This byte sequence will be
+   * transferred from the buffer starting at index <i>p</i>, where <i>p</i> is the buffer's position
+   * at the moment this method is invoked; the index of the last byte written will be <i>p</i>&nbsp;
+   * <code>+</code>&nbsp;<i>n</i>&nbsp;<code>-</code>&nbsp;<code>1</code>. Upon return the buffer's
+   * position will be equal to <i>p</i>&nbsp; <code>+</code>&nbsp;<i>n</i>; its limit will not have
+   * changed.
+   *
+   * <p>If the underlying channel is in blocking mode, a write operation will return only after
+   * writing all of the <i>r</i> requested bytesProduced. On the other hand, if it is in
+   * non-blocking mode, this operation may write only some of the bytesProduced or possibly none at
+   * all, in this case a {@link WouldBlockException} will be thrown. Note that this also includes
+   * the possibility of a {@link NeedsReadException}, due to the fact that, during a TLS handshake,
+   * bytes need to be read from the underlying channel. In any case, after a {@link
+   * WouldBlockException}, the operation should be retried when the underlying channel is ready (for
+   * reading or writing, depending on the subclass).
+   *
+   * <p>If the channel is configured to not run tasks and one is due to run, a {@link
+   * NeedsTaskException} will be thrown. In this case the operation should be retried after the task
+   * is run.
+   *
+   * <p>This method may be invoked at any time. If another thread has already initiated a write or
+   * handshaking operation upon this channel, however, then an invocation of this method will block
+   * until the first operation is complete.
+   *
+   * @param src The buffer from which bytesProduced are to be retrieved
+   * @return The number of bytesProduced written, contrary to the behavior specified in {@link
+   *     ByteChannel}, this method never returns 0, but throws {@link WouldBlockException}
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @throws NeedsTaskException if the channel is not configured to run tasks automatically and a
+   *     task needs to be executed to complete the operation
+   * @throws SSLException if the {@link SSLEngine} throws a SSLException
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  int write(ByteBuffer src) throws IOException;
 
-    /**
-     * Forces the initial TLS handshake. Calling this method is usually not
-     * needed, as a handshake will happen automatically when doing the first
-     * <code>read()</code> or <code>write()</code> operation. Calling this
-     * method after the initial handshake has been done has no effect.
-     *
-     * <p>
-     * This method may block if the underlying channel is in blocking mode,
-     * otherwise a {@link WouldBlockException} can be thrown. In this case the
-     * operation should be retried when the underlying channel is ready (for
-     * reading or writing, depending on the subclass).
-     *
-     * <p>
-     * If the channel is configured to not run tasks and one is due to run, a
-     * {@link NeedsTaskException} will be thrown, with a reference to the task.
-     * In this case the operation should be retried after the task is run.
-     *
-     * <p>
-     * This method may be invoked at any time. If another thread has already
-     * initiated a read, write, or handshaking operation upon this channel,
-     * however, then an invocation of this method will block until the first
-     * operation is complete.
-     *
-     * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation
-     *                             cannot be completed immediately
-     * @throws NeedsTaskException  if the channel is not configured to run tasks automatically
-     *                             and a task needs to be executed to complete the operation
-     * @throws SSLException        if the {@link SSLEngine} throws a SSLException
-     * @throws IOException         if the underlying channel throws an IOException
-     */
-    void handshake() throws IOException;
+  /**
+   * Initiates a handshake (initial or renegotiation) on this channel. This method is not needed for
+   * the initial handshake, as the <code>read()</code> and <code>write()</code> methods will
+   * implicitly do the initial handshake if needed.
+   *
+   * <p>This method may block if the underlying channel if in blocking mode.
+   *
+   * <p>Note that renegotiation is a problematic feature of the TLS protocol, that should only be
+   * initiated at quiet point of the protocol.
+   *
+   * <p>This method may block if the underlying channel is in blocking mode, otherwise a {@link
+   * WouldBlockException} can be thrown. In this case the operation should be retried when the
+   * underlying channel is ready (for reading or writing, depending on the subclass).
+   *
+   * <p>If the channel is configured to not run tasks and one is due to run, a {@link
+   * NeedsTaskException} will be thrown, with a reference to the task. In this case the operation
+   * should be retried after the task is run.
+   *
+   * <p>This method may be invoked at any time. If another thread has already initiated a read,
+   * write, or handshaking operation upon this channel, however, then an invocation of this method
+   * will block until the first operation is complete.
+   *
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @throws NeedsTaskException if the channel is not configured to run tasks automatically and a
+   *     task needs to be executed to complete the operation
+   * @throws SSLException if the {@link SSLEngine} throws a SSLException
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  void renegotiate() throws IOException;
 
-    /**
-     * Writes a sequence of bytesProduced to this channel from a subsequence of the
-     * given buffers.
-     *
-     * <p>
-     * See {@link GatheringByteChannel#write(ByteBuffer[], int, int)} for more
-     * details of the meaning of this signature.
-     *
-     * <p>
-     * This method behaves slightly different than the interface specification,
-     * with respect to non-blocking responses, see {@link #write(ByteBuffer)}
-     * for more details.
-     *
-     * @param srcs   The buffers from which bytesProduced are to be retrieved
-     * @param offset The offset within the buffer array of the first buffer from
-     *               which bytesProduced are to be retrieved; must be non-negative and no
-     *               larger than <tt>srcs.length</tt>
-     * @param length The maximum number of buffers to be accessed; must be
-     *               non-negative and no larger than <tt>srcs.length</tt>
-     *               &nbsp;-&nbsp;<tt>offset</tt>
-     * @return The number of bytesProduced written, contrary to the behavior specified
-     * in {@link ByteChannel}, this method never returns 0, but throws
-     * {@link WouldBlockException}
-     * @throws IndexOutOfBoundsException If the preconditions on the <tt>offset</tt> and
-     *                                   <tt>length</tt> parameters do not hold
-     * @throws WouldBlockException       if the channel is in non-blocking mode and the IO operation
-     *                                   cannot be completed immediately
-     * @throws NeedsTaskException        if the channel is not configured to run tasks automatically
-     *                                   and a task needs to be executed to complete the operation
-     * @throws SSLException              if the {@link SSLEngine} throws a SSLException
-     * @throws IOException               if the underlying channel throws an IOException
-     */
-    long write(ByteBuffer[] srcs, int offset, int length) throws IOException;
+  /**
+   * Forces the initial TLS handshake. Calling this method is usually not needed, as a handshake
+   * will happen automatically when doing the first <code>read()</code> or <code>write()</code>
+   * operation. Calling this method after the initial handshake has been done has no effect.
+   *
+   * <p>This method may block if the underlying channel is in blocking mode, otherwise a {@link
+   * WouldBlockException} can be thrown. In this case the operation should be retried when the
+   * underlying channel is ready (for reading or writing, depending on the subclass).
+   *
+   * <p>If the channel is configured to not run tasks and one is due to run, a {@link
+   * NeedsTaskException} will be thrown, with a reference to the task. In this case the operation
+   * should be retried after the task is run.
+   *
+   * <p>This method may be invoked at any time. If another thread has already initiated a read,
+   * write, or handshaking operation upon this channel, however, then an invocation of this method
+   * will block until the first operation is complete.
+   *
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @throws NeedsTaskException if the channel is not configured to run tasks automatically and a
+   *     task needs to be executed to complete the operation
+   * @throws SSLException if the {@link SSLEngine} throws a SSLException
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  void handshake() throws IOException;
 
-    /**
-     * Writes a sequence of bytesProduced to this channel from the given buffers.
-     *
-     * <p>
-     * An invocation of this method of the form <tt>c.write(srcs)</tt> behaves
-     * in exactly the same manner as the invocation
-     *
-     * <blockquote>
-     *
-     * <pre>
-     * c.write(srcs, 0, srcs.length);
-     * </pre>
-     *
-     * </blockquote>
-     * <p>
-     * This method behaves slightly different than the interface specification,
-     * with respect to non-blocking responses, see {@link #write(ByteBuffer)}
-     * for more details.
-     *
-     * @param srcs The buffers from which bytesProduced are to be retrieved
-     * @return The number of bytesProduced written, contrary to the behavior specified
-     * in {@link ByteChannel}, this method never returns 0, but throws
-     * {@link WouldBlockException}
-     * @throws IndexOutOfBoundsException If the preconditions on the <tt>offset</tt> and
-     *                                   <tt>length</tt> parameters do not hold
-     * @throws WouldBlockException       if the channel is in non-blocking mode and the IO operation
-     *                                   cannot be completed immediately
-     * @throws NeedsTaskException        if the channel is not configured to run tasks automatically
-     *                                   and a task needs to be executed to complete the operation
-     * @throws SSLException              if the {@link SSLEngine} throws a SSLException
-     * @throws IOException               if the underlying channel throws an IOExceptions
-     */
-    long write(ByteBuffer[] srcs) throws IOException;
+  /**
+   * Writes a sequence of bytesProduced to this channel from a subsequence of the given buffers.
+   *
+   * <p>See {@link GatheringByteChannel#write(ByteBuffer[], int, int)} for more details of the
+   * meaning of this signature.
+   *
+   * <p>This method behaves slightly different than the interface specification, with respect to
+   * non-blocking responses, see {@link #write(ByteBuffer)} for more details.
+   *
+   * @param srcs The buffers from which bytesProduced are to be retrieved
+   * @param offset The offset within the buffer array of the first buffer from which bytesProduced
+   *     are to be retrieved; must be non-negative and no larger than <code>srcs.length</code>
+   * @param length The maximum number of buffers to be accessed; must be non-negative and no larger
+   *     than <code>srcs.length</code> &nbsp;-&nbsp;<code>offset</code>
+   * @return The number of bytesProduced written, contrary to the behavior specified in {@link
+   *     ByteChannel}, this method never returns 0, but throws {@link WouldBlockException}
+   * @throws IndexOutOfBoundsException If the preconditions on the <code>offset</code> and <code>
+   *     length</code> parameters do not hold
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @throws NeedsTaskException if the channel is not configured to run tasks automatically and a
+   *     task needs to be executed to complete the operation
+   * @throws SSLException if the {@link SSLEngine} throws a SSLException
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  long write(ByteBuffer[] srcs, int offset, int length) throws IOException;
 
-    /**
-     * Reads a sequence of bytesProduced from this channel into a subsequence of the
-     * given buffers.
-     *
-     * <p>
-     * See {@link ScatteringByteChannel#read(ByteBuffer[], int, int)} for more
-     * details of the meaning of this signature.
-     *
-     * <p>
-     * This method behaves slightly different than the interface specification,
-     * with respect to non-blocking responses, see {@link #read(ByteBuffer)} for
-     * more details.
-     *
-     * @param dsts   The buffers into which bytesProduced are to be transferred
-     * @param offset The offset within the buffer array of the first buffer into
-     *               which bytesProduced are to be transferred; must be non-negative and no
-     *               larger than <tt>dsts.length</tt>
-     * @param length The maximum number of buffers to be accessed; must be
-     *               non-negative and no larger than <tt>dsts.length</tt>
-     *               &nbsp;-&nbsp;<tt>offset</tt>
-     * @return The number of bytesProduced read, or <tt>-1</tt> if the channel has
-     * reached end-of-stream; contrary to the behavior specified in
-     * {@link ByteChannel}, this method never returns 0, but throws
-     * {@link WouldBlockException}
-     * @throws IndexOutOfBoundsException If the preconditions on the <tt>offset</tt> and
-     *                                   <tt>length</tt> parameters do not hold
-     * @throws WouldBlockException       if the channel is in non-blocking mode and the IO operation
-     *                                   cannot be completed immediately
-     * @throws NeedsTaskException        if the channel is not configured to run tasks automatically
-     *                                   and a task needs to be executed to complete the operation
-     * @throws SSLException              if the {@link SSLEngine} throws a SSLException
-     * @throws IOException               if the underlying channel throws an IOException
-     */
-    long read(ByteBuffer[] dsts, int offset, int length) throws IOException;
+  /**
+   * Writes a sequence of bytesProduced to this channel from the given buffers.
+   *
+   * <p>An invocation of this method of the form <code>c.write(srcs)</code> behaves in exactly the
+   * same manner as the invocation
+   *
+   * <blockquote>
+   *
+   * <pre>
+   * c.write(srcs, 0, srcs.length);
+   * </pre>
+   *
+   * </blockquote>
+   *
+   * This method behaves slightly different than the interface specification, with respect to
+   * non-blocking responses, see {@link #write(ByteBuffer)} for more details.
+   *
+   * @param srcs The buffers from which bytesProduced are to be retrieved
+   * @return The number of bytesProduced written, contrary to the behavior specified in {@link
+   *     ByteChannel}, this method never returns 0, but throws {@link WouldBlockException}
+   * @throws IndexOutOfBoundsException If the preconditions on the <code>offset</code> and <code>
+   *     length</code> parameters do not hold
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @throws NeedsTaskException if the channel is not configured to run tasks automatically and a
+   *     task needs to be executed to complete the operation
+   * @throws SSLException if the {@link SSLEngine} throws a SSLException
+   * @throws IOException if the underlying channel throws an IOExceptions
+   */
+  long write(ByteBuffer[] srcs) throws IOException;
 
-    /**
-     * Reads a sequence of bytesProduced from this channel into the given buffers.
-     *
-     * <p>
-     * An invocation of this method of the form <tt>c.read(dsts)</tt> behaves in
-     * exactly the same manner as the invocation
-     *
-     * <blockquote>
-     *
-     * <pre>
-     * c.read(dsts, 0, dsts.length);
-     * </pre>
-     *
-     * </blockquote>
-     *
-     * <p>
-     * This method behaves slightly different than the interface specification,
-     * with respect to non-blocking responses, see {@link #read(ByteBuffer)} for
-     * more details.
-     *
-     * @param dsts The buffers into which bytesProduced are to be transferred
-     * @return The number of bytesProduced read, or <tt>-1</tt> if the channel has
-     * reached end-of-stream; contrary to the behavior specified in
-     * {@link ByteChannel}, this method never returns 0, but throws
-     * {@link WouldBlockException}
-     * @throws IndexOutOfBoundsException If the preconditions on the <tt>offset</tt> and
-     *                                   <tt>length</tt> parameters do not hold
-     * @throws WouldBlockException       if the channel is in non-blocking mode and the IO operation
-     *                                   cannot be completed immediately
-     * @throws NeedsTaskException        if the channel is not configured to run tasks automatically
-     *                                   and a task needs to be executed to complete the operation
-     * @throws SSLException              if the {@link SSLEngine} throws a SSLException
-     * @throws IOException               if the underlying channel throws an IOException
-     */
-    long read(ByteBuffer[] dsts) throws IOException;
+  /**
+   * Reads a sequence of bytesProduced from this channel into a subsequence of the given buffers.
+   *
+   * <p>See {@link ScatteringByteChannel#read(ByteBuffer[], int, int)} for more details of the
+   * meaning of this signature.
+   *
+   * <p>This method behaves slightly different than the interface specification, with respect to
+   * non-blocking responses, see {@link #read(ByteBuffer)} for more details.
+   *
+   * @param dsts The buffers into which bytesProduced are to be transferred
+   * @param offset The offset within the buffer array of the first buffer into which bytesProduced
+   *     are to be transferred; must be non-negative and no larger than <code>dsts.length</code>
+   * @param length The maximum number of buffers to be accessed; must be non-negative and no larger
+   *     than <code>dsts.length</code> &nbsp;-&nbsp;<code>offset</code>
+   * @return The number of bytesProduced read, or <code>-1</code> if the channel has reached
+   *     end-of-stream; contrary to the behavior specified in {@link ByteChannel}, this method never
+   *     returns 0, but throws {@link WouldBlockException}
+   * @throws IndexOutOfBoundsException If the preconditions on the <code>offset</code> and <code>
+   *     length</code> parameters do not hold
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @throws NeedsTaskException if the channel is not configured to run tasks automatically and a
+   *     task needs to be executed to complete the operation
+   * @throws SSLException if the {@link SSLEngine} throws a SSLException
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  long read(ByteBuffer[] dsts, int offset, int length) throws IOException;
 
-    /**
-     * Closes the underlying channel. This method first does some form of TLS
-     * close if not already done. The exact behavior can be configured using the
-     * {@link TlsChannelBuilder#withWaitForCloseConfirmation}.
-     *
-     * <p>
-     * The default behavior mimics what happens in a normal (that is, non
-     * layered) {@link javax.net.ssl.SSLSocket#close()}.
-     *
-     * <p>
-     * For finer control of the TLS close, use {@link #shutdown()}
-     *
-     * @throws IOException if the underlying channel throws an IOException during close.
-     *                     Exceptions thrown during any previous TLS close are not
-     *                     propagated.
-     */
-    void close() throws IOException;
+  /**
+   * Reads a sequence of bytesProduced from this channel into the given buffers.
+   *
+   * <p>An invocation of this method of the form <code>c.read(dsts)</code> behaves in exactly the
+   * same manner as the invocation
+   *
+   * <blockquote>
+   *
+   * <pre>
+   * c.read(dsts, 0, dsts.length);
+   * </pre>
+   *
+   * </blockquote>
+   *
+   * <p>This method behaves slightly different than the interface specification, with respect to
+   * non-blocking responses, see {@link #read(ByteBuffer)} for more details.
+   *
+   * @param dsts The buffers into which bytesProduced are to be transferred
+   * @return The number of bytesProduced read, or <code>-1</code> if the channel has reached
+   *     end-of-stream; contrary to the behavior specified in {@link ByteChannel}, this method never
+   *     returns 0, but throws {@link WouldBlockException}
+   * @throws IndexOutOfBoundsException If the preconditions on the <code>offset</code> and <code>
+   *     length</code> parameters do not hold
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @throws NeedsTaskException if the channel is not configured to run tasks automatically and a
+   *     task needs to be executed to complete the operation
+   * @throws SSLException if the {@link SSLEngine} throws a SSLException
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  long read(ByteBuffer[] dsts) throws IOException;
 
-    /**
-     * <p> Shuts down the TLS connection. This method emulates the behavior of OpenSSL's <a
-     * href="https://wiki.openssl.org/index.php/Manual:SSL_shutdown(3)"> SSL_shutdown()</a>.</p>
-     *
-     * <p> The shutdown procedure consists of two steps: the sending of the "close notify" shutdown alert and the
-     * reception of the peer's "close notify". According to the TLS standard, it is acceptable for an application to
-     * only send its shutdown alert and then close the underlying connection without waiting for the peer's response.
-     * When the underlying connection shall be used for more communications, the complete shutdown procedure
-     * (bidirectional "close notify" alerts) must be performed, so that the peers stay synchronized.</p>
-     *
-     * <p> This class supports both uni- and bidirectional shutdown by its 2 step behavior, using this method.</p>
-     *
-     * <p> When this is the first party to send the "close notify" alert, this method will only send the alert, set the
-     * {@link #shutdownSent()} flag and return <code>false</code>. If a unidirectional shutdown is enough, this first
-     * call is sufficient. In order to complete the bidirectional shutdown handshake, This method must be called again.
-     * The second call will wait for the peer's "close notify" shutdown alert. On success, the second call will return
-     * <code>true</code>.</p>
-     *
-     * <p> If the peer already sent the "close notify" alert and it was already processed implicitly inside a read
-     * operation, the {@link #shutdownReceived()} flag is already set. This method will then send the "close notify"
-     * alert, set the {@link #shutdownSent()} flag and immediately return <code>true</code>. It is therefore recommended
-     * to check the return value of this method and call it again, if the bidirectional shutdown is not yet
-     * complete.</p>
-     *
-     * <p> If the underlying channel is blocking, this method will only return once the handshake step has been finished
-     * or an error occurred.</p>
-     *
-     * <p> If the underlying channel is non-blocking, this method may throw {@link WouldBlockException} if the
-     * underlying channel could not support the continuation of the handshake. The calling process then must repeat the
-     * call after taking appropriate action (like waiting in a selector in case of a {@link SocketChannel}).</p>
-     *
-     * <p> Note that despite not being mandated by the specification, a proper TLS close is important to prevent
-     * truncation attacks, which consists, essentially, of an adversary introducing TCP FIN segments to trick on party
-     * to ignore the final bytes of a secure stream. For more details, see <a href="https://hal.inria.fr/hal-01102013">the
-     * original paper</a>.</p>
-     *
-     * @return whether the closing is finished.
-     * @throws IOException         if the underlying channel throws an IOException
-     * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot be completed
-     *                             immediately
-     * @see TlsChannelBuilder#withWaitForCloseConfirmation(boolean)
-     */
-    boolean shutdown() throws IOException;
+  /**
+   * Closes the underlying channel. This method first does some form of TLS close if not already
+   * done. The exact behavior can be configured using the {@link
+   * TlsChannelBuilder#withWaitForCloseConfirmation}.
+   *
+   * <p>The default behavior mimics what happens in a normal (that is, non layered) {@link
+   * javax.net.ssl.SSLSocket#close()}.
+   *
+   * <p>For finer control of the TLS close, use {@link #shutdown()}
+   *
+   * @throws IOException if the underlying channel throws an IOException during close. Exceptions
+   *     thrown during any previous TLS close are not propagated.
+   */
+  void close() throws IOException;
 
-    /**
-     * Return whether this side of the connection has already received the close
-     * notification.
-     *
-     * @return <code>true</code> if the close notification was received
-     * @see #shutdown()
-     */
-    boolean shutdownReceived();
+  /**
+   * Shuts down the TLS connection. This method emulates the behavior of OpenSSL's <a
+   * href="https://wiki.openssl.org/index.php/Manual:SSL_shutdown(3)">SSL_shutdown()</a>.
+   *
+   * <p>The shutdown procedure consists of two steps: the sending of the "close notify" shutdown
+   * alert and the reception of the peer's "close notify". According to the TLS standard, it is
+   * acceptable for an application to only send its shutdown alert and then close the underlying
+   * connection without waiting for the peer's response. When the underlying connection shall be
+   * used for more communications, the complete shutdown procedure (bidirectional "close notify"
+   * alerts) must be performed, so that the peers stay synchronized.
+   *
+   * <p>This class supports both uni- and bidirectional shutdown by its 2 step behavior, using this
+   * method.
+   *
+   * <p>When this is the first party to send the "close notify" alert, this method will only send
+   * the alert, set the {@link #shutdownSent()} flag and return <code>false</code>. If a
+   * unidirectional shutdown is enough, this first call is sufficient. In order to complete the
+   * bidirectional shutdown handshake, This method must be called again. The second call will wait
+   * for the peer's "close notify" shutdown alert. On success, the second call will return <code>
+   * true</code>.
+   *
+   * <p>If the peer already sent the "close notify" alert and it was already processed implicitly
+   * inside a read operation, the {@link #shutdownReceived()} flag is already set. This method will
+   * then send the "close notify" alert, set the {@link #shutdownSent()} flag and immediately return
+   * <code>true</code>. It is therefore recommended to check the return value of this method and
+   * call it again, if the bidirectional shutdown is not yet complete.
+   *
+   * <p>If the underlying channel is blocking, this method will only return once the handshake step
+   * has been finished or an error occurred.
+   *
+   * <p>If the underlying channel is non-blocking, this method may throw {@link WouldBlockException}
+   * if the underlying channel could not support the continuation of the handshake. The calling
+   * process then must repeat the call after taking appropriate action (like waiting in a selector
+   * in case of a {@link SocketChannel}).
+   *
+   * <p>Note that despite not being mandated by the specification, a proper TLS close is important
+   * to prevent truncation attacks, which consists, essentially, of an adversary introducing TCP FIN
+   * segments to trick on party to ignore the final bytes of a secure stream. For more details, see
+   * <a href="https://hal.inria.fr/hal-01102013">the original paper</a>.
+   *
+   * @return whether the closing is finished.
+   * @throws IOException if the underlying channel throws an IOException
+   * @throws WouldBlockException if the channel is in non-blocking mode and the IO operation cannot
+   *     be completed immediately
+   * @see TlsChannelBuilder#withWaitForCloseConfirmation(boolean)
+   */
+  boolean shutdown() throws IOException;
 
-    /**
-     * Return whether this side of the connection has already sent the close
-     * notification.
-     *
-     * @return <code>true</code> if the close notification was sent
-     * @see #shutdown()
-     */
-    boolean shutdownSent();
+  /**
+   * Return whether this side of the connection has already received the close notification.
+   *
+   * @see #shutdown()
+   * @return <code>true</code> if the close notification was received
+   */
+  boolean shutdownReceived();
 
+  /**
+   * Return whether this side of the connection has already sent the close notification.
+   *
+   * @see #shutdown()
+   * @return <code>true</code> if the close notification was sent
+   */
+  boolean shutdownSent();
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannel.java
@@ -19,6 +19,8 @@
 
 package com.mongodb.internal.connection.tlschannel;
 
+import com.mongodb.internal.connection.tlschannel.mongo.TrackingByteBufAllocator;
+
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
@@ -101,7 +103,7 @@ public interface TlsChannel extends ByteChannel, GatheringByteChannel, Scatterin
    * @see TlsChannelBuilder#withPlainBufferAllocator(BufferAllocator)
    * @see TrackingAllocator
    */
-  TrackingAllocator getPlainBufferAllocator();
+  TrackingByteBufAllocator getPlainBufferAllocator();
 
   /**
    * Return the {@link BufferAllocator} to use for encrypted data. Actually, a decorating subclass
@@ -111,7 +113,7 @@ public interface TlsChannel extends ByteChannel, GatheringByteChannel, Scatterin
    * @see TlsChannelBuilder#withEncryptedBufferAllocator(BufferAllocator)
    * @see TrackingAllocator
    */
-  TrackingAllocator getEncryptedBufferAllocator();
+  TrackingByteBufAllocator getEncryptedBufferAllocator();
 
   /**
    * Return whether CPU-intensive tasks are run or not.

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannelBuilder.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannelBuilder.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
@@ -25,106 +25,117 @@ import java.io.IOException;
 import java.nio.channels.ByteChannel;
 import java.util.function.Consumer;
 
-/**
- * Base class for builders of {@link TlsChannel}.
- */
+/** Base class for builders of {@link TlsChannel}. */
 public abstract class TlsChannelBuilder<T extends TlsChannelBuilder<T>> {
 
-    final ByteChannel underlying;
+  final ByteChannel underlying;
 
-    // @formatter:off
-    Consumer<SSLSession> sessionInitCallback = new Consumer<SSLSession>() {
-        @Override
-        public void accept(final SSLSession session) {
-        }
-    };
-    // @formatter:on
-    boolean runTasks = true;
-    BufferAllocator plainBufferAllocator = null;
-    BufferAllocator encryptedBufferAllocator = null;
-    boolean releaseBuffers = true;
-    boolean waitForCloseConfirmation = false;
+  // @formatter:off
+  Consumer<SSLSession> sessionInitCallback = session -> {};
+  // @formatter:on
+  boolean runTasks = true;
+  BufferAllocator plainBufferAllocator = TlsChannel.defaultPlainBufferAllocator;
+  BufferAllocator encryptedBufferAllocator = TlsChannel.defaultEncryptedBufferAllocator;
+  boolean releaseBuffers = true;
+  boolean waitForCloseConfirmation = false;
 
-    TlsChannelBuilder(final ByteChannel underlying) {
-        this.underlying = underlying;
-    }
+  TlsChannelBuilder(ByteChannel underlying) {
+    this.underlying = underlying;
+  }
 
-    abstract T getThis();
+  abstract T getThis();
 
-    /**
-     * Whether CPU-intensive tasks are run or not. Default is to do run them. If
-     * setting this <code>false</code>, the calling code should be prepared to handle
-     * {@link NeedsTaskException}}
-     */
-    public T withRunTasks(final boolean runTasks) {
-        this.runTasks = runTasks;
-        return getThis();
-    }
+  /**
+   * Whether CPU-intensive tasks are run or not. Default is to do run them. If setting this <code>
+   * false</code>, the calling code should be prepared to handle {@link NeedsTaskException}
+   *
+   * @param runTasks whether to run tasks
+   * @return this object
+   */
+  public T withRunTasks(boolean runTasks) {
+    this.runTasks = runTasks;
+    return getThis();
+  }
 
-    /**
-     * Set the {@link BufferAllocator} to use for unencrypted data.
-     */
-    public T withPlainBufferAllocator(final BufferAllocator bufferAllocator) {
-        this.plainBufferAllocator = bufferAllocator;
-        return getThis();
-    }
+  /**
+   * Set the {@link BufferAllocator} to use for unencrypted data. By default a {@link
+   * HeapBufferAllocator} is used, as this buffers are used to supplement user-supplied ones when
+   * dealing with too big a TLS record, that is, they operate entirely inside the JVM.
+   *
+   * @param bufferAllocator the buffer allocator
+   * @return this object
+   */
+  public T withPlainBufferAllocator(BufferAllocator bufferAllocator) {
+    this.plainBufferAllocator = bufferAllocator;
+    return getThis();
+  }
 
-    /**
-     * Set the {@link BufferAllocator} to use for encrypted data.
-     */
-    public T withEncryptedBufferAllocator(final BufferAllocator bufferAllocator) {
-        this.encryptedBufferAllocator = bufferAllocator;
-        return getThis();
-    }
+  /**
+   * Set the {@link BufferAllocator} to use for encrypted data. By default a {@link
+   * DirectBufferAllocator} is used, as this data is usually read from or written to native sockets.
+   *
+   * @param bufferAllocator the buffer allocator
+   * @return this object
+   */
+  public T withEncryptedBufferAllocator(BufferAllocator bufferAllocator) {
+    this.encryptedBufferAllocator = bufferAllocator;
+    return getThis();
+  }
 
-    /**
-     * Register a callback function to be executed when the TLS session is
-     * established (or re-established). The supplied function will run in the
-     * same thread as the rest of the handshake, so it should ideally run as
-     * fast as possible.
-     */
-    public T withSessionInitCallback(final Consumer<SSLSession> sessionInitCallback) {
-        this.sessionInitCallback = sessionInitCallback;
-        return getThis();
-    }
+  /**
+   * Register a callback function to be executed when the TLS session is established (or
+   * re-established). The supplied function will run in the same thread as the rest of the
+   * handshake, so it should ideally run as fast as possible.
+   *
+   * @param sessionInitCallback the session initialization callback
+   * @return this object
+   */
+  public T withSessionInitCallback(Consumer<SSLSession> sessionInitCallback) {
+    this.sessionInitCallback = sessionInitCallback;
+    return getThis();
+  }
 
-    /**
-     * Whether to release unused buffers in the mid of connections. Equivalent to
-     * OpenSSL's SSL_MODE_RELEASE_BUFFERS.
-     * <p>
-     * Default is to release. Releasing unused buffers is specially effective
-     * in the case case of idle long-lived connections, when the memory footprint
-     * can be reduced significantly. A potential reason for setting this value
-     * to <code>false</code> is performance, since more releases means more
-     * allocations, which have a cost. This is effectively a memory-time trade-off.
-     * However, in most cases the default behavior makes sense.
-     */
-    public T withReleaseBuffers(final boolean releaseBuffers) {
-        this.releaseBuffers = releaseBuffers;
-        return getThis();
-    }
+  /**
+   * Whether to release unused buffers in the mid of connections. Equivalent to OpenSSL's
+   * SSL_MODE_RELEASE_BUFFERS.
+   *
+   * <p>Default is to release. Releasing unused buffers is specially effective in the case case of
+   * idle long-lived connections, when the memory footprint can be reduced significantly. A
+   * potential reason for setting this value to <code>false</code> is performance, since more
+   * releases means more allocations, which have a cost. This is effectively a memory-time
+   * trade-off. However, in most cases the default behavior makes sense.
+   *
+   * @param releaseBuffers whether to release buffers
+   * @return this object
+   */
+  public T withReleaseBuffers(boolean releaseBuffers) {
+    this.releaseBuffers = releaseBuffers;
+    return getThis();
+  }
 
-    /**
-     * <p> Whether to wait for TLS close confirmation when executing a local {@link TlsChannel#close()} on the channel.
-     * If the underlying channel is blocking, setting this to <code>true</code> will block (potentially until it times
-     * out, or indefinitely) the close operation until the counterpart confirms the close on their side (sending a
-     * close_notify alert. If the underlying channel is non-blocking, setting this parameter to true is ineffective.
-     * </p>
-     *
-     * <p> Setting this value to <code>true</code> emulates the behavior of {@link SSLSocket} when used in layered mode
-     * (and without autoClose). </p>
-     *
-     * <p> Even when this behavior is enabled, the close operation will not propagate any {@link IOException} thrown
-     * during the TLS close exchange and just proceed to close the underlying channel. </p>
-     *
-     * <p> Default is to not wait and close immediately. The proper closing procedure can be initiated at any moment
-     * using {@link TlsChannel#shutdown()}.</p>
-     *
-     * @see TlsChannel#shutdown()
-     */
-    public T withWaitForCloseConfirmation(final boolean waitForCloseConfirmation) {
-        this.waitForCloseConfirmation = waitForCloseConfirmation;
-        return getThis();
-    }
-
+  /**
+   * Whether to wait for TLS close confirmation when executing a local {@link TlsChannel#close()} on
+   * the channel. If the underlying channel is blocking, setting this to <code>true</code> will
+   * block (potentially until it times out, or indefinitely) the close operation until the
+   * counterpart confirms the close on their side (sending a close_notify alert. If the underlying
+   * channel is non-blocking, setting this parameter to true is ineffective.
+   *
+   * <p>Setting this value to <code>true</code> emulates the behavior of {@link SSLSocket} when used
+   * in layered mode (and without autoClose).
+   *
+   * <p>Even when this behavior is enabled, the close operation will not propagate any {@link
+   * IOException} thrown during the TLS close exchange and just proceed to close the underlying
+   * channel.
+   *
+   * <p>Default is to not wait and close immediately. The proper closing procedure can be initiated
+   * at any moment using {@link TlsChannel#shutdown()}.
+   *
+   * @param waitForCloseConfirmation whether to wait for close confirmation
+   * @return this object
+   * @see TlsChannel#shutdown()
+   */
+  public T withWaitForCloseConfirmation(boolean waitForCloseConfirmation) {
+    this.waitForCloseConfirmation = waitForCloseConfirmation;
+    return getThis();
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannelBuilder.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannelBuilder.java
@@ -19,6 +19,8 @@
 
 package com.mongodb.internal.connection.tlschannel;
 
+import com.mongodb.internal.connection.tlschannel.mongo.ByteBufAllocator;
+
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import java.io.IOException;
@@ -34,8 +36,8 @@ public abstract class TlsChannelBuilder<T extends TlsChannelBuilder<T>> {
   Consumer<SSLSession> sessionInitCallback = session -> {};
   // @formatter:on
   boolean runTasks = true;
-  BufferAllocator plainBufferAllocator = TlsChannel.defaultPlainBufferAllocator;
-  BufferAllocator encryptedBufferAllocator = TlsChannel.defaultEncryptedBufferAllocator;
+  ByteBufAllocator plainBufferAllocator;
+  ByteBufAllocator encryptedBufferAllocator;
   boolean releaseBuffers = true;
   boolean waitForCloseConfirmation = false;
 
@@ -65,7 +67,7 @@ public abstract class TlsChannelBuilder<T extends TlsChannelBuilder<T>> {
    * @param bufferAllocator the buffer allocator
    * @return this object
    */
-  public T withPlainBufferAllocator(BufferAllocator bufferAllocator) {
+  public T withPlainBufferAllocator(ByteBufAllocator bufferAllocator) {
     this.plainBufferAllocator = bufferAllocator;
     return getThis();
   }
@@ -77,7 +79,7 @@ public abstract class TlsChannelBuilder<T extends TlsChannelBuilder<T>> {
    * @param bufferAllocator the buffer allocator
    * @return this object
    */
-  public T withEncryptedBufferAllocator(BufferAllocator bufferAllocator) {
+  public T withEncryptedBufferAllocator(ByteBufAllocator bufferAllocator) {
     this.encryptedBufferAllocator = bufferAllocator;
     return getThis();
   }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannelCallbackException.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannelCallbackException.java
@@ -19,27 +19,16 @@
 
 package com.mongodb.internal.connection.tlschannel;
 
-import java.nio.ByteBuffer;
+import javax.net.ssl.SSLException;
 
 /**
- * A factory for {@link ByteBuffer}s. Implementations are free to return heap or direct buffers, or
- * to do any kind of pooling. They are also expected to be thread-safe.
+ * Thrown during {@link TlsChannel} handshake to indicate that a user-supplied function threw an
+ * exception.
  */
-public interface BufferAllocator {
+public class TlsChannelCallbackException extends SSLException {
+  private static final long serialVersionUID = 8491908031320425318L;
 
-  /**
-   * Allocate a {@link ByteBuffer} with the given initial capacity.
-   *
-   * @param size the size to allocate
-   * @return the newly created buffer
-   */
-  ByteBuffer allocate(int size);
-
-  /**
-   * Deallocate the given {@link ByteBuffer}.
-   *
-   * @param buffer the buffer to deallocate, that should have been allocated using the same {@link
-   *     BufferAllocator} instance
-   */
-  void free(ByteBuffer buffer);
+  public TlsChannelCallbackException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannelFlowControlException.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/TlsChannelFlowControlException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
@@ -24,28 +24,23 @@ import java.nio.channels.ByteChannel;
 
 /**
  * Base class for exceptions used to control flow.
- * <p>
- * Because exceptions of this class are not used to signal errors, they don't
- * contain stack traces, to improve efficiency.
- * <p>
- * This class inherits from {@link IOException} as a compromise to allow
- * {@link TlsChannel} to throw it while still implementing the
- * {@link ByteChannel} interface.
+ *
+ * <p>Because exceptions of this class are not used to signal errors, they don't contain stack
+ * traces, to improve efficiency.
+ *
+ * <p>This class inherits from {@link IOException} as a compromise to allow {@link TlsChannel} to
+ * throw it while still implementing the {@link ByteChannel} interface.
  */
 public abstract class TlsChannelFlowControlException extends IOException {
+  private static final long serialVersionUID = -2394919487958591959L;
 
-    private static final long serialVersionUID = 6237031103824382007L;
+  public TlsChannelFlowControlException() {
+    super();
+  }
 
-    public TlsChannelFlowControlException() {
-        super();
-    }
-
-    /**
-     * For efficiency, override this method to do nothing.
-     */
-    @Override
-    public Throwable fillInStackTrace() {
-        return this;
-    }
-
+  /** For efficiency, override this method to do nothing. */
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/WouldBlockException.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/WouldBlockException.java
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
 package com.mongodb.internal.connection.tlschannel;
 
 /**
- * Signals that some IO operation cannot continue because the channel is in non
- * blocking mode and some blocking would otherwise happen.
+ * Signals that some IO operation cannot continue because the channel is in non blocking mode and
+ * some blocking would otherwise happen.
  */
 public class WouldBlockException extends TlsChannelFlowControlException {
-
-    private static final long serialVersionUID = -165334493836093518L;
+  private static final long serialVersionUID = -1881728208118024998L;
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannel.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
 package com.mongodb.internal.connection.tlschannel.async;
 
-import com.mongodb.internal.connection.ExtendedAsynchronousByteChannel;
 import com.mongodb.internal.connection.tlschannel.TlsChannel;
+import com.mongodb.internal.connection.tlschannel.async.AsynchronousTlsChannelGroup.RegisteredSocket;
 import com.mongodb.internal.connection.tlschannel.impl.ByteBufferSet;
 
 import java.io.IOException;
@@ -32,385 +32,253 @@ import java.nio.channels.SocketChannel;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.function.LongConsumer;
 
-/**
- * An {@link AsynchronousByteChannel} that works using {@link TlsChannel}s.
- */
+import static com.mongodb.internal.connection.tlschannel.async.AsynchronousTlsChannelGroup.ReadOperation;
+import static com.mongodb.internal.connection.tlschannel.async.AsynchronousTlsChannelGroup.WriteOperation;
+
+/** An {@link AsynchronousByteChannel} that works using {@link TlsChannel}s. */
 public class AsynchronousTlsChannel implements ExtendedAsynchronousByteChannel {
 
-    private class FutureReadResult extends CompletableFuture<Integer> {
-        AsynchronousTlsChannelGroup.ReadOperation op;
-
-        @Override
-        public boolean cancel(final boolean mayInterruptIfRunning) {
-            super.cancel(mayInterruptIfRunning);
-            return group.doCancelRead(registeredSocket, op);
-        }
-    }
-
-    private class FutureWriteResult extends CompletableFuture<Integer> {
-        AsynchronousTlsChannelGroup.WriteOperation op;
-
-        @Override
-        public boolean cancel(final boolean mayInterruptIfRunning) {
-            super.cancel(mayInterruptIfRunning);
-            return group.doCancelWrite(registeredSocket, op);
-        }
-    }
-
-    private final AsynchronousTlsChannelGroup group;
-    private final TlsChannel tlsChannel;
-    private final AsynchronousTlsChannelGroup.RegisteredSocket registeredSocket;
-
-    /**
-     * Initializes a new instance of this class.
-     *
-     * @param channelGroup  group to associate new new channel to
-     * @param tlsChannel    existing TLS channel to be used asynchronously
-     * @param socketChannel underlying socket
-     * @throws ClosedChannelException   if any of the underlying channels are closed.
-     * @throws IllegalArgumentException is the socket is in blocking mode
-     */
-    public AsynchronousTlsChannel(
-            final AsynchronousTlsChannelGroup channelGroup,
-            final TlsChannel tlsChannel,
-            final SocketChannel socketChannel) throws ClosedChannelException, IllegalArgumentException {
-        if (!socketChannel.isOpen()) {
-            throw new ClosedChannelException();
-        }
-        if (!tlsChannel.isOpen()) {
-            throw new ClosedChannelException();
-        }
-        if (socketChannel.isBlocking()) {
-            throw new IllegalArgumentException("socket channel must be in non-blocking mode");
-        }
-        this.group = channelGroup;
-        this.tlsChannel = tlsChannel;
-        this.registeredSocket = channelGroup.registerSocket(tlsChannel, socketChannel);
-    }
+  private class FutureReadResult extends CompletableFuture<Integer> {
+    ReadOperation op;
 
     @Override
-    public <A> void read(
-            final ByteBuffer dst,
-            final A attach, final CompletionHandler<Integer, ? super A> handler) {
-        checkReadOnly(dst);
-        if (!dst.hasRemaining()) {
-            completeWithZeroInt(attach, handler);
-            return;
-        }
+    public boolean cancel(boolean mayInterruptIfRunning) {
+      super.cancel(mayInterruptIfRunning);
+      return group.doCancelRead(registeredSocket, op);
+    }
+  }
+
+  private class FutureWriteResult extends CompletableFuture<Integer> {
+    WriteOperation op;
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+      super.cancel(mayInterruptIfRunning);
+      return group.doCancelWrite(registeredSocket, op);
+    }
+  }
+
+  private final AsynchronousTlsChannelGroup group;
+  private final TlsChannel tlsChannel;
+  private final RegisteredSocket registeredSocket;
+
+  /**
+   * Initializes a new instance of this class.
+   *
+   * @param channelGroup group to associate new new channel to
+   * @param tlsChannel existing TLS channel to be used asynchronously
+   * @param socketChannel underlying socket
+   * @throws ClosedChannelException if any of the underlying channels are closed.
+   * @throws IllegalArgumentException is the socket is in blocking mode
+   */
+  public AsynchronousTlsChannel(
+      AsynchronousTlsChannelGroup channelGroup, TlsChannel tlsChannel, SocketChannel socketChannel)
+      throws ClosedChannelException, IllegalArgumentException {
+    if (!tlsChannel.isOpen() || !socketChannel.isOpen()) {
+      throw new ClosedChannelException();
+    }
+    if (socketChannel.isBlocking()) {
+      throw new IllegalArgumentException("socket channel must be in non-blocking mode");
+    }
+    this.group = channelGroup;
+    this.tlsChannel = tlsChannel;
+    this.registeredSocket = channelGroup.registerSocket(tlsChannel, socketChannel);
+  }
+
+  @Override
+  public <A> void read(ByteBuffer dst, A attach, CompletionHandler<Integer, ? super A> handler) {
+    checkReadOnly(dst);
+    if (!dst.hasRemaining()) {
+      completeWithZeroInt(attach, handler);
+      return;
+    }
+    group.startRead(
+        registeredSocket,
+        new ByteBufferSet(dst),
+        0,
+        TimeUnit.MILLISECONDS,
+        c -> group.executor.submit(() -> handler.completed((int) c, attach)),
+        e -> group.executor.submit(() -> handler.failed(e, attach)));
+  }
+
+  @Override
+  public <A> void read(
+      ByteBuffer dst,
+      long timeout,
+      TimeUnit unit,
+      A attach,
+      CompletionHandler<Integer, ? super A> handler) {
+    checkReadOnly(dst);
+    if (!dst.hasRemaining()) {
+      completeWithZeroInt(attach, handler);
+      return;
+    }
+    group.startRead(
+        registeredSocket,
+        new ByteBufferSet(dst),
+        timeout,
+        unit,
+        c -> group.executor.submit(() -> handler.completed((int) c, attach)),
+        e -> group.executor.submit(() -> handler.failed(e, attach)));
+  }
+
+  @Override
+  public <A> void read(
+      ByteBuffer[] dsts,
+      int offset,
+      int length,
+      long timeout,
+      TimeUnit unit,
+      A attach,
+      CompletionHandler<Long, ? super A> handler) {
+    ByteBufferSet bufferSet = new ByteBufferSet(dsts, offset, length);
+    if (bufferSet.isReadOnly()) {
+      throw new IllegalArgumentException("buffer is read-only");
+    }
+    if (!bufferSet.hasRemaining()) {
+      completeWithZeroLong(attach, handler);
+      return;
+    }
+    group.startRead(
+        registeredSocket,
+        bufferSet,
+        timeout,
+        unit,
+        c -> group.executor.submit(() -> handler.completed(c, attach)),
+        e -> group.executor.submit(() -> handler.failed(e, attach)));
+  }
+
+  @Override
+  public Future<Integer> read(ByteBuffer dst) {
+    checkReadOnly(dst);
+    if (!dst.hasRemaining()) {
+      return CompletableFuture.completedFuture(0);
+    }
+    FutureReadResult future = new FutureReadResult();
+    ReadOperation op =
         group.startRead(
-                registeredSocket,
-                new ByteBufferSet(dst),
-                0, TimeUnit.MILLISECONDS,
-                new LongConsumer() {
-                    @Override
-                    public void accept(final long c) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.completed((int) c, attach);
-                            }
-                        });
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(final Throwable e) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.failed(e, attach);
-                            }
-                        });
-                    }
-                });
-    }
+            registeredSocket,
+            new ByteBufferSet(dst),
+            0,
+            TimeUnit.MILLISECONDS,
+            c -> future.complete((int) c),
+            future::completeExceptionally);
+    future.op = op;
+    return future;
+  }
 
-    @Override
-    public <A> void read(
-            final ByteBuffer dst,
-            final long timeout, final TimeUnit unit,
-            final A attach, final CompletionHandler<Integer, ? super A> handler) {
-        checkReadOnly(dst);
-        if (!dst.hasRemaining()) {
-            completeWithZeroInt(attach, handler);
-            return;
-        }
-        group.startRead(
-                registeredSocket,
-                new ByteBufferSet(dst),
-                timeout, unit,
-                new LongConsumer() {
-                    @Override
-                    public void accept(final long c) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.completed((int) c, attach);
-                            }
-                        });
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(final Throwable e) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.failed(e, attach);
-                            }
-                        });
-                    }
-                });
+  private void checkReadOnly(ByteBuffer dst) {
+    if (dst.isReadOnly()) {
+      throw new IllegalArgumentException("buffer is read-only");
     }
+  }
 
-    @Override
-    public <A> void read(
-            final ByteBuffer[] dsts, final int offset, final int length,
-            final long timeout, final TimeUnit unit,
-            final A attach, final CompletionHandler<Long, ? super A> handler) {
-        ByteBufferSet bufferSet = new ByteBufferSet(dsts, offset, length);
-        if (bufferSet.isReadOnly()) {
-            throw new IllegalArgumentException("buffer is read-only");
-        }
-        if (!bufferSet.hasRemaining()) {
-            completeWithZeroLong(attach, handler);
-            return;
-        }
-        group.startRead(
-                registeredSocket,
-                bufferSet,
-                timeout, unit,
-                new LongConsumer() {
-                    @Override
-                    public void accept(final long c) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.completed(c, attach);
-                            }
-                        });
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(final Throwable e) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.failed(e, attach);
-                            }
-                        });
-                    }
-                });
+  @Override
+  public <A> void write(ByteBuffer src, A attach, CompletionHandler<Integer, ? super A> handler) {
+    if (!src.hasRemaining()) {
+      completeWithZeroInt(attach, handler);
+      return;
     }
+    group.startWrite(
+        registeredSocket,
+        new ByteBufferSet(src),
+        0,
+        TimeUnit.MILLISECONDS,
+        c -> group.executor.submit(() -> handler.completed((int) c, attach)),
+        e -> group.executor.submit(() -> handler.failed(e, attach)));
+  }
 
-    @Override
-    public Future<Integer> read(final ByteBuffer dst) {
-        checkReadOnly(dst);
-        if (!dst.hasRemaining()) {
-            return CompletableFuture.completedFuture(0);
-        }
-        final FutureReadResult future = new FutureReadResult();
-        future.op = group.startRead(
-                registeredSocket,
-                new ByteBufferSet(dst),
-                0, TimeUnit.MILLISECONDS,
-                new LongConsumer() {
-                    @Override
-                    public void accept(final long c) {
-                        future.complete((int) c);
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(final Throwable ex) {
-                        future.completeExceptionally(ex);
-                    }
-                });
-        return future;
+  @Override
+  public <A> void write(
+      ByteBuffer src,
+      long timeout,
+      TimeUnit unit,
+      A attach,
+      CompletionHandler<Integer, ? super A> handler) {
+    if (!src.hasRemaining()) {
+      completeWithZeroInt(attach, handler);
+      return;
     }
+    group.startWrite(
+        registeredSocket,
+        new ByteBufferSet(src),
+        timeout,
+        unit,
+        c -> group.executor.submit(() -> handler.completed((int) c, attach)),
+        e -> group.executor.submit(() -> handler.failed(e, attach)));
+  }
 
-    private void checkReadOnly(final ByteBuffer dst) {
-        if (dst.isReadOnly()) {
-            throw new IllegalArgumentException("buffer is read-only");
-        }
+  @Override
+  public <A> void write(
+      ByteBuffer[] srcs,
+      int offset,
+      int length,
+      long timeout,
+      TimeUnit unit,
+      A attach,
+      CompletionHandler<Long, ? super A> handler) {
+    ByteBufferSet bufferSet = new ByteBufferSet(srcs, offset, length);
+    if (!bufferSet.hasRemaining()) {
+      completeWithZeroLong(attach, handler);
+      return;
     }
+    group.startWrite(
+        registeredSocket,
+        bufferSet,
+        timeout,
+        unit,
+        c -> group.executor.submit(() -> handler.completed(c, attach)),
+        e -> group.executor.submit(() -> handler.failed(e, attach)));
+  }
 
-    @Override
-    public <A> void write(final ByteBuffer src, final A attach, final CompletionHandler<Integer, ? super A> handler) {
-        if (!src.hasRemaining()) {
-            completeWithZeroInt(attach, handler);
-            return;
-        }
+  @Override
+  public Future<Integer> write(ByteBuffer src) {
+    if (!src.hasRemaining()) {
+      return CompletableFuture.completedFuture(0);
+    }
+    FutureWriteResult future = new FutureWriteResult();
+    WriteOperation op =
         group.startWrite(
-                registeredSocket,
-                new ByteBufferSet(src),
-                0, TimeUnit.MILLISECONDS,
-                new LongConsumer() {
-                    @Override
-                    public void accept(final long c) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.completed((int) c, attach);
-                            }
-                        });
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(final Throwable e) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.failed(e, attach);
-                            }
-                        });
-                    }
-                });
-    }
+            registeredSocket,
+            new ByteBufferSet(src),
+            0,
+            TimeUnit.MILLISECONDS,
+            c -> future.complete((int) c),
+            future::completeExceptionally);
+    future.op = op;
+    return future;
+  }
 
-    @Override
-    public <A> void write(
-            final ByteBuffer src,
-            final long timeout, final TimeUnit unit,
-            final A attach, final CompletionHandler<Integer, ? super A> handler) {
-        if (!src.hasRemaining()) {
-            completeWithZeroInt(attach, handler);
-            return;
-        }
-        group.startWrite(
-                registeredSocket,
-                new ByteBufferSet(src),
-                timeout, unit,
-                new LongConsumer() {
-                    @Override
-                    public void accept(final long c) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.completed((int) c, attach);
-                            }
-                        });
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(final Throwable e) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.failed(e, attach);
-                            }
-                        });
-                    }
-                });
-    }
+  private <A> void completeWithZeroInt(A attach, CompletionHandler<Integer, ? super A> handler) {
+    group.executor.submit(() -> handler.completed(0, attach));
+  }
 
-    @Override
-    public <A> void write(
-            final ByteBuffer[] srcs, final int offset, final int length,
-            final long timeout, final TimeUnit unit,
-            final A attach, final CompletionHandler<Long, ? super A> handler) {
-        ByteBufferSet bufferSet = new ByteBufferSet(srcs, offset, length);
-        if (!bufferSet.hasRemaining()) {
-            completeWithZeroLong(attach, handler);
-            return;
-        }
-        group.startWrite(
-                registeredSocket,
-                bufferSet,
-                timeout, unit,
-                new LongConsumer() {
-                    @Override
-                    public void accept(final long c) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.completed(c, attach);
-                            }
-                        });
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(final Throwable e) {
-                        group.executor.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.failed(e, attach);
-                            }
-                        });
-                    }
-                });
-    }
+  private <A> void completeWithZeroLong(A attach, CompletionHandler<Long, ? super A> handler) {
+    group.executor.submit(() -> handler.completed(0L, attach));
+  }
 
-    @Override
-    public Future<Integer> write(final ByteBuffer src) {
-        if (!src.hasRemaining()) {
-            return CompletableFuture.completedFuture(0);
-        }
-        final FutureWriteResult future = new FutureWriteResult();
-        future.op = group.startWrite(
-                registeredSocket,
-                new ByteBufferSet(src),
-                0, TimeUnit.MILLISECONDS,
-                new LongConsumer() {
-                    @Override
-                    public void accept(final long c) {
-                        future.complete((int) c);
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(final Throwable ex) {
-                        future.completeExceptionally(ex);
-                    }
-                });
-        return future;
-    }
+  /**
+   * Tells whether or not this channel is open.
+   *
+   * @return <code>true</code> if, and only if, this channel is open
+   */
+  @Override
+  public boolean isOpen() {
+    return tlsChannel.isOpen();
+  }
 
-    private <A> void completeWithZeroInt(final A attach, final CompletionHandler<Integer, ? super A> handler) {
-        group.executor.submit(new Runnable() {
-            @Override
-            public void run() {
-                handler.completed(0, attach);
-            }
-        });
-    }
-
-    private <A> void completeWithZeroLong(final A attach, final CompletionHandler<Long, ? super A> handler) {
-        group.executor.submit(new Runnable() {
-            @Override
-            public void run() {
-                handler.completed(0L, attach);
-            }
-        });
-    }
-
-    /**
-     * Tells whether or not this channel is open.
-     *
-     * @return <tt>true</tt> if, and only if, this channel is open
-     */
-    @Override
-    public boolean isOpen() {
-        return tlsChannel.isOpen();
-    }
-
-    /**
-     * Closes this channel.
-     *
-     * <p>This method will close the underlying {@link TlsChannel} and also deregister it from its group.</p>
-     *
-     * @throws IOException If an I/O error occurs
-     */
-    @Override
-    public void close() throws IOException {
-        tlsChannel.close();
-        registeredSocket.close();
-    }
+  /**
+   * Closes this channel.
+   *
+   * <p>This method will close the underlying {@link TlsChannel} and also deregister it from its
+   * group.
+   *
+   * @throws IOException If an I/O error occurs
+   */
+  @Override
+  public void close() throws IOException {
+    tlsChannel.close();
+    registeredSocket.close();
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannelGroup.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannelGroup.java
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
 package com.mongodb.internal.connection.tlschannel.async;
 
-import com.mongodb.diagnostics.logging.Logger;
-import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.internal.connection.tlschannel.NeedsReadException;
 import com.mongodb.internal.connection.tlschannel.NeedsTaskException;
 import com.mongodb.internal.connection.tlschannel.NeedsWriteException;
 import com.mongodb.internal.connection.tlschannel.TlsChannel;
 import com.mongodb.internal.connection.tlschannel.impl.ByteBufferSet;
 import com.mongodb.internal.connection.tlschannel.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.channels.CancelledKeyException;
@@ -45,7 +45,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,747 +53,706 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-import java.util.function.IntBinaryOperator;
 import java.util.function.LongConsumer;
 
-import static java.lang.String.format;
-
 /**
- * This class encapsulates the infrastructure for running {@link AsynchronousTlsChannel}s. Each instance of this class
- * is a singleton-like object that manages a thread pool that makes it possible to run a group of asynchronous
- * channels.
+ * This class encapsulates the infrastructure for running {@link AsynchronousTlsChannel}s. Each
+ * instance of this class is a singleton-like object that manages a thread pool that makes it
+ * possible to run a group of asynchronous channels.
  */
 public class AsynchronousTlsChannelGroup {
 
-    private static final Logger LOGGER = Loggers.getLogger("connection.tls");
+  private static final Logger logger = LoggerFactory.getLogger(AsynchronousTlsChannelGroup.class);
+
+  /** The main executor of the group has a queue, whose size is a multiple of the number of CPUs. */
+  private static final int queueLengthMultiplier = 32;
+
+  private static AtomicInteger globalGroupCount = new AtomicInteger();
+
+  class RegisteredSocket {
+
+    final TlsChannel tlsChannel;
+    final SocketChannel socketChannel;
 
     /**
-     * The main executor of the group has a queue, whose size is a multiple of the number of CPUs.
+     * Used to wait until the channel is effectively in the selector (which happens asynchronously
+     * to the initial registration.
      */
-    private static final int QUEUE_LENGTH_MULTIPLIER = 32;
+    final CountDownLatch registered = new CountDownLatch(1);
 
-    private static AtomicInteger globalGroupCount = new AtomicInteger();
+    SelectionKey key;
 
-    class RegisteredSocket {
+    /** Protects {@link #readOperation} reference and instance. */
+    final Lock readLock = new ReentrantLock();
 
-        final TlsChannel tlsChannel;
-        final SocketChannel socketChannel;
+    /** Protects {@link #writeOperation} reference and instance. */
+    final Lock writeLock = new ReentrantLock();
 
-        /**
-         * Used to wait until the channel is effectively in the selector (which happens asynchronously to the initial
-         * registration.
-         */
-        final CountDownLatch registered = new CountDownLatch(1);
+    /** Current read operation, in not null */
+    ReadOperation readOperation;
 
-        SelectionKey key;
+    /** Current write operation, if not null */
+    WriteOperation writeOperation;
 
-        /**
-         * Protects {@link #readOperation} reference and instance.
-         */
-        final Lock readLock = new ReentrantLock();
+    /** Bitwise union of pending operation to be registered in the selector */
+    final AtomicInteger pendingOps = new AtomicInteger();
 
-        /**
-         * Protects {@link #writeOperation} reference and instance.
-         */
-        final Lock writeLock = new ReentrantLock();
-
-        /**
-         * Current read operation, in not null
-         */
-        ReadOperation readOperation;
-
-        /**
-         * Current write operation, if not null
-         */
-        WriteOperation writeOperation;
-
-        /**
-         * Bitwise union of pending operation to be registered in the selector
-         */
-        final AtomicInteger pendingOps = new AtomicInteger();
-
-        RegisteredSocket(final TlsChannel tlsChannel, final SocketChannel socketChannel) {
-            this.tlsChannel = tlsChannel;
-            this.socketChannel = socketChannel;
-        }
-
-        public void close() {
-            doCancelRead(this, null);
-            doCancelWrite(this, null);
-            key.cancel();
-            currentRegistrations.getAndDecrement();
-            /*
-             * Actual de-registration from the selector will happen asynchronously.
-             */
-            selector.wakeup();
-        }
+    RegisteredSocket(TlsChannel tlsChannel, SocketChannel socketChannel)
+        throws ClosedChannelException {
+      this.tlsChannel = tlsChannel;
+      this.socketChannel = socketChannel;
     }
 
-    private abstract static class Operation {
-        final ByteBufferSet bufferSet;
-        final LongConsumer onSuccess;
-        final Consumer<Throwable> onFailure;
-        Future<?> timeoutFuture;
-
-        Operation(final ByteBufferSet bufferSet, final LongConsumer onSuccess, final Consumer<Throwable> onFailure) {
-            this.bufferSet = bufferSet;
-            this.onSuccess = onSuccess;
-            this.onFailure = onFailure;
-        }
+    public void close() {
+      doCancelRead(this, null);
+      doCancelWrite(this, null);
+      key.cancel();
+      currentRegistrations.getAndDecrement();
+      /*
+       * Actual de-registration from the selector will happen asynchronously.
+       */
+      selector.wakeup();
     }
+  }
 
-    static final class ReadOperation extends Operation {
-        ReadOperation(final ByteBufferSet bufferSet, final LongConsumer onSuccess, final Consumer<Throwable> onFailure) {
-            super(bufferSet, onSuccess, onFailure);
-        }
+  private abstract static class Operation {
+    final ByteBufferSet bufferSet;
+    final LongConsumer onSuccess;
+    final Consumer<Throwable> onFailure;
+    Future<?> timeoutFuture;
+
+    Operation(ByteBufferSet bufferSet, LongConsumer onSuccess, Consumer<Throwable> onFailure) {
+      this.bufferSet = bufferSet;
+      this.onSuccess = onSuccess;
+      this.onFailure = onFailure;
     }
+  }
 
-    static final class WriteOperation extends Operation {
-
-        /**
-         * Because a write operation can flag a block (needs read/write) even after the source buffer was read from, we
-         * need to accumulate consumed bytes.
-         */
-        long consumesBytes = 0;
-
-        WriteOperation(final ByteBufferSet bufferSet, final LongConsumer onSuccess, final Consumer<Throwable> onFailure) {
-            super(bufferSet, onSuccess, onFailure);
-        }
+  static final class ReadOperation extends Operation {
+    ReadOperation(ByteBufferSet bufferSet, LongConsumer onSuccess, Consumer<Throwable> onFailure) {
+      super(bufferSet, onSuccess, onFailure);
     }
+  }
 
-    private final int id = globalGroupCount.getAndIncrement();
+  static final class WriteOperation extends Operation {
 
     /**
-     * With the intention of being spacer with warnings, use this flag to ensure that we only log the warning about
-     * needed task once.
+     * Because a write operation can flag a block (needs read/write) even after the source buffer
+     * was read from, we need to accumulate consumed bytes.
      */
-    private final AtomicBoolean loggedTaskWarning = new AtomicBoolean();
+    long consumesBytes = 0;
 
-    private final Selector selector;
-
-    final ExecutorService executor;
-
-    private final ScheduledThreadPoolExecutor timeoutExecutor = new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
-        @Override
-        public Thread newThread(final Runnable runnable) {
-            return new Thread(runnable, format("async-channel-group-%d-timeout-thread", id));
-        }
+    WriteOperation(ByteBufferSet bufferSet, LongConsumer onSuccess, Consumer<Throwable> onFailure) {
+      super(bufferSet, onSuccess, onFailure);
     }
-    );
+  }
 
-    private final Thread selectorThread = new Thread(new Runnable() {
-        @Override
-        public void run() {
-            AsynchronousTlsChannelGroup.this.loop();
-        }
-    }, format("async-channel-group-%d-selector", id));
+  private final int id = globalGroupCount.getAndIncrement();
 
-    private final ConcurrentLinkedQueue<RegisteredSocket> pendingRegistrations = new ConcurrentLinkedQueue<RegisteredSocket>();
+  /**
+   * With the intention of being spacer with warnings, use this flag to ensure that we only log the
+   * warning about needed task once.
+   */
+  private final AtomicBoolean loggedTaskWarning = new AtomicBoolean();
 
-    private enum Shutdown {
-        No, Wait, Immediate
+  private final Selector selector;
+
+  final ExecutorService executor;
+
+  private final ScheduledThreadPoolExecutor timeoutExecutor =
+      new ScheduledThreadPoolExecutor(
+          1,
+          runnable ->
+              new Thread(runnable, String.format("async-channel-group-%d-timeout-thread", id)));
+
+  private final Thread selectorThread =
+      new Thread(this::loop, String.format("async-channel-group-%d-selector", id));
+
+  private final ConcurrentLinkedQueue<RegisteredSocket> pendingRegistrations =
+      new ConcurrentLinkedQueue<>();
+
+  private enum Shutdown {
+    No,
+    Wait,
+    Immediate
+  }
+
+  private volatile Shutdown shutdown = Shutdown.No;
+
+  private LongAdder selectionCount = new LongAdder();
+
+  private LongAdder startedReads = new LongAdder();
+  private LongAdder startedWrites = new LongAdder();
+  private LongAdder successfulReads = new LongAdder();
+  private LongAdder successfulWrites = new LongAdder();
+  private LongAdder failedReads = new LongAdder();
+  private LongAdder failedWrites = new LongAdder();
+  private LongAdder cancelledReads = new LongAdder();
+  private LongAdder cancelledWrites = new LongAdder();
+
+  // used for synchronization
+  private AtomicInteger currentRegistrations = new AtomicInteger();
+
+  private LongAdder currentReads = new LongAdder();
+  private LongAdder currentWrites = new LongAdder();
+
+  /**
+   * Creates an instance of this class.
+   *
+   * @param nThreads number of threads in the executor used to assist the selector loop and run
+   *     completion handlers.
+   */
+  public AsynchronousTlsChannelGroup(int nThreads) {
+    try {
+      selector = Selector.open();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
+    timeoutExecutor.setRemoveOnCancelPolicy(true);
+    this.executor =
+        new ThreadPoolExecutor(
+            nThreads,
+            nThreads,
+            0,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(nThreads * queueLengthMultiplier),
+            runnable ->
+                new Thread(runnable, String.format("async-channel-group-%d-handler-executor", id)),
+            new ThreadPoolExecutor.CallerRunsPolicy());
+    selectorThread.start();
+  }
 
-    private volatile Shutdown shutdown = Shutdown.No;
+  /** Creates an instance of this class, using as many thread as available processors. */
+  public AsynchronousTlsChannelGroup() {
+    this(Runtime.getRuntime().availableProcessors());
+  }
 
-    private LongAdder selectionCount = new LongAdder();
+  RegisteredSocket registerSocket(TlsChannel reader, SocketChannel socketChannel)
+      throws ClosedChannelException {
+    if (shutdown != Shutdown.No) {
+      throw new ShutdownChannelGroupException();
+    }
+    RegisteredSocket socket = new RegisteredSocket(reader, socketChannel);
+    currentRegistrations.getAndIncrement();
+    pendingRegistrations.add(socket);
+    selector.wakeup();
+    return socket;
+  }
 
-    private LongAdder startedReads = new LongAdder();
-    private LongAdder startedWrites = new LongAdder();
-    private LongAdder successfulReads = new LongAdder();
-    private LongAdder successfulWrites = new LongAdder();
-    private LongAdder failedReads = new LongAdder();
-    private LongAdder failedWrites = new LongAdder();
-    private LongAdder cancelledReads = new LongAdder();
-    private LongAdder cancelledWrites = new LongAdder();
+  boolean doCancelRead(RegisteredSocket socket, ReadOperation op) {
+    socket.readLock.lock();
+    try {
+      // a null op means cancel any operation
+      if (op != null && socket.readOperation == op || op == null && socket.readOperation != null) {
+        socket.readOperation = null;
+        cancelledReads.increment();
+        currentReads.decrement();
+        return true;
+      } else {
+        return false;
+      }
+    } finally {
+      socket.readLock.unlock();
+    }
+  }
 
-    // used for synchronization
-    private AtomicInteger currentRegistrations = new AtomicInteger();
+  boolean doCancelWrite(RegisteredSocket socket, WriteOperation op) {
+    socket.writeLock.lock();
+    try {
+      // a null op means cancel any operation
+      if (op != null && socket.writeOperation == op
+          || op == null && socket.writeOperation != null) {
+        socket.writeOperation = null;
+        cancelledWrites.increment();
+        currentWrites.decrement();
+        return true;
+      } else {
+        return false;
+      }
+    } finally {
+      socket.writeLock.unlock();
+    }
+  }
 
-    private LongAdder currentReads = new LongAdder();
-    private LongAdder currentWrites = new LongAdder();
-
-    /**
-     * Creates an instance of this class.
-     *
-     * @param nThreads number of threads in the executor used to assist the selector loop and run completion handlers.
-     */
-    public AsynchronousTlsChannelGroup(final int nThreads) {
-        try {
-            selector = Selector.open();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        timeoutExecutor.setRemoveOnCancelPolicy(true);
-        this.executor = new ThreadPoolExecutor(
-                nThreads, nThreads,
-                0, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<Runnable>(nThreads * QUEUE_LENGTH_MULTIPLIER),
-                new ThreadFactory() {
-                    @Override
-                    public Thread newThread(final Runnable runnable) {
-                        return new Thread(runnable, format("async-channel-group-%d-handler-executor", id));
-                    }
+  ReadOperation startRead(
+      RegisteredSocket socket,
+      ByteBufferSet buffer,
+      long timeout,
+      TimeUnit unit,
+      LongConsumer onSuccess,
+      Consumer<Throwable> onFailure)
+      throws ReadPendingException {
+    checkTerminated();
+    Util.assertTrue(buffer.hasRemaining());
+    waitForSocketRegistration(socket);
+    ReadOperation op;
+    socket.readLock.lock();
+    try {
+      if (socket.readOperation != null) {
+        throw new ReadPendingException();
+      }
+      op = new ReadOperation(buffer, onSuccess, onFailure);
+      /*
+       * we do not try to outsmart the TLS state machine and register for both IO operations for each new socket
+       * operation
+       */
+      socket.pendingOps.set(SelectionKey.OP_WRITE | SelectionKey.OP_READ);
+      if (timeout != 0) {
+        op.timeoutFuture =
+            timeoutExecutor.schedule(
+                () -> {
+                  boolean success = doCancelRead(socket, op);
+                  if (success) {
+                    op.onFailure.accept(new InterruptedByTimeoutException());
+                  }
                 },
-                new ThreadPoolExecutor.CallerRunsPolicy());
-        selectorThread.start();
+                timeout,
+                unit);
+      }
+      socket.readOperation = op;
+    } finally {
+      socket.readLock.unlock();
     }
+    selector.wakeup();
+    startedReads.increment();
+    currentReads.increment();
+    return op;
+  }
 
-    /**
-     * Creates an instance of this class, using as many thread as available processors.
-     */
-    public AsynchronousTlsChannelGroup() {
-        this(Runtime.getRuntime().availableProcessors());
+  WriteOperation startWrite(
+      RegisteredSocket socket,
+      ByteBufferSet buffer,
+      long timeout,
+      TimeUnit unit,
+      LongConsumer onSuccess,
+      Consumer<Throwable> onFailure)
+      throws WritePendingException {
+    checkTerminated();
+    Util.assertTrue(buffer.hasRemaining());
+    waitForSocketRegistration(socket);
+    WriteOperation op;
+    socket.writeLock.lock();
+    try {
+      if (socket.writeOperation != null) {
+        throw new WritePendingException();
+      }
+      op = new WriteOperation(buffer, onSuccess, onFailure);
+      /*
+       * we do not try to outsmart the TLS state machine and register for both IO operations for each new socket
+       * operation
+       */
+      socket.pendingOps.set(SelectionKey.OP_WRITE | SelectionKey.OP_READ);
+      if (timeout != 0) {
+        op.timeoutFuture =
+            timeoutExecutor.schedule(
+                () -> {
+                  boolean success = doCancelWrite(socket, op);
+                  if (success) {
+                    op.onFailure.accept(new InterruptedByTimeoutException());
+                  }
+                },
+                timeout,
+                unit);
+      }
+      socket.writeOperation = op;
+    } finally {
+      socket.writeLock.unlock();
     }
+    selector.wakeup();
+    startedWrites.increment();
+    currentWrites.increment();
+    return op;
+  }
 
-    RegisteredSocket registerSocket(final TlsChannel reader, final SocketChannel socketChannel) {
-        if (shutdown != Shutdown.No) {
-            throw new ShutdownChannelGroupException();
-        }
-        RegisteredSocket socket = new RegisteredSocket(reader, socketChannel);
-        currentRegistrations.getAndIncrement();
-        pendingRegistrations.add(socket);
-        selector.wakeup();
-        return socket;
+  private void checkTerminated() {
+    if (isTerminated()) {
+      throw new ShutdownChannelGroupException();
     }
+  }
 
-    boolean doCancelRead(final RegisteredSocket socket, final ReadOperation op) {
-        socket.readLock.lock();
-        try {
-            // a null op means cancel any operation
-            if (op != null && socket.readOperation == op || op == null && socket.readOperation != null) {
-                socket.readOperation = null;
-                cancelledReads.increment();
-                currentReads.decrement();
-                return true;
-            } else {
-                return false;
-            }
-        } finally {
-            socket.readLock.unlock();
-        }
+  private void waitForSocketRegistration(RegisteredSocket socket) {
+    try {
+      socket.registered.await();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    boolean doCancelWrite(final RegisteredSocket socket, final WriteOperation op) {
-        socket.writeLock.lock();
-        try {
-            // a null op means cancel any operation
-            if (op != null && socket.writeOperation == op || op == null && socket.writeOperation != null) {
-                socket.writeOperation = null;
-                cancelledWrites.increment();
-                currentWrites.decrement();
-                return true;
-            } else {
-                return false;
-            }
-        } finally {
-            socket.writeLock.unlock();
-        }
-    }
-
-    ReadOperation startRead(
-            final RegisteredSocket socket,
-            final ByteBufferSet buffer,
-            final long timeout, final TimeUnit unit,
-            final LongConsumer onSuccess, final Consumer<Throwable> onFailure)
-            throws ReadPendingException {
-        checkTerminated();
-        Util.assertTrue(buffer.hasRemaining());
-        waitForSocketRegistration(socket);
-        ReadOperation op;
-        socket.readLock.lock();
-        try {
-            if (socket.readOperation != null) {
-                throw new ReadPendingException();
-            }
-            op = new ReadOperation(buffer, onSuccess, onFailure);
-            final ReadOperation finalOp = op;
-            /*
-             * we do not try to outsmart the TLS state machine and register for both IO operations for each new socket
-             * operation
-             */
-            socket.pendingOps.set(SelectionKey.OP_WRITE | SelectionKey.OP_READ);
-            if (timeout != 0) {
-                op.timeoutFuture = timeoutExecutor.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        boolean success = AsynchronousTlsChannelGroup.this.doCancelRead(socket, finalOp);
-                        if (success) {
-                            finalOp.onFailure.accept(new InterruptedByTimeoutException());
-                        }
-                    }
-                }, timeout, unit);
-            }
-            socket.readOperation = op;
-        } finally {
-            socket.readLock.unlock();
-        }
-        selector.wakeup();
-        startedReads.increment();
-        currentReads.increment();
-        return op;
-    }
-
-    WriteOperation startWrite(
-            final RegisteredSocket socket,
-            final ByteBufferSet buffer,
-            final long timeout, final TimeUnit unit,
-            final LongConsumer onSuccess, final Consumer<Throwable> onFailure)
-            throws WritePendingException {
-        checkTerminated();
-        Util.assertTrue(buffer.hasRemaining());
-        waitForSocketRegistration(socket);
-        WriteOperation op;
-        socket.writeLock.lock();
-        try {
-            if (socket.writeOperation != null) {
-                throw new WritePendingException();
-            }
-            op = new WriteOperation(buffer, onSuccess, onFailure);
-            final WriteOperation finalOp = op;
-            /*
-             * we do not try to outsmart the TLS state machine and register for both IO operations for each new socket
-             * operation
-             */
-            socket.pendingOps.set(SelectionKey.OP_WRITE | SelectionKey.OP_READ);
-            if (timeout != 0) {
-                op.timeoutFuture = timeoutExecutor.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        boolean success = AsynchronousTlsChannelGroup.this.doCancelWrite(socket, finalOp);
-                        if (success) {
-                            finalOp.onFailure.accept(new InterruptedByTimeoutException());
-                        }
-                    }
-                }, timeout, unit);
-            }
-            socket.writeOperation = op;
-        } finally {
-            socket.writeLock.unlock();
-        }
-        selector.wakeup();
-        startedWrites.increment();
-        currentWrites.increment();
-        return op;
-    }
-
-    private void checkTerminated() {
-        if (isTerminated()) {
-            throw new ShutdownChannelGroupException();
-        }
-    }
-
-    private void waitForSocketRegistration(final RegisteredSocket socket) {
-        try {
-            socket.registered.await();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void loop() {
-        try {
-            while (shutdown == Shutdown.No || shutdown == Shutdown.Wait && currentRegistrations.intValue() > 0) {
-                int c = selector.select(); // block
-                selectionCount.increment();
-                // avoid unnecessary creation of iterator object
-                if (c > 0) {
-                    Iterator<SelectionKey> it = selector.selectedKeys().iterator();
-                    while (it.hasNext()) {
-                        SelectionKey key = it.next();
-                        it.remove();
-                        try {
-                            key.interestOps(0);
-                        } catch (CancelledKeyException e) {
-                            // can happen when channels are closed with pending operations
-                            continue;
-                        }
-                        RegisteredSocket socket = (RegisteredSocket) key.attachment();
-                        processRead(socket);
-                        processWrite(socket);
-                    }
-                }
-                registerPendingSockets();
-                processPendingInterests();
-            }
-        } catch (Throwable e) {
-            LOGGER.error("error in selector loop", e);
-        } finally {
-            executor.shutdown();
-            // use shutdownNow to stop delayed tasks
-            timeoutExecutor.shutdownNow();
-            if (shutdown == Shutdown.Immediate) {
-                for (SelectionKey key : selector.keys()) {
-                    RegisteredSocket socket = (RegisteredSocket) key.attachment();
-                    socket.close();
-                }
-            }
+  private void loop() {
+    try {
+      while (shutdown == Shutdown.No
+          || shutdown == Shutdown.Wait && currentRegistrations.intValue() > 0) {
+        int c = selector.select(); // block
+        selectionCount.increment();
+        // avoid unnecessary creation of iterator object
+        if (c > 0) {
+          Iterator<SelectionKey> it = selector.selectedKeys().iterator();
+          while (it.hasNext()) {
+            SelectionKey key = it.next();
+            it.remove();
             try {
-                selector.close();
-            } catch (IOException e) {
-                LOGGER.warn(format("error closing selector: %s", e.getMessage()));
+              key.interestOps(0);
+            } catch (CancelledKeyException e) {
+              // can happen when channels are closed with pending operations
+              continue;
             }
-        }
-    }
-
-    private void processPendingInterests() {
-        for (SelectionKey key : selector.keys()) {
             RegisteredSocket socket = (RegisteredSocket) key.attachment();
-            int pending = socket.pendingOps.getAndSet(0);
-            if (pending != 0) {
-                try {
-                    key.interestOps(key.interestOps() | pending);
-                } catch (CancelledKeyException e) {
-                    // can happen when channels are closed with pending operations
-                    break;
-                }
-            }
+            processRead(socket);
+            processWrite(socket);
+          }
         }
+        registerPendingSockets();
+        processPendingInterests();
+      }
+    } catch (Throwable e) {
+      logger.error("error in selector loop", e);
+    } finally {
+      executor.shutdown();
+      // use shutdownNow to stop delayed tasks
+      timeoutExecutor.shutdownNow();
+      if (shutdown == Shutdown.Immediate) {
+        for (SelectionKey key : selector.keys()) {
+          RegisteredSocket socket = (RegisteredSocket) key.attachment();
+          socket.close();
+        }
+      }
+      try {
+        selector.close();
+      } catch (IOException e) {
+        logger.warn("error closing selector: {}", e.getMessage());
+      }
     }
+  }
 
-    private void processWrite(final RegisteredSocket socket) {
-        socket.writeLock.lock();
+  private void processPendingInterests() {
+    for (SelectionKey key : selector.keys()) {
+      RegisteredSocket socket = (RegisteredSocket) key.attachment();
+      int pending = socket.pendingOps.getAndSet(0);
+      if (pending != 0) {
+        key.interestOps(key.interestOps() | pending);
+      }
+    }
+  }
+
+  private void processWrite(RegisteredSocket socket) {
+    socket.writeLock.lock();
+    try {
+      WriteOperation op = socket.writeOperation;
+      if (op != null) {
+        executor.execute(
+            () -> {
+              try {
+                doWrite(socket, op);
+              } catch (Throwable e) {
+                logger.error("error in operation", e);
+              }
+            });
+      }
+    } finally {
+      socket.writeLock.unlock();
+    }
+  }
+
+  private void processRead(RegisteredSocket socket) {
+    socket.readLock.lock();
+    try {
+      ReadOperation op = socket.readOperation;
+      if (op != null) {
+        executor.execute(
+            () -> {
+              try {
+                doRead(socket, op);
+              } catch (Throwable e) {
+                logger.error("error in operation", e);
+              }
+            });
+      }
+    } finally {
+      socket.readLock.unlock();
+    }
+  }
+
+  private void doWrite(RegisteredSocket socket, WriteOperation op) {
+    socket.writeLock.lock();
+    try {
+      if (socket.writeOperation != op) {
+        return;
+      }
+      try {
+        long before = op.bufferSet.remaining();
         try {
-            final WriteOperation op = socket.writeOperation;
-            if (op != null) {
-                executor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            AsynchronousTlsChannelGroup.this.doWrite(socket, op);
-                        } catch (Throwable e) {
-                            LOGGER.error("error in operation", e);
-                        }
-                    }
-                });
-            }
+          writeHandlingTasks(socket, op);
         } finally {
-            socket.writeLock.unlock();
+          long c = before - op.bufferSet.remaining();
+          Util.assertTrue(c >= 0);
+          op.consumesBytes += c;
         }
-    }
-
-    private void processRead(final RegisteredSocket socket) {
-        socket.readLock.lock();
-        try {
-            final ReadOperation op = socket.readOperation;
-            if (op != null) {
-                executor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            AsynchronousTlsChannelGroup.this.doRead(socket, op);
-                        } catch (Throwable e) {
-                            LOGGER.error("error in operation", e);
-                        }
-                    }
-                });
-            }
-        } finally {
-            socket.readLock.unlock();
+        socket.writeOperation = null;
+        if (op.timeoutFuture != null) {
+          op.timeoutFuture.cancel(false);
         }
-    }
-
-    private void doWrite(final RegisteredSocket socket, final WriteOperation op) {
-        socket.writeLock.lock();
-        try {
-            if (socket.writeOperation != op) {
-                return;
-            }
-            try {
-                long before = op.bufferSet.remaining();
-                try {
-                    writeHandlingTasks(socket, op);
-                } finally {
-                    long c = before - op.bufferSet.remaining();
-                    Util.assertTrue(c >= 0);
-                    op.consumesBytes += c;
-                }
-                socket.writeOperation = null;
-                if (op.timeoutFuture != null) {
-                    op.timeoutFuture.cancel(false);
-                }
-                op.onSuccess.accept(op.consumesBytes);
-                successfulWrites.increment();
-                currentWrites.decrement();
-            } catch (NeedsReadException e) {
-                socket.pendingOps.accumulateAndGet(SelectionKey.OP_READ, new IntBinaryOperator() {
-                    @Override
-                    public int applyAsInt(final int a, final int b) {
-                        return a | b;
-                    }
-                });
-                selector.wakeup();
-            } catch (NeedsWriteException e) {
-                socket.pendingOps.accumulateAndGet(SelectionKey.OP_WRITE, new IntBinaryOperator() {
-                    @Override
-                    public int applyAsInt(final int a, final int b) {
-                        return a | b;
-                    }
-                });
-                selector.wakeup();
-            } catch (IOException e) {
-                if (socket.writeOperation == op) {
-                    socket.writeOperation = null;
-                }
-                if (op.timeoutFuture != null) {
-                    op.timeoutFuture.cancel(false);
-                }
-                op.onFailure.accept(e);
-                failedWrites.increment();
-                currentWrites.decrement();
-            }
-        } finally {
-            socket.writeLock.unlock();
-        }
-    }
-
-    /**
-     * Intended use of the channel group is with sockets that run tasks internally, but out of tolerance, run tasks in
-     * thread in case the socket does not.
-     */
-    private void writeHandlingTasks(final RegisteredSocket socket, final WriteOperation op) throws IOException {
-        while (true) {
-            try {
-                socket.tlsChannel.write(op.bufferSet.array, op.bufferSet.offset, op.bufferSet.length);
-                return;
-            } catch (NeedsTaskException e) {
-                warnAboutNeedTask();
-                e.getTask().run();
-            }
-        }
-    }
-
-    private void warnAboutNeedTask() {
-        if (!loggedTaskWarning.getAndSet(true)) {
-            LOGGER.warn(format(
-                    "caught %s; channels used in asynchronous groups should run tasks themselves; "
-                            + "although task is being dealt with anyway, consider configuring channels properly",
-                    NeedsTaskException.class.getName()));
-        }
-    }
-
-    private void doRead(final RegisteredSocket socket, final ReadOperation op) {
-        socket.readLock.lock();
-        try {
-            if (socket.readOperation != op) {
-                return;
-            }
-            try {
-                Util.assertTrue(op.bufferSet.hasRemaining());
-                long c = readHandlingTasks(socket, op);
-                Util.assertTrue(c > 0 || c == -1);
-                socket.readOperation = null;
-                if (op.timeoutFuture != null) {
-                    op.timeoutFuture.cancel(false);
-                }
-                op.onSuccess.accept(c);
-                successfulReads.increment();
-                currentReads.decrement();
-            } catch (NeedsReadException e) {
-                socket.pendingOps.accumulateAndGet(SelectionKey.OP_READ, new IntBinaryOperator() {
-                    @Override
-                    public int applyAsInt(final int a, final int b) {
-                        return a | b;
-                    }
-                });
-                selector.wakeup();
-            } catch (NeedsWriteException e) {
-                socket.pendingOps.accumulateAndGet(SelectionKey.OP_WRITE, new IntBinaryOperator() {
-                    @Override
-                    public int applyAsInt(final int a, final int b) {
-                        return a | b;
-                    }
-                });
-                selector.wakeup();
-            } catch (IOException e) {
-                if (socket.readOperation == op) {
-                    socket.readOperation = null;
-                }
-                if (op.timeoutFuture != null) {
-                    op.timeoutFuture.cancel(false);
-                }
-                op.onFailure.accept(e);
-                failedReads.increment();
-                currentReads.decrement();
-            }
-        } finally {
-            socket.readLock.unlock();
-        }
-    }
-
-    /**
-     * @see #writeHandlingTasks
-     */
-    private long readHandlingTasks(final RegisteredSocket socket, final ReadOperation op) throws IOException {
-        while (true) {
-            try {
-                return socket.tlsChannel.read(op.bufferSet.array, op.bufferSet.offset, op.bufferSet.length);
-            } catch (NeedsTaskException e) {
-                warnAboutNeedTask();
-                e.getTask().run();
-            }
-        }
-    }
-
-    private void registerPendingSockets() throws ClosedChannelException {
-        RegisteredSocket socket;
-        while ((socket = pendingRegistrations.poll()) != null) {
-            socket.key = socket.socketChannel.register(selector, 0, socket);
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(format("registered key: %ss", socket.key));
-            }
-            socket.registered.countDown();
-        }
-    }
-
-    /**
-     * Whether either {@link #shutdown()} or {@link #shutdownNow()} have been called.
-     *
-     * @return {@code true} if this group has initiated shutdown and {@code false} if the group is active
-     */
-    public boolean isShutdown() {
-        return shutdown != Shutdown.No;
-    }
-
-    /**
-     * Starts the shutdown process. New sockets cannot be registered, already registered one continue operating normally
-     * until they are closed.
-     */
-    public void shutdown() {
-        shutdown = Shutdown.Wait;
+        op.onSuccess.accept(op.consumesBytes);
+        successfulWrites.increment();
+        currentWrites.decrement();
+      } catch (NeedsReadException e) {
+        socket.pendingOps.accumulateAndGet(SelectionKey.OP_READ, (a, b) -> a | b);
         selector.wakeup();
-    }
-
-    /**
-     * Shuts down this channel group immediately. All registered sockets are closed, pending operations may or may not
-     * finish.
-     */
-    public void shutdownNow() {
-        shutdown = Shutdown.Immediate;
+      } catch (NeedsWriteException e) {
+        socket.pendingOps.accumulateAndGet(SelectionKey.OP_WRITE, (a, b) -> a | b);
         selector.wakeup();
+      } catch (IOException e) {
+        if (socket.writeOperation == op) {
+          socket.writeOperation = null;
+        }
+        if (op.timeoutFuture != null) {
+          op.timeoutFuture.cancel(false);
+        }
+        op.onFailure.accept(e);
+        failedWrites.increment();
+        currentWrites.decrement();
+      }
+    } finally {
+      socket.writeLock.unlock();
     }
+  }
 
-    /**
-     * Whether this channel group was shut down, and all pending tasks have drained.
-     */
-    public boolean isTerminated() {
-        return executor.isTerminated();
+  /**
+   * Intended use of the channel group is with sockets that run tasks internally, but out of
+   * tolerance, run tasks in thread in case the socket does not.
+   */
+  private void writeHandlingTasks(RegisteredSocket socket, WriteOperation op) throws IOException {
+    while (true) {
+      try {
+        socket.tlsChannel.write(op.bufferSet.array, op.bufferSet.offset, op.bufferSet.length);
+        return;
+      } catch (NeedsTaskException e) {
+        warnAboutNeedTask();
+        e.getTask().run();
+      }
     }
+  }
 
-    /**
-     * Blocks until all registers sockets are closed and pending tasks finished execution after a shutdown request, or
-     * the timeout occurs, or the current thread is interrupted, whichever happens first.
-     *
-     * @param timeout the maximum time to wait
-     * @param unit    the time unit of the timeout argument
-     * @return {@code true} if this group terminated and {@code false} if the group elapsed before termination
-     * @throws InterruptedException if interrupted while waiting
-     */
-    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
-        return executor.awaitTermination(timeout, unit);
+  private void warnAboutNeedTask() {
+    if (!loggedTaskWarning.getAndSet(true)) {
+      logger.warn(
+          "caught {}; channels used in asynchronous groups should run tasks themselves; "
+              + "although task is being dealt with anyway, consider configuring channels properly",
+          NeedsTaskException.class.getName());
     }
+  }
 
-    long getSelectionCount() {
-        return selectionCount.longValue();
+  private void doRead(RegisteredSocket socket, ReadOperation op) {
+    socket.readLock.lock();
+    try {
+      if (socket.readOperation != op) {
+        return;
+      }
+      try {
+        Util.assertTrue(op.bufferSet.hasRemaining());
+        long c = readHandlingTasks(socket, op);
+        Util.assertTrue(c > 0 || c == -1);
+        socket.readOperation = null;
+        if (op.timeoutFuture != null) {
+          op.timeoutFuture.cancel(false);
+        }
+        op.onSuccess.accept(c);
+        successfulReads.increment();
+        currentReads.decrement();
+      } catch (NeedsReadException e) {
+        socket.pendingOps.accumulateAndGet(SelectionKey.OP_READ, (a, b) -> a | b);
+        selector.wakeup();
+      } catch (NeedsWriteException e) {
+        socket.pendingOps.accumulateAndGet(SelectionKey.OP_WRITE, (a, b) -> a | b);
+        selector.wakeup();
+      } catch (IOException e) {
+        if (socket.readOperation == op) {
+          socket.readOperation = null;
+        }
+        if (op.timeoutFuture != null) {
+          op.timeoutFuture.cancel(false);
+        }
+        op.onFailure.accept(e);
+        failedReads.increment();
+        currentReads.decrement();
+      }
+    } finally {
+      socket.readLock.unlock();
     }
+  }
 
-    /**
-     * Return the total number of read operations that were started.
-     *
-     * @return number of operations
-     */
-    public long getStartedReadCount() {
-        return startedReads.longValue();
+  /** @see #writeHandlingTasks */
+  private long readHandlingTasks(RegisteredSocket socket, ReadOperation op) throws IOException {
+    while (true) {
+      try {
+        return socket.tlsChannel.read(op.bufferSet.array, op.bufferSet.offset, op.bufferSet.length);
+      } catch (NeedsTaskException e) {
+        warnAboutNeedTask();
+        e.getTask().run();
+      }
     }
+  }
 
-    /**
-     * Return the total number of write operations that were started.
-     *
-     * @return number of operations
-     */
-    public long getStartedWriteCount() {
-        return startedWrites.longValue();
+  private void registerPendingSockets() throws ClosedChannelException {
+    RegisteredSocket socket;
+    while ((socket = pendingRegistrations.poll()) != null) {
+      socket.key = socket.socketChannel.register(selector, 0, socket);
+      logger.trace("registered key: {}", socket.key);
+      socket.registered.countDown();
     }
+  }
 
-    /**
-     * Return the total number of read operations that succeeded.
-     *
-     * @return number of operations
-     */
-    public long getSuccessfulReadCount() {
-        return successfulReads.longValue();
-    }
+  /**
+   * Whether either {@link #shutdown()} or {@link #shutdownNow()} have been called.
+   *
+   * @return {@code true} if this group has initiated shutdown and {@code false} if the group is
+   *     active
+   */
+  public boolean isShutdown() {
+    return shutdown != Shutdown.No;
+  }
 
-    /**
-     * Return the total number of write operations that succeeded.
-     *
-     * @return number of operations
-     */
-    public long getSuccessfulWriteCount() {
-        return successfulWrites.longValue();
-    }
+  /**
+   * Starts the shutdown process. New sockets cannot be registered, already registered one continue
+   * operating normally until they are closed.
+   */
+  public void shutdown() {
+    shutdown = Shutdown.Wait;
+    selector.wakeup();
+  }
 
-    /**
-     * Return the total number of read operations that failed.
-     *
-     * @return number of operations
-     */
-    public long getFailedReadCount() {
-        return failedReads.longValue();
-    }
+  /**
+   * Shuts down this channel group immediately. All registered sockets are closed, pending
+   * operations may or may not finish.
+   */
+  public void shutdownNow() {
+    shutdown = Shutdown.Immediate;
+    selector.wakeup();
+  }
 
-    /**
-     * Return the total number of write operations that failed.
-     *
-     * @return number of operations
-     */
-    public long getFailedWriteCount() {
-        return failedWrites.longValue();
-    }
+  /**
+   * Whether this channel group was shut down, and all pending tasks have drained.
+   *
+   * @return whether the channel is terminated
+   */
+  public boolean isTerminated() {
+    return executor.isTerminated();
+  }
 
-    /**
-     * Return the total number of read operations that were cancelled.
-     *
-     * @return number of operations
-     */
-    public long getCancelledReadCount() {
-        return cancelledReads.longValue();
-    }
+  /**
+   * Blocks until all registers sockets are closed and pending tasks finished execution after a
+   * shutdown request, or the timeout occurs, or the current thread is interrupted, whichever
+   * happens first.
+   *
+   * @param timeout the maximum time to wait
+   * @param unit the time unit of the timeout argument
+   * @return {@code true} if this group terminated and {@code false} if the group elapsed before
+   *     termination
+   * @throws InterruptedException if interrupted while waiting
+   */
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return executor.awaitTermination(timeout, unit);
+  }
 
-    /**
-     * Return the total number of write operations that were cancelled.
-     *
-     * @return number of operations
-     */
-    public long getCancelledWriteCount() {
-        return cancelledWrites.longValue();
-    }
+  long getSelectionCount() {
+    return selectionCount.longValue();
+  }
 
-    /**
-     * Returns the current number of active read operations.
-     *
-     * @return number of operations
-     */
-    public long getCurrentReadCount() {
-        return currentReads.longValue();
-    }
+  /**
+   * Return the total number of read operations that were started.
+   *
+   * @return number of operations
+   */
+  public long getStartedReadCount() {
+    return startedReads.longValue();
+  }
 
-    /**
-     * Returns the current number of active write operations.
-     *
-     * @return number of operations
-     */
-    public long getCurrentWriteCount() {
-        return currentWrites.longValue();
-    }
+  /**
+   * Return the total number of write operations that were started.
+   *
+   * @return number of operations
+   */
+  public long getStartedWriteCount() {
+    return startedWrites.longValue();
+  }
 
-    /**
-     * Returns the current number of registered sockets.
-     *
-     * @return number of sockets
-     */
-    public long getCurrentRegistrationCount() {
-        return currentRegistrations.longValue();
-    }
+  /**
+   * Return the total number of read operations that succeeded.
+   *
+   * @return number of operations
+   */
+  public long getSuccessfulReadCount() {
+    return successfulReads.longValue();
+  }
 
+  /**
+   * Return the total number of write operations that succeeded.
+   *
+   * @return number of operations
+   */
+  public long getSuccessfulWriteCount() {
+    return successfulWrites.longValue();
+  }
+
+  /**
+   * Return the total number of read operations that failed.
+   *
+   * @return number of operations
+   */
+  public long getFailedReadCount() {
+    return failedReads.longValue();
+  }
+
+  /**
+   * Return the total number of write operations that failed.
+   *
+   * @return number of operations
+   */
+  public long getFailedWriteCount() {
+    return failedWrites.longValue();
+  }
+
+  /**
+   * Return the total number of read operations that were cancelled.
+   *
+   * @return number of operations
+   */
+  public long getCancelledReadCount() {
+    return cancelledReads.longValue();
+  }
+
+  /**
+   * Return the total number of write operations that were cancelled.
+   *
+   * @return number of operations
+   */
+  public long getCancelledWriteCount() {
+    return cancelledWrites.longValue();
+  }
+
+  /**
+   * Returns the current number of active read operations.
+   *
+   * @return number of operations
+   */
+  public long getCurrentReadCount() {
+    return currentReads.longValue();
+  }
+
+  /**
+   * Returns the current number of active write operations.
+   *
+   * @return number of operations
+   */
+  public long getCurrentWriteCount() {
+    return currentWrites.longValue();
+  }
+
+  /**
+   * Returns the current number of registered sockets.
+   *
+   * @return number of sockets
+   */
+  public long getCurrentRegistrationCount() {
+    return currentRegistrations.longValue();
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/ExtendedAsynchronousByteChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/ExtendedAsynchronousByteChannel.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel.async;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousByteChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.channels.InterruptedByTimeoutException;
+import java.nio.channels.ReadPendingException;
+import java.nio.channels.ShutdownChannelGroupException;
+import java.nio.channels.WritePendingException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This interface extends {@link AsynchronousByteChannel} adding optional timeouts and scattering
+ * and gathering methods. These additions are analogous to the ones made by {@link
+ * java.nio.channels.AsynchronousSocketChannel}.
+ */
+public interface ExtendedAsynchronousByteChannel extends AsynchronousByteChannel {
+
+  /**
+   * Reads a sequence of bytes from this channel into the given buffer.
+   *
+   * <p>This method initiates an asynchronous read operation to read a sequence of bytes from this
+   * channel into the given buffer. The {@code handler} parameter is a completion handler that is
+   * invoked when the read operation completes (or fails). The result passed to the completion
+   * handler is the number of bytes read or {@code -1} if no bytes could be read because the channel
+   * has reached end-of-stream.
+   *
+   * <p>If a timeout is specified and the timeout elapses before the operation completes then the
+   * operation completes with the exception {@link InterruptedByTimeoutException}. Where a timeout
+   * occurs, and the implementation cannot guarantee that bytes have not been read, or will not be
+   * read from the channel into the given buffer, then further attempts to read from the channel
+   * will cause an unspecific runtime exception to be thrown.
+   *
+   * <p>Otherwise this method works in the same manner as the {@link
+   * AsynchronousByteChannel#read(ByteBuffer,Object,CompletionHandler)} method.
+   *
+   * @param   <A> The type for the object to the attached to the operation
+   * @param dst The buffer into which bytes are to be transferred
+   * @param timeout The maximum time for the I/O operation to complete
+   * @param unit The time unit of the {@code timeout} argument
+   * @param attach The object to attach to the I/O operation; can be {@code null}
+   * @param handler The handler for consuming the result
+   * @throws IllegalArgumentException If the buffer is read-only
+   * @throws ReadPendingException If a read operation is already in progress on this channel
+   * @throws ShutdownChannelGroupException If the channel group has terminated
+   */
+  <A> void read(
+      ByteBuffer dst,
+      long timeout,
+      TimeUnit unit,
+      A attach,
+      CompletionHandler<Integer, ? super A> handler);
+
+  /**
+   * Reads a sequence of bytes from this channel into a subsequence of the given buffers. This
+   * operation, sometimes called a <em>scattering read</em>, is often useful when implementing
+   * network protocols that group data into segments consisting of one or more fixed-length headers
+   * followed by a variable-length body. The {@code handler} parameter is a completion handler that
+   * is invoked when the read operation completes (or fails). The result passed to the completion
+   * handler is the number of bytes read or {@code -1} if no bytes could be read because the channel
+   * has reached end-of-stream.
+   *
+   * <p>This method initiates a read of up to <i>r</i> bytes from this channel, where <i>r</i> is
+   * the total number of bytes remaining in the specified subsequence of the given buffer array,
+   * that is,
+   *
+   * <blockquote>
+   *
+   * <pre>
+   * dsts[offset].remaining()
+   *     + dsts[offset+1].remaining()
+   *     + ... + dsts[offset+length-1].remaining()</pre>
+   *
+   * </blockquote>
+   *
+   * at the moment that the read is attempted.
+   *
+   * <p>Suppose that a byte sequence of length <i>n</i> is read, where <code>0</code>&nbsp;<code>
+   * &lt;</code>&nbsp;<i>n</i>&nbsp;<code>&lt;=</code>&nbsp;<i>r</i>. Up to the first <code>
+   * dsts[offset].remaining()</code> bytes of this sequence are transferred into buffer <code>
+   * dsts[offset]</code>, up to the next <code>dsts[offset+1].remaining()</code> bytes are
+   * transferred into buffer <code>dsts[offset+1]</code>, and so forth, until the entire byte
+   * sequence is transferred into the given buffers. As many bytes as possible are transferred into
+   * each buffer, hence the final position of each updated buffer, except the last updated buffer,
+   * is guaranteed to be equal to that buffer's limit. The underlying operating system may impose a
+   * limit on the number of buffers that may be used in an I/O operation. Where the number of
+   * buffers (with bytes remaining), exceeds this limit, then the I/O operation is performed with
+   * the maximum number of buffers allowed by the operating system.
+   *
+   * <p>If a timeout is specified and the timeout elapses before the operation completes then it
+   * completes with the exception {@link InterruptedByTimeoutException}. Where a timeout occurs, and
+   * the implementation cannot guarantee that bytes have not been read, or will not be read from the
+   * channel into the given buffers, then further attempts to read from the channel will cause an
+   * unspecific runtime exception to be thrown.
+   *
+   * @param   <A> The type for the object to the attached to the operation
+   * @param dsts The buffers into which bytes are to be transferred
+   * @param offset The offset within the buffer array of the first buffer into which bytes are to be
+   *     transferred; must be non-negative and no larger than {@code dsts.length}
+   * @param length The maximum number of buffers to be accessed; must be non-negative and no larger
+   *     than {@code dsts.length - offset}
+   * @param timeout The maximum time for the I/O operation to complete
+   * @param unit The time unit of the {@code timeout} argument
+   * @param attach The object to attach to the I/O operation; can be {@code null}
+   * @param handler The handler for consuming the result
+   * @throws IndexOutOfBoundsException If the pre-conditions for the {@code offset} and {@code
+   *     length} parameter aren't met
+   * @throws IllegalArgumentException If the buffer is read-only
+   * @throws ReadPendingException If a read operation is already in progress on this channel
+   * @throws ShutdownChannelGroupException If the channel group has terminated
+   */
+  <A> void read(
+      ByteBuffer[] dsts,
+      int offset,
+      int length,
+      long timeout,
+      TimeUnit unit,
+      A attach,
+      CompletionHandler<Long, ? super A> handler);
+
+  /**
+   * Writes a sequence of bytes to this channel from the given buffer.
+   *
+   * <p>This method initiates an asynchronous write operation to write a sequence of bytes to this
+   * channel from the given buffer. The {@code handler} parameter is a completion handler that is
+   * invoked when the write operation completes (or fails). The result passed to the completion
+   * handler is the number of bytes written.
+   *
+   * <p>If a timeout is specified and the timeout elapses before the operation completes then it
+   * completes with the exception {@link InterruptedByTimeoutException}. Where a timeout occurs, and
+   * the implementation cannot guarantee that bytes have not been written, or will not be written to
+   * the channel from the given buffer, then further attempts to write to the channel will cause an
+   * unspecific runtime exception to be thrown.
+   *
+   * <p>Otherwise this method works in the same manner as the {@link
+   * AsynchronousByteChannel#write(ByteBuffer,Object,CompletionHandler)} method.
+   *
+   * @param   <A> The type for the object to the attached to the operation
+   * @param src The buffer from which bytes are to be retrieved
+   * @param timeout The maximum time for the I/O operation to complete
+   * @param unit The time unit of the {@code timeout} argument
+   * @param attach The object to attach to the I/O operation; can be {@code null}
+   * @param handler The handler for consuming the result
+   * @throws WritePendingException If a write operation is already in progress on this channel
+   * @throws ShutdownChannelGroupException If the channel group has terminated
+   */
+  <A> void write(
+      ByteBuffer src,
+      long timeout,
+      TimeUnit unit,
+      A attach,
+      CompletionHandler<Integer, ? super A> handler);
+
+  /**
+   * Writes a sequence of bytes to this channel from a subsequence of the given buffers. This
+   * operation, sometimes called a <em>gathering write</em>, is often useful when implementing
+   * network protocols that group data into segments consisting of one or more fixed-length headers
+   * followed by a variable-length body. The {@code handler} parameter is a completion handler that
+   * is invoked when the write operation completes (or fails). The result passed to the completion
+   * handler is the number of bytes written.
+   *
+   * <p>This method initiates a write of up to <i>r</i> bytes to this channel, where <i>r</i> is the
+   * total number of bytes remaining in the specified subsequence of the given buffer array, that
+   * is,
+   *
+   * <blockquote>
+   *
+   * <pre>
+   * srcs[offset].remaining()
+   *     + srcs[offset+1].remaining()
+   *     + ... + srcs[offset+length-1].remaining()</pre>
+   *
+   * </blockquote>
+   *
+   * at the moment that the write is attempted.
+   *
+   * <p>Suppose that a byte sequence of length <i>n</i> is written, where <code>0</code>&nbsp;<code>
+   * &lt;</code>&nbsp;<i>n</i>&nbsp;<code>&lt;=</code>&nbsp;<i>r</i>. Up to the first <code>
+   * srcs[offset].remaining()</code> bytes of this sequence are written from buffer <code>
+   * srcs[offset]</code>, up to the next <code>srcs[offset+1].remaining()</code> bytes are written
+   * from buffer <code>srcs[offset+1]</code>, and so forth, until the entire byte sequence is
+   * written. As many bytes as possible are written from each buffer, hence the final position of
+   * each updated buffer, except the last updated buffer, is guaranteed to be equal to that buffer's
+   * limit. The underlying operating system may impose a limit on the number of buffers that may be
+   * used in an I/O operation. Where the number of buffers (with bytes remaining), exceeds this
+   * limit, then the I/O operation is performed with the maximum number of buffers allowed by the
+   * operating system.
+   *
+   * <p>If a timeout is specified and the timeout elapses before the operation completes then it
+   * completes with the exception {@link InterruptedByTimeoutException}. Where a timeout occurs, and
+   * the implementation cannot guarantee that bytes have not been written, or will not be written to
+   * the channel from the given buffers, then further attempts to write to the channel will cause an
+   * unspecific runtime exception to be thrown.
+   *
+   * @param   <A> The type for the object to the attached to the operation
+   * @param srcs The buffers from which bytes are to be retrieved
+   * @param offset The offset within the buffer array of the first buffer from which bytes are to be
+   *     retrieved; must be non-negative and no larger than {@code srcs.length}
+   * @param length The maximum number of buffers to be accessed; must be non-negative and no larger
+   *     than {@code srcs.length - offset}
+   * @param timeout The maximum time for the I/O operation to complete
+   * @param unit The time unit of the {@code timeout} argument
+   * @param attach The object to attach to the I/O operation; can be {@code null}
+   * @param handler The handler for consuming the result
+   * @throws IndexOutOfBoundsException If the pre-conditions for the {@code offset} and {@code
+   *     length} parameter aren't met
+   * @throws WritePendingException If a write operation is already in progress on this channel
+   * @throws ShutdownChannelGroupException If the channel group has terminated
+   */
+  <A> void write(
+      ByteBuffer[] srcs,
+      int offset,
+      int length,
+      long timeout,
+      TimeUnit unit,
+      A attach,
+      CompletionHandler<Long, ? super A> handler);
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/package-info.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/package-info.java
@@ -13,25 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
-package com.mongodb.internal.connection.tlschannel.util;
-
-import com.mongodb.internal.connection.tlschannel.TlsChannel;
-
-import javax.net.ssl.SSLException;
-
 /**
- * Thrown during {@link TlsChannel} handshake to indicate that a user-supplied function threw an exception.
+ * This package enables the usage of TLS Channel as an {@link
+ * java.nio.channels.AsynchronousByteChannel}.
  */
-public class TlsChannelCallbackException extends SSLException {
-
-    private static final long serialVersionUID = -8618230576763080549L;
-
-    public TlsChannelCallbackException(final String message, final Throwable throwable) {
-        super(message, throwable);
-    }
-
-}
+package com.mongodb.internal.connection.tlschannel.async;

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/impl/ByteBufferUtil.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/impl/ByteBufferUtil.java
@@ -13,36 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
 package com.mongodb.internal.connection.tlschannel.impl;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 public class ByteBufferUtil {
 
-    public static void copy(final ByteBuffer src, final ByteBuffer dst, final int length) {
-        if (length < 0) {
-            throw new IllegalArgumentException("negative length");
-        }
-        if (src.remaining() < length) {
-            throw new IllegalArgumentException(
-                    String.format("source buffer does not have enough remaining capacity (%d < %d)", src.remaining(), length));
-        }
-        if (dst.remaining() < length) {
-            throw new IllegalArgumentException(
-                    String.format("destination buffer does not have enough remaining capacity (%d < %d)", dst.remaining(), length));
-        }
-        if (length == 0) {
-            return;
-        }
-        ByteBuffer tmp = src.duplicate();
-        ((Buffer) tmp).limit(src.position() + length);
-        dst.put(tmp);
-        ((Buffer) src).position(src.position() + length);
+  public static void copy(ByteBuffer src, ByteBuffer dst, int length) {
+    if (length < 0) {
+      throw new IllegalArgumentException("negative length");
     }
-
+    if (src.remaining() < length) {
+      throw new IllegalArgumentException(
+          String.format(
+              "source buffer does not have enough remaining capacity (%d < %d)",
+              src.remaining(), length));
+    }
+    if (dst.remaining() < length) {
+      throw new IllegalArgumentException(
+          String.format(
+              "destination buffer does not have enough remaining capacity (%d < %d)",
+              dst.remaining(), length));
+    }
+    if (length == 0) {
+      return;
+    }
+    ByteBuffer tmp = src.duplicate();
+    tmp.limit(src.position() + length);
+    dst.put(tmp);
+    src.position(src.position() + length);
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/impl/TlsChannelImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/impl/TlsChannelImpl.java
@@ -13,31 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
 package com.mongodb.internal.connection.tlschannel.impl;
 
-import com.mongodb.diagnostics.logging.Logger;
-import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.internal.connection.tlschannel.NeedsReadException;
 import com.mongodb.internal.connection.tlschannel.NeedsTaskException;
 import com.mongodb.internal.connection.tlschannel.NeedsWriteException;
+import com.mongodb.internal.connection.tlschannel.TlsChannelCallbackException;
 import com.mongodb.internal.connection.tlschannel.TrackingAllocator;
 import com.mongodb.internal.connection.tlschannel.WouldBlockException;
-import com.mongodb.internal.connection.tlschannel.util.TlsChannelCallbackException;
 import com.mongodb.internal.connection.tlschannel.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.ClosedChannelException;
@@ -47,747 +45,738 @@ import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
-import static java.lang.String.format;
-import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
 
 public class TlsChannelImpl implements ByteChannel {
 
-    private static final Logger LOGGER = Loggers.getLogger("connection.tls");
+  private static final Logger logger = LoggerFactory.getLogger(TlsChannelImpl.class);
 
-    private static final int BUFFERS_INITIAL_SIZE = 4096;
+  public static final int buffersInitialSize = 4096;
 
-    /**
-     * Official TLS max data size is 2^14 = 16k. Use 1024 more to account for
-     * the overhead
-     */
-    static final int MAX_TLS_PACKET_SIZE = 17 * 1024;
+  /** Official TLS max data size is 2^14 = 16k. Use 1024 more to account for the overhead */
+  public static final int maxTlsPacketSize = 17 * 1024;
 
-    private static class UnwrapResult {
-        final int bytesProduced;
-        final HandshakeStatus lastHandshakeStatus;
-        final boolean wasClosed;
+  private static class UnwrapResult {
+    public final int bytesProduced;
+    public final HandshakeStatus lastHandshakeStatus;
+    public final boolean wasClosed;
 
-        UnwrapResult(final int bytesProduced, final HandshakeStatus lastHandshakeStatus, final boolean wasClosed) {
-            this.bytesProduced = bytesProduced;
-            this.lastHandshakeStatus = lastHandshakeStatus;
-            this.wasClosed = wasClosed;
-        }
+    public UnwrapResult(int bytesProduced, HandshakeStatus lastHandshakeStatus, boolean wasClosed) {
+      this.bytesProduced = bytesProduced;
+      this.lastHandshakeStatus = lastHandshakeStatus;
+      this.wasClosed = wasClosed;
     }
+  }
 
-    private static class WrapResult {
-        final int bytesConsumed;
-        final HandshakeStatus lastHandshakeStatus;
+  private static class WrapResult {
+    public final int bytesConsumed;
+    public final HandshakeStatus lastHandshakeStatus;
 
-        WrapResult(final int bytesConsumed, final HandshakeStatus lastHandshakeStatus) {
-            this.bytesConsumed = bytesConsumed;
-            this.lastHandshakeStatus = lastHandshakeStatus;
-        }
+    public WrapResult(int bytesConsumed, HandshakeStatus lastHandshakeStatus) {
+      this.bytesConsumed = bytesConsumed;
+      this.lastHandshakeStatus = lastHandshakeStatus;
     }
+  }
 
-    /**
-     * Used to signal EOF conditions from the underlying channel
-     */
-    public static class EofException extends Exception {
+  /** Used to signal EOF conditions from the underlying channel */
+  public static class EofException extends Exception {
+    private static final long serialVersionUID = -3859156713994602991L;
 
-        private static final long serialVersionUID = -9215047770779892445L;
-
-        /**
-         * For efficiency, override this method to do nothing.
-         */
-        @Override
-        public Throwable fillInStackTrace() {
-            return this;
-        }
-
+    /** For efficiency, override this method to do nothing. */
+    @Override
+    public Throwable fillInStackTrace() {
+      return this;
     }
+  }
 
-    private final ReadableByteChannel readChannel;
-    private final WritableByteChannel writeChannel;
-    private final SSLEngine engine;
-    private BufferHolder inEncrypted;
-    private final Consumer<SSLSession> initSessionCallback;
+  private final ReadableByteChannel readChannel;
+  private final WritableByteChannel writeChannel;
+  private final SSLEngine engine;
+  private BufferHolder inEncrypted;
+  private final Consumer<SSLSession> initSessionCallback;
 
-    private final boolean runTasks;
-    private final TrackingAllocator encryptedBufAllocator;
-    private final TrackingAllocator plainBufAllocator;
-    private final boolean waitForCloseConfirmation;
+  private final boolean runTasks;
+  private final TrackingAllocator encryptedBufAllocator;
+  private final TrackingAllocator plainBufAllocator;
+  private final boolean waitForCloseConfirmation;
 
-    // @formatter:off
-    public TlsChannelImpl(
-            final ReadableByteChannel readChannel,
-            final WritableByteChannel writeChannel,
-            final SSLEngine engine,
-            final Optional<BufferHolder> inEncrypted,
-            final Consumer<SSLSession> initSessionCallback,
-            final boolean runTasks,
-            final TrackingAllocator plainBufAllocator,
-            final TrackingAllocator encryptedBufAllocator,
-            final boolean releaseBuffers,
-            final boolean waitForCloseConfirmation) {
-        // @formatter:on
-        this.readChannel = readChannel;
-        this.writeChannel = writeChannel;
-        this.engine = engine;
-        this.inEncrypted = inEncrypted.orElseGet(new Supplier<BufferHolder>() {
-            @Override
-            public BufferHolder get() {
-                return new BufferHolder(
-                        "inEncrypted",
-                        encryptedBufAllocator,
-                        BUFFERS_INITIAL_SIZE,
-                        MAX_TLS_PACKET_SIZE,
-                        false /* plainData */,
-                        releaseBuffers);
+  // @formatter:off
+  public TlsChannelImpl(
+      ReadableByteChannel readChannel,
+      WritableByteChannel writeChannel,
+      SSLEngine engine,
+      Optional<BufferHolder> inEncrypted,
+      Consumer<SSLSession> initSessionCallback,
+      boolean runTasks,
+      TrackingAllocator plainBufAllocator,
+      TrackingAllocator encryptedBufAllocator,
+      boolean releaseBuffers,
+      boolean waitForCloseConfirmation) {
+    // @formatter:on
+    this.readChannel = readChannel;
+    this.writeChannel = writeChannel;
+    this.engine = engine;
+    this.inEncrypted =
+        inEncrypted.orElseGet(
+            () ->
+                new BufferHolder(
+                    "inEncrypted",
+                    Optional.empty(),
+                    encryptedBufAllocator,
+                    buffersInitialSize,
+                    maxTlsPacketSize,
+                    false /* plainData */,
+                    releaseBuffers));
+    this.initSessionCallback = initSessionCallback;
+    this.runTasks = runTasks;
+    this.plainBufAllocator = plainBufAllocator;
+    this.encryptedBufAllocator = encryptedBufAllocator;
+    this.waitForCloseConfirmation = waitForCloseConfirmation;
+    inPlain =
+        new BufferHolder(
+            "inPlain",
+            Optional.empty(),
+            plainBufAllocator,
+            buffersInitialSize,
+            maxTlsPacketSize,
+            true /* plainData */,
+            releaseBuffers);
+    outEncrypted =
+        new BufferHolder(
+            "outEncrypted",
+            Optional.empty(),
+            encryptedBufAllocator,
+            buffersInitialSize,
+            maxTlsPacketSize,
+            false /* plainData */,
+            releaseBuffers);
+  }
+
+  private final Lock initLock = new ReentrantLock();
+  private final Lock readLock = new ReentrantLock();
+  private final Lock writeLock = new ReentrantLock();
+
+  private volatile boolean negotiated = false;
+
+  /**
+   * Whether a IOException was received from the underlying channel or from the {@link SSLEngine}.
+   */
+  private volatile boolean invalid = false;
+
+  /** Whether a close_notify was already sent. */
+  private volatile boolean shutdownSent = false;
+
+  /** Whether a close_notify was already received. */
+  private volatile boolean shutdownReceived = false;
+
+  // decrypted data from inEncrypted
+  private BufferHolder inPlain;
+
+  // contains data encrypted to send to the underlying channel
+  private BufferHolder outEncrypted;
+
+  /**
+   * Handshake wrap() method calls need a buffer to read from, even when they actually do not read
+   * anything.
+   *
+   * <p>Note: standard SSLEngine is happy with no buffers, the empty buffer is here to make this
+   * work with Netty's OpenSSL's wrapper.
+   */
+  private final ByteBufferSet dummyOut =
+      new ByteBufferSet(new ByteBuffer[] {ByteBuffer.allocate(0)});
+
+  public Consumer<SSLSession> getSessionInitCallback() {
+    return initSessionCallback;
+  }
+
+  public TrackingAllocator getPlainBufferAllocator() {
+    return plainBufAllocator;
+  }
+
+  public TrackingAllocator getEncryptedBufferAllocator() {
+    return encryptedBufAllocator;
+  }
+
+  // read
+
+  public long read(ByteBufferSet dest) throws IOException, NeedsTaskException {
+    checkReadBuffer(dest);
+    if (!dest.hasRemaining()) return 0;
+    handshake();
+    readLock.lock();
+    try {
+      if (invalid || shutdownSent) {
+        throw new ClosedChannelException();
+      }
+      HandshakeStatus handshakeStatus = engine.getHandshakeStatus();
+      int bytesToReturn = inPlain.nullOrEmpty() ? 0 : inPlain.buffer.position();
+      while (true) {
+        if (bytesToReturn > 0) {
+          if (inPlain.nullOrEmpty()) {
+            return bytesToReturn;
+          } else {
+            return transferPendingPlain(dest);
+          }
+        }
+        if (shutdownReceived) {
+          return -1;
+        }
+        Util.assertTrue(inPlain.nullOrEmpty());
+        switch (handshakeStatus) {
+          case NEED_UNWRAP:
+          case NEED_WRAP:
+            bytesToReturn = handshake(Optional.of(dest), Optional.of(handshakeStatus));
+            handshakeStatus = NOT_HANDSHAKING;
+            break;
+          case NOT_HANDSHAKING:
+          case FINISHED:
+            UnwrapResult res = readAndUnwrap(Optional.of(dest));
+            if (res.wasClosed) {
+              return -1;
             }
-        });
-        this.initSessionCallback = initSessionCallback;
-        this.runTasks = runTasks;
-        this.plainBufAllocator = plainBufAllocator;
-        this.encryptedBufAllocator = encryptedBufAllocator;
-        this.waitForCloseConfirmation = waitForCloseConfirmation;
-        inPlain = new BufferHolder(
-                "inPlain",
-                plainBufAllocator,
-                BUFFERS_INITIAL_SIZE,
-                MAX_TLS_PACKET_SIZE,
-                true /* plainData */,
-                releaseBuffers);
-        outEncrypted = new BufferHolder(
-                "outEncrypted",
-                encryptedBufAllocator,
-                BUFFERS_INITIAL_SIZE,
-                MAX_TLS_PACKET_SIZE,
-                false /* plainData */,
-                releaseBuffers);
-    }
-
-    private final Lock initLock = new ReentrantLock();
-    private final Lock readLock = new ReentrantLock();
-    private final Lock writeLock = new ReentrantLock();
-
-    private volatile boolean negotiated = false;
-
-    /**
-     * Whether a IOException was received from the underlying channel or from
-     * the {@link SSLEngine}.
-     */
-    private volatile boolean invalid = false;
-
-    /**
-     * Whether a close_notify was already sent.
-     */
-    private volatile boolean shutdownSent = false;
-
-    /**
-     * Whether a close_notify was already received.
-     */
-    private volatile boolean shutdownReceived = false;
-
-    // decrypted data from inEncrypted
-    private BufferHolder inPlain;
-
-    // contains data encrypted to send to the underlying channel
-    private BufferHolder outEncrypted;
-
-    // handshake wrap() method calls need a buffer to read from, even when they
-    // actually do not read anything
-    private final ByteBufferSet dummyOut = new ByteBufferSet(new ByteBuffer[]{});
-
-    public Consumer<SSLSession> getSessionInitCallback() {
-        return initSessionCallback;
-    }
-
-    public TrackingAllocator getPlainBufferAllocator() {
-        return plainBufAllocator;
-    }
-
-    public TrackingAllocator getEncryptedBufferAllocator() {
-        return encryptedBufAllocator;
-    }
-
-    // read
-
-    public long read(final ByteBufferSet dest) throws IOException {
-        checkReadBuffer(dest);
-        if (!dest.hasRemaining()) {
-            return 0;
-        }
-        handshake();
-        readLock.lock();
-        try {
-            if (invalid || shutdownSent) {
-                throw new ClosedChannelException();
-            }
-            HandshakeStatus handshakeStatus = engine.getHandshakeStatus();
-            int bytesToReturn = inPlain.nullOrEmpty() ? 0 : inPlain.buffer.position();
-            while (true) {
-                if (bytesToReturn > 0) {
-                    if (inPlain.nullOrEmpty()) {
-                        return bytesToReturn;
-                    } else {
-                        return transferPendingPlain(dest);
-                    }
-                }
-                if (shutdownReceived) {
-                    return -1;
-                }
-                Util.assertTrue(inPlain.nullOrEmpty());
-                switch (handshakeStatus) {
-                    case NEED_UNWRAP:
-                    case NEED_WRAP:
-                        bytesToReturn = handshake(Optional.of(dest), Optional.of(handshakeStatus));
-                        handshakeStatus = NOT_HANDSHAKING;
-                        break;
-                    case NOT_HANDSHAKING:
-                    case FINISHED:
-                        UnwrapResult res = readAndUnwrap(Optional.of(dest), NOT_HANDSHAKING /* statusCondition */,
-                                false /* closing */);
-                        if (res.wasClosed) {
-                            return -1;
-                        }
-                        bytesToReturn = res.bytesProduced;
-                        handshakeStatus = res.lastHandshakeStatus;
-                        break;
-                    case NEED_TASK:
-                        handleTask();
-                        handshakeStatus = engine.getHandshakeStatus();
-                        break;
-                    default:
-                        throw new SSLHandshakeException("Unsupported handshake status: " + handshakeStatus);
-                }
-            }
-        } catch (EofException e) {
+            bytesToReturn = res.bytesProduced;
+            handshakeStatus = res.lastHandshakeStatus;
+            break;
+          case NEED_TASK:
+            handleTask();
+            handshakeStatus = engine.getHandshakeStatus();
+            break;
+          default:
+            // Unsupported stage eg: NEED_UNWRAP_AGAIN
             return -1;
-        } finally {
-            readLock.unlock();
         }
+      }
+    } catch (EofException e) {
+      return -1;
+    } finally {
+      readLock.unlock();
     }
+  }
 
-    private void handleTask() throws NeedsTaskException {
-        if (runTasks) {
-            engine.getDelegatedTask().run();
+  private void handleTask() throws NeedsTaskException {
+    if (runTasks) {
+      engine.getDelegatedTask().run();
+    } else {
+      throw new NeedsTaskException(engine.getDelegatedTask());
+    }
+  }
+
+  private int transferPendingPlain(ByteBufferSet dstBuffers) {
+    inPlain.buffer.flip(); // will read
+    int bytes = dstBuffers.putRemaining(inPlain.buffer);
+    inPlain.buffer.compact(); // will write
+    boolean disposed = inPlain.release();
+    if (!disposed) {
+      inPlain.zeroRemaining();
+    }
+    return bytes;
+  }
+
+  private UnwrapResult unwrapLoop(Optional<ByteBufferSet> dest, HandshakeStatus originalStatus)
+      throws SSLException {
+    ByteBufferSet effDest =
+        dest.orElseGet(
+            () -> {
+              inPlain.prepare();
+              return new ByteBufferSet(inPlain.buffer);
+            });
+    while (true) {
+      Util.assertTrue(inPlain.nullOrEmpty());
+      SSLEngineResult result = callEngineUnwrap(effDest);
+      /*
+       * Note that data can be returned even in case of overflow, in that
+       * case, just return the data.
+       */
+      if (result.bytesProduced() > 0
+          || result.getStatus() == Status.BUFFER_UNDERFLOW
+          || result.getStatus() == Status.CLOSED
+          || result.getHandshakeStatus() != originalStatus) {
+        boolean wasClosed = result.getStatus() == Status.CLOSED;
+        return new UnwrapResult(result.bytesProduced(), result.getHandshakeStatus(), wasClosed);
+      }
+      if (result.getStatus() == Status.BUFFER_OVERFLOW) {
+        if (dest.isPresent() && effDest == dest.get()) {
+          /*
+           * The client-supplier buffer is not big enough. Use the
+           * internal inPlain buffer, also ensure that it is bigger
+           * than the too-small supplied one.
+           */
+          inPlain.prepare();
+          ensureInPlainCapacity(Math.min(((int) dest.get().remaining()) * 2, maxTlsPacketSize));
         } else {
-            throw new NeedsTaskException(engine.getDelegatedTask());
+          inPlain.enlarge();
         }
+        // inPlain changed, re-create the wrapper
+        effDest = new ByteBufferSet(inPlain.buffer);
+      }
     }
+  }
 
-    private int transferPendingPlain(final ByteBufferSet dstBuffers) {
-        ((Buffer) inPlain.buffer).flip(); // will read
-        int bytes = dstBuffers.putRemaining(inPlain.buffer);
-        inPlain.buffer.compact(); // will write
-        boolean disposed = inPlain.release();
-        if (!disposed) {
-            inPlain.zeroRemaining();
-        }
-        return bytes;
+  private SSLEngineResult callEngineUnwrap(ByteBufferSet dest) throws SSLException {
+    inEncrypted.buffer.flip();
+    try {
+      SSLEngineResult result =
+          engine.unwrap(inEncrypted.buffer, dest.array, dest.offset, dest.length);
+      if (logger.isTraceEnabled()) {
+        logger.trace(
+            "engine.unwrap() result [{}]. Engine status: {}; inEncrypted {}; inPlain: {}",
+            Util.resultToString(result),
+            result.getHandshakeStatus(),
+            inEncrypted,
+            dest);
+      }
+      return result;
+    } catch (SSLException e) {
+      // something bad was received from the underlying channel, we cannot
+      // continue
+      invalid = true;
+      throw e;
+    } finally {
+      inEncrypted.buffer.compact();
     }
+  }
 
-    private UnwrapResult unwrapLoop(final Optional<ByteBufferSet> dest, final HandshakeStatus statusCondition, final boolean closing)
-            throws SSLException {
-        ByteBufferSet effDest = dest.orElseGet(new Supplier<ByteBufferSet>() {
-            @Override
-            public ByteBufferSet get() {
-                inPlain.prepare();
-                return new ByteBufferSet(inPlain.buffer);
-            }
-        });
-        while (true) {
-            Util.assertTrue(inPlain.nullOrEmpty());
-            SSLEngineResult result = callEngineUnwrap(effDest);
-            /*
-             * Note that data can be returned even in case of overflow, in that
-             * case, just return the data.
-             */
-            if (result.bytesProduced() > 0 || result.getStatus() == Status.BUFFER_UNDERFLOW
-                    || !closing && result.getStatus() == Status.CLOSED
-                    || result.getHandshakeStatus() != statusCondition) {
-                boolean wasClosed = result.getStatus() == Status.CLOSED;
-                return new UnwrapResult(result.bytesProduced(), result.getHandshakeStatus(), wasClosed);
-            }
-            if (result.getStatus() == Status.BUFFER_OVERFLOW) {
-                if (dest.isPresent() && effDest == dest.get()) {
-                    /*
-                     * The client-supplier buffer is not big enough. Use the
-                     * internal inPlain buffer, also ensure that it is bigger
-                     * than the too-small supplied one.
-                     */
-                    inPlain.prepare();
-                    ensureInPlainCapacity(Math.min(((int) dest.get().remaining()) * 2, MAX_TLS_PACKET_SIZE));
-                } else {
-                    inPlain.enlarge();
-                }
-                // inPlain changed, re-create the wrapper
-                effDest = new ByteBufferSet(inPlain.buffer);
-            }
-        }
+  private int readFromChannel() throws IOException, EofException {
+    try {
+      return readFromChannel(readChannel, inEncrypted.buffer);
+    } catch (WouldBlockException e) {
+      throw e;
+    } catch (IOException e) {
+      invalid = true;
+      throw e;
     }
+  }
 
-    private SSLEngineResult callEngineUnwrap(final ByteBufferSet dest) throws SSLException {
-        ((Buffer) inEncrypted.buffer).flip();
-        try {
-            SSLEngineResult result = engine.unwrap(inEncrypted.buffer, dest.array, dest.offset, dest.length);
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(format("engine.unwrap() result [%s]. Engine status: %s; inEncrypted %s; inPlain: %s",
-                        Util.resultToString(result), result.getHandshakeStatus(), inEncrypted, dest));
-            }
-            return result;
-        } catch (SSLException e) {
-            // something bad was received from the underlying channel, we cannot
-            // continue
-            invalid = true;
-            throw e;
-        } finally {
-            inEncrypted.buffer.compact();
-        }
+  public static int readFromChannel(ReadableByteChannel readChannel, ByteBuffer buffer)
+      throws IOException, EofException {
+    Util.assertTrue(buffer.hasRemaining());
+    logger.trace("Reading from channel");
+    int c = readChannel.read(buffer); // IO block
+    logger.trace("Read from channel; response: {}, buffer: {}", c, buffer);
+    if (c == -1) {
+      throw new EofException();
     }
-
-    private int readFromChannel() throws IOException, EofException {
-        try {
-            return readFromChannel(readChannel, inEncrypted.buffer);
-        } catch (WouldBlockException e) {
-            throw e;
-        } catch (IOException e) {
-            invalid = true;
-            throw e;
-        }
+    if (c == 0) {
+      throw new NeedsReadException();
     }
+    return c;
+  }
 
-    public static int readFromChannel(final ReadableByteChannel readChannel, final ByteBuffer buffer)
-            throws IOException, EofException {
-        Util.assertTrue(buffer.hasRemaining());
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Reading from channel");
-        }
-        int c = readChannel.read(buffer); // IO block
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace(format("Read from channel; response: %s, buffer: %s", c, buffer));
-        }
-        if (c == -1) {
-            throw new EofException();
-        }
-        if (c == 0) {
-            throw new NeedsReadException();
-        }
-        return c;
+  // write
+
+  public long write(ByteBufferSet source) throws IOException {
+    /*
+     * Note that we should enter the write loop even in the case that the source buffer has no remaining bytes,
+     * as it could be the case, in non-blocking usage, that the user is forced to call write again after the
+     * underlying channel is available for writing, just to write pending encrypted bytes.
+     */
+    handshake();
+    writeLock.lock();
+    try {
+      if (invalid || shutdownSent) {
+        throw new ClosedChannelException();
+      }
+      return wrapAndWrite(source);
+    } finally {
+      writeLock.unlock();
     }
+  }
 
-    // write
+  private long wrapAndWrite(ByteBufferSet source) throws IOException {
+    long bytesToConsume = source.remaining();
+    long bytesConsumed = 0;
+    outEncrypted.prepare();
+    try {
+      while (true) {
+        writeToChannel();
+        if (bytesConsumed == bytesToConsume) return bytesToConsume;
+        WrapResult res = wrapLoop(source);
+        bytesConsumed += res.bytesConsumed;
+      }
+    } finally {
+      outEncrypted.release();
+    }
+  }
 
-    public long write(final ByteBufferSet source) throws IOException {
+  private WrapResult wrapLoop(ByteBufferSet source) throws SSLException {
+    while (true) {
+      SSLEngineResult result = callEngineWrap(source);
+      switch (result.getStatus()) {
+        case OK:
+        case CLOSED:
+          return new WrapResult(result.bytesConsumed(), result.getHandshakeStatus());
+        case BUFFER_OVERFLOW:
+          Util.assertTrue(result.bytesConsumed() == 0);
+          outEncrypted.enlarge();
+          break;
+        case BUFFER_UNDERFLOW:
+          throw new IllegalStateException();
+      }
+    }
+  }
+
+  private SSLEngineResult callEngineWrap(ByteBufferSet source) throws SSLException {
+    try {
+      SSLEngineResult result =
+          engine.wrap(source.array, source.offset, source.length, outEncrypted.buffer);
+      if (logger.isTraceEnabled()) {
+        logger.trace(
+            "engine.wrap() result: [{}]; engine status: {}; srcBuffer: {}, outEncrypted: {}",
+            Util.resultToString(result),
+            result.getHandshakeStatus(),
+            source,
+            outEncrypted);
+      }
+      return result;
+    } catch (SSLException e) {
+      invalid = true;
+      throw e;
+    }
+  }
+
+  private void ensureInPlainCapacity(int newCapacity) {
+    if (inPlain.buffer.capacity() < newCapacity) {
+      logger.trace(
+          "inPlain buffer too small, increasing from {} to {}",
+          inPlain.buffer.capacity(),
+          newCapacity);
+      inPlain.resize(newCapacity);
+    }
+  }
+
+  private void writeToChannel() throws IOException {
+    if (outEncrypted.buffer.position() == 0) {
+      return;
+    }
+    outEncrypted.buffer.flip();
+    try {
+      try {
+        writeToChannel(writeChannel, outEncrypted.buffer);
+      } catch (WouldBlockException e) {
+        throw e;
+      } catch (IOException e) {
+        invalid = true;
+        throw e;
+      }
+    } finally {
+      outEncrypted.buffer.compact();
+    }
+  }
+
+  private static void writeToChannel(WritableByteChannel channel, ByteBuffer src)
+      throws IOException {
+    while (src.hasRemaining()) {
+      logger.trace("Writing to channel: {}", src);
+      int c = channel.write(src);
+      if (c == 0) {
         /*
-         * Note that we should enter the write loop even in the case that the source buffer has no remaining bytes,
-         * as it could be the case, in non-blocking usage, that the user is forced to call write again after the
-         * underlying channel is available for writing, just to write pending encrypted bytes.
+         * If no bytesProduced were written, it means that the socket is
+         * non-blocking and needs more buffer space, so stop the loop
          */
-        handshake();
-        writeLock.lock();
-        try {
-            if (invalid || shutdownSent) {
-                throw new ClosedChannelException();
-            }
-            return wrapAndWrite(source);
-        } finally {
-            writeLock.unlock();
-        }
+        throw new NeedsWriteException();
+      }
+      // blocking SocketChannels can write less than all the bytesProduced
+      // just before an error the loop forces the exception
     }
+  }
 
-    private long wrapAndWrite(final ByteBufferSet source) throws IOException {
-        long bytesToConsume = source.remaining();
-        long bytesConsumed = 0;
+  // handshake and close
+
+  /**
+   * Force a new negotiation.
+   *
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  public void renegotiate() throws IOException {
+    /*
+     * Renegotiation was removed in TLS 1.3. We have to do the check at this level because SSLEngine will not
+     * check that, and just enter into undefined behavior.
+     */
+    // relying in hopefully-robust lexicographic ordering of protocol names
+    if (engine.getSession().getProtocol().compareTo("TLSv1.3") >= 0) {
+      throw new SSLException("renegotiation not supported in TLS 1.3 or latter");
+    }
+    try {
+      doHandshake(true /* force */);
+    } catch (EofException e) {
+      throw new ClosedChannelException();
+    }
+  }
+
+  /**
+   * Do a negotiation if this connection is new and it hasn't been done already.
+   *
+   * @throws IOException if the underlying channel throws an IOException
+   */
+  public void handshake() throws IOException {
+    try {
+      doHandshake(false /* force */);
+    } catch (EofException e) {
+      throw new ClosedChannelException();
+    }
+  }
+
+  private void doHandshake(boolean force) throws IOException, EofException {
+    if (!force && negotiated) return;
+    initLock.lock();
+    try {
+      if (invalid || shutdownSent) throw new ClosedChannelException();
+      if (force || !negotiated) {
+        engine.beginHandshake();
+        logger.trace("Called engine.beginHandshake()");
+        handshake(Optional.empty(), Optional.empty());
+        // call client code
+        try {
+          initSessionCallback.accept(engine.getSession());
+        } catch (Exception e) {
+          logger.trace("client code threw exception in session initialization callback", e);
+          throw new TlsChannelCallbackException("session initialization callback failed", e);
+        }
+        negotiated = true;
+      }
+    } finally {
+      initLock.unlock();
+    }
+  }
+
+  private int handshake(Optional<ByteBufferSet> dest, Optional<HandshakeStatus> handshakeStatus)
+      throws IOException, EofException {
+    readLock.lock();
+    try {
+      writeLock.lock();
+      try {
+        Util.assertTrue(inPlain.nullOrEmpty());
         outEncrypted.prepare();
         try {
-            while (true) {
-                writeToChannel();
-                if (bytesConsumed == bytesToConsume) {
-                    return bytesToConsume;
-                }
-                WrapResult res = wrapLoop(source);
-                bytesConsumed += res.bytesConsumed;
-            }
+          writeToChannel(); // IO block
+          return handshakeLoop(dest, handshakeStatus);
         } finally {
-            outEncrypted.release();
+          outEncrypted.release();
         }
+      } finally {
+        writeLock.unlock();
+      }
+    } finally {
+      readLock.unlock();
     }
+  }
 
-    private WrapResult wrapLoop(final ByteBufferSet source) throws SSLException {
-        while (true) {
-            SSLEngineResult result = callEngineWrap(source);
-            switch (result.getStatus()) {
-                case OK:
-                case CLOSED:
-                    return new WrapResult(result.bytesConsumed(), result.getHandshakeStatus());
-                case BUFFER_OVERFLOW:
-                    Util.assertTrue(result.bytesConsumed() == 0);
-                    outEncrypted.enlarge();
-                    break;
-                case BUFFER_UNDERFLOW:
-                    throw new IllegalStateException();
-                default:
-                    throw new AssertionError("Unexpected status: " + result.getStatus());
-            }
-        }
+  private int handshakeLoop(Optional<ByteBufferSet> dest, Optional<HandshakeStatus> handshakeStatus)
+      throws IOException, EofException {
+    Util.assertTrue(inPlain.nullOrEmpty());
+    HandshakeStatus status = handshakeStatus.orElseGet(() -> engine.getHandshakeStatus());
+    while (true) {
+      switch (status) {
+        case NEED_WRAP:
+          Util.assertTrue(outEncrypted.nullOrEmpty());
+          WrapResult wrapResult = wrapLoop(dummyOut);
+          status = wrapResult.lastHandshakeStatus;
+          writeToChannel(); // IO block
+          break;
+        case NEED_UNWRAP:
+          UnwrapResult res = readAndUnwrap(dest);
+          status = res.lastHandshakeStatus;
+          if (res.bytesProduced > 0) return res.bytesProduced;
+          break;
+        case NOT_HANDSHAKING:
+          /*
+           * This should not really happen using SSLEngine, because
+           * handshaking ends with a FINISHED status. However, we accept
+           * this value to permit the use of a pass-through stub engine
+           * with no encryption.
+           */
+          return 0;
+        case NEED_TASK:
+          handleTask();
+          status = engine.getHandshakeStatus();
+          break;
+        case FINISHED:
+          return 0;
+        default:
+          // Unsupported stage eg: NEED_UNWRAP_AGAIN
+          return 0;
+      }
     }
+  }
 
-    private SSLEngineResult callEngineWrap(final ByteBufferSet source) throws SSLException {
-        try {
-            SSLEngineResult result = engine.wrap(source.array, source.offset, source.length, outEncrypted.buffer);
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(format("engine.wrap() result: [%s]; engine status: %s; srcBuffer: %s, outEncrypted: %s",
-                        Util.resultToString(result), result.getHandshakeStatus(), source, outEncrypted));
-            }
-            return result;
-        } catch (SSLException e) {
-            invalid = true;
-            throw e;
-        }
-    }
-
-    private void ensureInPlainCapacity(final int newCapacity) {
-        if (inPlain.buffer.capacity() < newCapacity) {
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(format("inPlain buffer too small, increasing from %s to %s", inPlain.buffer.capacity(), newCapacity));
-            }
-            inPlain.resize(newCapacity);
-        }
-    }
-
-    private void writeToChannel() throws IOException {
-        if (outEncrypted.buffer.position() == 0) {
-            return;
-        }
-        ((Buffer) outEncrypted.buffer).flip();
-        try {
-            try {
-                writeToChannel(writeChannel, outEncrypted.buffer);
-            } catch (WouldBlockException e) {
-                throw e;
-            } catch (IOException e) {
-                invalid = true;
-                throw e;
-            }
-        } finally {
-            outEncrypted.buffer.compact();
-        }
-    }
-
-    private static void writeToChannel(final WritableByteChannel channel, final ByteBuffer src) throws IOException {
-        while (src.hasRemaining()) {
-            LOGGER.trace(format("Writing to channel: %s", src));
-            int c = channel.write(src);
-            if (c == 0) {
-                /*
-                 * If no bytesProduced were written, it means that the socket is
-                 * non-blocking and needs more buffer space, so stop the loop
-                 */
-                throw new NeedsWriteException();
-            }
-            // blocking SocketChannels can write less than all the bytesProduced
-            // just before an error the loop forces the exception
-        }
-    }
-
-    // handshake and close
-
-    /**
-     * Force new negotiation
-     */
-    public void renegotiate() throws IOException {
-        try {
-            doHandshake(true /* force */);
-        } catch (EofException e) {
-            throw new ClosedChannelException();
-        }
-    }
-
-    /**
-     * Do a negotiation if this connection is new and it hasn't been done
-     * already.
-     */
-    public void handshake() throws IOException {
-        try {
-            doHandshake(false /* force */);
-        } catch (EofException e) {
-            throw new ClosedChannelException();
-        }
-    }
-
-    private void doHandshake(final boolean force) throws IOException, EofException {
-        if (!force && negotiated) {
-            return;
-        }
-        if (invalid || shutdownSent) {
-            throw new ClosedChannelException();
-        }
-        initLock.lock();
-        try {
-            if (force || !negotiated) {
-                engine.beginHandshake();
-                LOGGER.trace("Called engine.beginHandshake()");
-                handshake(Optional.<ByteBufferSet>empty(), Optional.<HandshakeStatus>empty());
-                // call client code
-                try {
-                    initSessionCallback.accept(engine.getSession());
-                } catch (Exception e) {
-                    LOGGER.trace("client code threw exception in session initialization callback", e);
-                    throw new TlsChannelCallbackException("session initialization callback failed", e);
-                }
-                negotiated = true;
-            }
-        } finally {
-            initLock.unlock();
-        }
-    }
-
-    private int handshake(final Optional<ByteBufferSet> dest, final Optional<HandshakeStatus> handshakeStatus)
-            throws IOException, EofException {
-        readLock.lock();
-        try {
-            writeLock.lock();
-            try {
-                Util.assertTrue(inPlain.nullOrEmpty());
-                outEncrypted.prepare();
-                try {
-                    writeToChannel(); // IO block
-                    return handshakeLoop(dest, handshakeStatus);
-                } finally {
-                    outEncrypted.release();
-                }
-            } finally {
-                writeLock.unlock();
-            }
-        } finally {
-            readLock.unlock();
-        }
-    }
-
-    private int handshakeLoop(final Optional<ByteBufferSet> dest, final Optional<HandshakeStatus> handshakeStatus)
-            throws IOException, EofException {
+  private UnwrapResult readAndUnwrap(Optional<ByteBufferSet> dest)
+      throws IOException, EofException {
+    // Save status before operation: use it to stop when status changes
+    HandshakeStatus orig = engine.getHandshakeStatus();
+    inEncrypted.prepare();
+    try {
+      while (true) {
         Util.assertTrue(inPlain.nullOrEmpty());
-        HandshakeStatus status = handshakeStatus.orElseGet(new Supplier<HandshakeStatus>() {
-            @Override
-            public HandshakeStatus get() {
-                return engine.getHandshakeStatus();
-            }
-        });
-        while (true) {
-            switch (status) {
-                case NEED_WRAP:
-                    Util.assertTrue(outEncrypted.nullOrEmpty());
-                    WrapResult wrapResult = wrapLoop(dummyOut);
-                    status = wrapResult.lastHandshakeStatus;
-                    writeToChannel(); // IO block
-                    break;
-                case NEED_UNWRAP:
-                    UnwrapResult res = readAndUnwrap(dest, NEED_UNWRAP /* statusCondition */, false /* closing */);
-                    status = res.lastHandshakeStatus;
-                    if (res.bytesProduced > 0) {
-                        return res.bytesProduced;
-                    }
-                    break;
-                case NOT_HANDSHAKING:
-                    /*
-                     * This should not really happen using SSLEngine, because
-                     * handshaking ends with a FINISHED status. However, we accept
-                     * this value to permit the use of a pass-through stub engine
-                     * with no encryption.
-                     */
-                    return 0;
-                case NEED_TASK:
-                    handleTask();
-                    status = engine.getHandshakeStatus();
-                    break;
-                case FINISHED:
-                    return 0;
-                default:
-                    throw new AssertionError("Unexpected status: " + status);
-            }
+        UnwrapResult res = unwrapLoop(dest, orig);
+        if (res.bytesProduced > 0 || res.lastHandshakeStatus != orig || res.wasClosed) {
+          if (res.wasClosed) {
+            shutdownReceived = true;
+          }
+          return res;
         }
-    }
-
-    private UnwrapResult readAndUnwrap(final Optional<ByteBufferSet> dest, final HandshakeStatus statusCondition, final boolean closing)
-            throws IOException, EofException {
-        inEncrypted.prepare();
-        try {
-            while (true) {
-                Util.assertTrue(inPlain.nullOrEmpty());
-                UnwrapResult res = unwrapLoop(dest, statusCondition, closing);
-                if (res.bytesProduced > 0 || res.lastHandshakeStatus != statusCondition || !closing && res.wasClosed) {
-                    if (res.wasClosed) {
-                        shutdownReceived = true;
-                    }
-                    return res;
-                }
-                if (!inEncrypted.buffer.hasRemaining()) {
-                    inEncrypted.enlarge();
-                }
-                readFromChannel(); // IO block
-            }
-        } finally {
-            inEncrypted.release();
+        if (!inEncrypted.buffer.hasRemaining()) {
+          inEncrypted.enlarge();
         }
+        readFromChannel(); // IO block
+      }
+    } finally {
+      inEncrypted.release();
     }
+  }
 
-    public void close() throws IOException {
-        tryShutdown();
-        writeChannel.close();
-        readChannel.close();
+  public void close() throws IOException {
+    tryShutdown();
+    writeChannel.close();
+    readChannel.close();
+    /*
+     * After closing the underlying channels, locks should be taken fast.
+     */
+    readLock.lock();
+    try {
+      writeLock.lock();
+      try {
+        freeBuffers();
+      } finally {
+        writeLock.unlock();
+      }
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  private void tryShutdown() {
+    if (!readLock.tryLock()) return;
+    try {
+      if (!writeLock.tryLock()) return;
+      try {
+        if (!shutdownSent) {
+          try {
+            boolean closed = shutdown();
+            if (!closed && waitForCloseConfirmation) {
+              shutdown();
+            }
+          } catch (Throwable e) {
+            logger.debug("error doing TLS shutdown on close(), continuing: {}", e.getMessage());
+          }
+        }
+      } finally {
+        writeLock.unlock();
+      }
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  public boolean shutdown() throws IOException {
+    readLock.lock();
+    try {
+      writeLock.lock();
+      try {
+        if (invalid) {
+          throw new ClosedChannelException();
+        }
+        if (!shutdownSent) {
+          shutdownSent = true;
+          outEncrypted.prepare();
+          try {
+            writeToChannel(); // IO block
+            engine.closeOutbound();
+            wrapLoop(dummyOut);
+            writeToChannel(); // IO block
+          } finally {
+            outEncrypted.release();
+          }
+          /*
+           * If this side is the first to send close_notify, then,
+           * inbound is not done and false should be returned (so the
+           * client waits for the response). If this side is the
+           * second, then inbound was already done, and we can return
+           * true.
+           */
+          if (shutdownReceived) {
+            freeBuffers();
+          }
+          return shutdownReceived;
+        }
         /*
-         * After closing the underlying channels, locks should be taken fast.
+         * If we reach this point, then we just have to read the close
+         * notification from the client. Only try to do it if necessary,
+         * to make this method idempotent.
          */
-        readLock.lock();
-        try {
-            writeLock.lock();
-            try {
-                freeBuffers();
-            } finally {
-                writeLock.unlock();
-            }
-        } finally {
-            readLock.unlock();
+        if (!shutdownReceived) {
+          try {
+            // IO block
+            readAndUnwrap(Optional.empty());
+            Util.assertTrue(shutdownReceived);
+          } catch (EofException e) {
+            throw new ClosedChannelException();
+          }
         }
+        freeBuffers();
+        return true;
+      } finally {
+        writeLock.unlock();
+      }
+    } finally {
+      readLock.unlock();
     }
+  }
 
-    private void tryShutdown() {
-        if (!readLock.tryLock()) {
-            return;
-        }
-        try {
-            if (!writeLock.tryLock()) {
-                return;
-            }
-            try {
-                if (!shutdownSent) {
-                    try {
-                        boolean closed = shutdown();
-                        if (!closed && waitForCloseConfirmation) {
-                            shutdown();
-                        }
-                    } catch (Throwable e) {
-                        LOGGER.debug(format("error doing TLS shutdown on close(), continuing: %s", e.getMessage()));
-                    }
-                }
-            } finally {
-                writeLock.unlock();
-            }
-        } finally {
-            readLock.unlock();
-        }
+  private void freeBuffers() {
+    if (inEncrypted != null) {
+      inEncrypted.dispose();
+      inEncrypted = null;
     }
+    if (inPlain != null) {
+      inPlain.dispose();
+      inPlain = null;
+    }
+    if (outEncrypted != null) {
+      outEncrypted.dispose();
+      outEncrypted = null;
+    }
+  }
 
-    public boolean shutdown() throws IOException {
-        readLock.lock();
-        try {
-            writeLock.lock();
-            try {
-                if (invalid) {
-                    throw new ClosedChannelException();
-                }
-                if (!shutdownSent) {
-                    shutdownSent = true;
-                    outEncrypted.prepare();
-                    try {
-                        writeToChannel(); // IO block
-                        engine.closeOutbound();
-                        wrapLoop(dummyOut);
-                        writeToChannel(); // IO block
-                    } finally {
-                        outEncrypted.release();
-                    }
-                    /*
-                     * If this side is the first to send close_notify, then,
-                     * inbound is not done and false should be returned (so the
-                     * client waits for the response. If this side is the
-                     * second, then inbound was already done, and we can return
-                     * true.
-                     */
-                    if (shutdownReceived) {
-                        freeBuffers();
-                    }
-                    return shutdownReceived;
-                }
-                /*
-                 * If we reach this point, then we just have to read the close
-                 * notification from the client. Only try to do it if necessary,
-                 * to make this method idempotent.
-                 */
-                if (!shutdownReceived) {
-                    try {
-                        // IO block
-                        readAndUnwrap(Optional.<ByteBufferSet>empty(), NEED_UNWRAP /* statusCondition */, true /* closing */);
-                        Util.assertTrue(shutdownReceived);
-                    } catch (EofException e) {
-                        throw new ClosedChannelException();
-                    }
-                }
-                freeBuffers();
-                return true;
-            } finally {
-                writeLock.unlock();
-            }
-        } finally {
-            readLock.unlock();
-        }
-    }
+  public boolean isOpen() {
+    return !invalid && writeChannel.isOpen() && readChannel.isOpen();
+  }
 
-    private void freeBuffers() {
-        if (inEncrypted != null) {
-            inEncrypted.dispose();
-            inEncrypted = null;
-        }
-        if (inPlain != null) {
-            inPlain.dispose();
-            inPlain = null;
-        }
-        if (outEncrypted != null) {
-            outEncrypted.dispose();
-            outEncrypted = null;
-        }
-    }
+  public static void checkReadBuffer(ByteBufferSet dest) {
+    if (dest.isReadOnly()) throw new IllegalArgumentException();
+  }
 
-    public boolean isOpen() {
-        return !invalid && writeChannel.isOpen() && readChannel.isOpen();
-    }
+  public SSLEngine engine() {
+    return engine;
+  }
 
-    public static void checkReadBuffer(final ByteBufferSet dest) {
-        if (dest.isReadOnly()) {
-            throw new IllegalArgumentException();
-        }
-    }
+  public boolean getRunTasks() {
+    return runTasks;
+  }
 
-    public SSLEngine engine() {
-        return engine;
-    }
+  @Override
+  public int read(ByteBuffer dst) throws IOException {
+    return (int) read(new ByteBufferSet(dst));
+  }
 
-    public boolean getRunTasks() {
-        return runTasks;
-    }
+  @Override
+  public int write(ByteBuffer src) throws IOException {
+    return (int) write(new ByteBufferSet(src));
+  }
 
-    @Override
-    public int read(final ByteBuffer dst) throws IOException {
-        return (int) read(new ByteBufferSet(dst));
-    }
+  public boolean shutdownReceived() {
+    return shutdownReceived;
+  }
 
-    @Override
-    public int write(final ByteBuffer src) throws IOException {
-        return (int) write(new ByteBufferSet(src));
-    }
+  public boolean shutdownSent() {
+    return shutdownSent;
+  }
 
-    public boolean shutdownReceived() {
-        return shutdownReceived;
-    }
+  public ReadableByteChannel plainReadableChannel() {
+    return readChannel;
+  }
 
-    public boolean shutdownSent() {
-        return shutdownSent;
-    }
-
-    public ReadableByteChannel plainReadableChannel() {
-        return readChannel;
-    }
-
-    public WritableByteChannel plainWritableChannel() {
-        return writeChannel;
-    }
+  public WritableByteChannel plainWritableChannel() {
+    return writeChannel;
+  }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/impl/TlsExplorer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/impl/TlsExplorer.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel.impl;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLProtocolException;
+import javax.net.ssl.StandardConstants;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+ * Implement basic TLS parsing, just to read the SNI (as this is not done by
+ * {@link SSLEngine}.
+ */
+public final class TlsExplorer {
+
+  private TlsExplorer() {}
+
+  /** The header size of TLS/SSL records. */
+  public static final int RECORD_HEADER_SIZE = 5;
+
+  /**
+   * Returns the required number of bytesProduced in the {@code source} {@link ByteBuffer} necessary
+   * to explore SSL/TLS connection.
+   *
+   * <p>This method tries to parse as few bytesProduced as possible from {@code source} byte buffer
+   * to get the length of an SSL/TLS record.
+   *
+   * @param source source buffer
+   * @return the required size
+   */
+  public static int getRequiredSize(ByteBuffer source) {
+    if (source.remaining() < RECORD_HEADER_SIZE) throw new BufferUnderflowException();
+    source.mark();
+    try {
+      byte firstByte = source.get();
+      source.get(); // second byte discarded
+      byte thirdByte = source.get();
+      if ((firstByte & 0x80) != 0 && thirdByte == 0x01) {
+        // looks like a V2ClientHello
+        return RECORD_HEADER_SIZE; // Only need the header fields
+      } else {
+        return (((source.get() & 0xFF) << 8) | (source.get() & 0xFF)) + 5;
+      }
+    } finally {
+      source.reset();
+    }
+  }
+
+  public static Map<Integer, SNIServerName> explore(ByteBuffer source) throws SSLProtocolException {
+    if (source.remaining() < RECORD_HEADER_SIZE) throw new BufferUnderflowException();
+    source.mark();
+    try {
+      byte firstByte = source.get();
+      ignore(source, 1); // ignore second byte
+      byte thirdByte = source.get();
+      if ((firstByte & 0x80) != 0 && thirdByte == 0x01) {
+        // looks like a V2ClientHello
+        return new HashMap<>();
+      } else if (firstByte == 22) {
+        // 22: handshake record
+        return exploreTLSRecord(source, firstByte);
+      } else {
+        throw new SSLProtocolException("Not handshake record");
+      }
+    } finally {
+      source.reset();
+    }
+  }
+
+  /*
+   * struct { uint8 major; uint8 minor; } ProtocolVersion;
+   *
+   * enum { change_cipher_spec(20), alert(21), handshake(22),
+   * application_data(23), (255) } ContentType;
+   *
+   * struct { ContentType type; ProtocolVersion version; uint16 length; opaque
+   * fragment[TLSPlaintext.length]; } TLSPlaintext;
+   */
+  private static Map<Integer, SNIServerName> exploreTLSRecord(ByteBuffer input, byte firstByte)
+      throws SSLProtocolException {
+    // Is it a handshake message?
+    if (firstByte != 22) // 22: handshake record
+    throw new SSLProtocolException("Not handshake record");
+    // Is there enough data for a full record?
+    int recordLength = getInt16(input);
+    if (recordLength > input.remaining()) throw new BufferUnderflowException();
+    return exploreHandshake(input, recordLength);
+  }
+
+  /*
+   * enum { hello_request(0), client_hello(1), server_hello(2),
+   * certificate(11), server_key_exchange (12), certificate_request(13),
+   * server_hello_done(14), certificate_verify(15), client_key_exchange(16),
+   * finished(20) (255) } HandshakeType;
+   *
+   * struct { HandshakeType msg_type; uint24 length; select (HandshakeType) {
+   * case hello_request: HelloRequest; case client_hello: ClientHello; case
+   * server_hello: ServerHello; case certificate: Certificate; case
+   * server_key_exchange: ServerKeyExchange; case certificate_request:
+   * CertificateRequest; case server_hello_done: ServerHelloDone; case
+   * certificate_verify: CertificateVerify; case client_key_exchange:
+   * ClientKeyExchange; case finished: Finished; } body; } Handshake;
+   */
+  private static Map<Integer, SNIServerName> exploreHandshake(ByteBuffer input, int recordLength)
+      throws SSLProtocolException {
+    // What is the handshake type?
+    byte handshakeType = input.get();
+    if (handshakeType != 0x01) // 0x01: client_hello message
+    throw new SSLProtocolException("Not initial handshaking");
+    // What is the handshake body length?
+    int handshakeLength = getInt24(input);
+    // Theoretically, a single handshake message might span multiple
+    // records, but in practice this does not occur.
+    if (handshakeLength > recordLength - 4) // 4: handshake header size
+    throw new SSLProtocolException("Handshake message spans multiple records");
+    input.limit(handshakeLength + input.position());
+    return exploreClientHello(input);
+  }
+
+  /*
+   * struct { uint32 gmt_unix_time; opaque random_bytes[28]; } Random;
+   *
+   * opaque SessionID<0..32>;
+   *
+   * uint8 CipherSuite[2];
+   *
+   * enum { null(0), (255) } CompressionMethod;
+   *
+   * struct { ProtocolVersion client_version; Random random; SessionID
+   * session_id; CipherSuite cipher_suites<2..2^16-2>; CompressionMethod
+   * compression_methods<1..2^8-1>; select (extensions_present) { case false:
+   * struct {}; case true: Extension extensions<0..2^16-1>; }; } ClientHello;
+   */
+  private static Map<Integer, SNIServerName> exploreClientHello(ByteBuffer input)
+      throws SSLProtocolException {
+    ignore(input, 2); // ignore version
+    ignore(input, 32); // ignore random; 32: the length of Random
+    ignoreByteVector8(input); // ignore session id
+    ignoreByteVector16(input); // ignore cipher_suites
+    ignoreByteVector8(input); // ignore compression methods
+    if (input.remaining() > 0) return exploreExtensions(input);
+    else return new HashMap<>();
+  }
+
+  /*
+   * struct { ExtensionType extension_type; opaque extension_data<0..2^16-1>;
+   * } Extension;
+   *
+   * enum { server_name(0), max_fragment_length(1), client_certificate_url(2),
+   * trusted_ca_keys(3), truncated_hmac(4), status_request(5), (65535) }
+   * ExtensionType;
+   */
+  private static Map<Integer, SNIServerName> exploreExtensions(ByteBuffer input)
+      throws SSLProtocolException {
+    int length = getInt16(input); // length of extensions
+    while (length > 0) {
+      int extType = getInt16(input); // extension type
+      int extLen = getInt16(input); // length of extension data
+      if (extType == 0x00) { // 0x00: type of server name indication
+        return exploreSNIExt(input, extLen);
+      } else { // ignore other extensions
+        ignore(input, extLen);
+      }
+      length -= extLen + 4;
+    }
+    return new HashMap<>();
+  }
+
+  /*
+   * struct { NameType name_type; select (name_type) { case host_name:
+   * HostName; } name; } ServerName;
+   *
+   * enum { host_name(0), (255) } NameType;
+   *
+   * opaque HostName<1..2^16-1>;
+   *
+   * struct { ServerName server_name_list<1..2^16-1> } ServerNameList;
+   */
+  private static Map<Integer, SNIServerName> exploreSNIExt(ByteBuffer input, int extLen)
+      throws SSLProtocolException {
+    Map<Integer, SNIServerName> sniMap = new HashMap<>();
+    int remains = extLen;
+    if (extLen >= 2) { // "server_name" extension in ClientHello
+      int listLen = getInt16(input); // length of server_name_list
+      if (listLen == 0 || listLen + 2 != extLen)
+        throw new SSLProtocolException("Invalid server name indication extension");
+      remains -= 2; // 2: the length field of server_name_list
+      while (remains > 0) {
+        int code = getInt8(input); // name_type
+        int snLen = getInt16(input); // length field of server name
+        if (snLen > remains)
+          throw new SSLProtocolException("Not enough data to fill declared vector size");
+        byte[] encoded = new byte[snLen];
+        input.get(encoded);
+        SNIServerName serverName;
+        switch (code) {
+          case StandardConstants.SNI_HOST_NAME:
+            if (encoded.length == 0)
+              throw new SSLProtocolException("Empty HostName in server name indication");
+            serverName = new SNIHostName(encoded);
+            break;
+          default:
+            serverName = new UnknownServerName(code, encoded);
+        }
+        // check for duplicated server name type
+        if (sniMap.put(serverName.getType(), serverName) != null)
+          throw new SSLProtocolException("Duplicated server name of type " + serverName.getType());
+        remains -= encoded.length + 3; // NameType: 1 byte; HostName;
+        // length: 2 bytesProduced
+      }
+    } else if (extLen == 0) { // "server_name" extension in ServerHello
+      throw new SSLProtocolException("Not server name indication extension in client");
+    }
+    if (remains != 0) throw new SSLProtocolException("Invalid server name indication extension");
+    return sniMap;
+  }
+
+  private static int getInt8(ByteBuffer input) {
+    return input.get();
+  }
+
+  private static int getInt16(ByteBuffer input) {
+    return ((input.get() & 0xFF) << 8) | (input.get() & 0xFF);
+  }
+
+  private static int getInt24(ByteBuffer input) {
+    return ((input.get() & 0xFF) << 16) | ((input.get() & 0xFF) << 8) | (input.get() & 0xFF);
+  }
+
+  private static void ignoreByteVector8(ByteBuffer input) {
+    ignore(input, getInt8(input));
+  }
+
+  private static void ignoreByteVector16(ByteBuffer input) {
+    ignore(input, getInt16(input));
+  }
+
+  private static void ignore(ByteBuffer input, int length) {
+    if (length != 0) input.position(input.position() + length);
+  }
+
+  // For some reason, SNIServerName is abstract
+  private static class UnknownServerName extends SNIServerName {
+    UnknownServerName(int code, byte[] encoded) {
+      super(code, encoded);
+    }
+  }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/AsynchronousTlsChannelAdapter.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/AsynchronousTlsChannelAdapter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel.mongo;
+
+import com.mongodb.internal.connection.ExtendedAsynchronousByteChannel;
+import com.mongodb.internal.connection.tlschannel.async.AsynchronousTlsChannel;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.CompletionHandler;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class AsynchronousTlsChannelAdapter implements ExtendedAsynchronousByteChannel {
+    private final AsynchronousTlsChannel wrapped;
+
+    public static ExtendedAsynchronousByteChannel adapt(final AsynchronousTlsChannel asynchronousTlsChannel) {
+        return new AsynchronousTlsChannelAdapter(asynchronousTlsChannel);
+    }
+
+    AsynchronousTlsChannelAdapter(AsynchronousTlsChannel wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public <A> void read(final ByteBuffer dst, final A attach, final CompletionHandler<Integer, ? super A> handler) {
+        wrapped.read(dst, attach, handler);
+    }
+
+    @Override
+    public <A> void read(final ByteBuffer dst, final long timeout, final TimeUnit unit, final A attach,
+                         final CompletionHandler<Integer, ? super A> handler) {
+        wrapped.read(dst, timeout, unit, attach, handler);
+    }
+
+    @Override
+    public <A> void read(final ByteBuffer[] dsts, final int offset, final int length, final long timeout, final TimeUnit unit,
+                         final A attach, final CompletionHandler<Long, ? super A> handler) {
+        wrapped.read(dsts, offset, length, timeout, unit, attach, handler);
+    }
+
+    @Override
+    public Future<Integer> read(final ByteBuffer dst) {
+        return wrapped.read(dst);
+    }
+
+    @Override
+    public <A> void write(final ByteBuffer src, final A attach, final CompletionHandler<Integer, ? super A> handler) {
+        wrapped.write(src, attach, handler);
+    }
+
+    @Override
+    public <A> void write(final ByteBuffer src, final long timeout, final TimeUnit unit, final A attach,
+                          final CompletionHandler<Integer, ? super A> handler) {
+        wrapped.write(src, timeout, unit, attach, handler);
+    }
+
+    @Override
+    public <A> void write(final ByteBuffer[] srcs, final int offset, final int length, final long timeout, final TimeUnit unit,
+                          final A attach, final CompletionHandler<Long, ? super A> handler) {
+        wrapped.write(srcs, offset, length, timeout, unit, attach, handler);
+    }
+
+    @Override
+    public Future<Integer> write(final ByteBuffer src) {
+        return wrapped.write(src);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return wrapped.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        wrapped.close();
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/ByteBufAllocator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/ByteBufAllocator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel.mongo;
+
+import com.mongodb.internal.connection.tlschannel.BufferAllocator;
+import org.bson.ByteBuf;
+
+/**
+ * A factory for {@link ByteBuf}s. Implementations are free to return heap or direct buffers, or
+ * to do any kind of pooling. They are also expected to be thread-safe.
+ */
+public interface ByteBufAllocator {
+
+    /**
+     * Allocate a {@link ByteBuf} with the given initial capacity.
+     *
+     * @param size the size to allocate
+     * @return the newly created buffer
+     */
+    ByteBuf allocate(int size);
+
+    /**
+     * Deallocate the given {@link ByteBuf}.
+     *
+     * @param buffer the buffer to deallocate, that should have been allocated using the same {@link
+     *     BufferAllocator} instance
+     */
+    void free(ByteBuf buffer);
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/ByteBufHolder.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/ByteBufHolder.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel.mongo;
+
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
+import com.mongodb.internal.connection.tlschannel.impl.TlsChannelImpl;
+import org.bson.ByteBuf;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+public class ByteBufHolder {
+
+  private static final Logger logger = Loggers.getLogger("connection.tls");
+  // Round to next highest power of two to account for PowerOfTwoBufferPool allocation style
+  private static final byte[] zeros = new byte[roundUpToNextHighestPowerOfTwo(TlsChannelImpl.maxTlsPacketSize)];
+
+  public final String name;
+  public final ByteBufAllocator allocator;
+  public final boolean plainData;
+  public final int maxSize;
+  public final boolean opportunisticDispose;
+
+  public ByteBuf byteBuf;
+  public ByteBuffer buffer;
+
+  public int lastSize;
+
+  public ByteBufHolder(
+      String name,
+      Optional<ByteBuf> byteBuf,
+      ByteBufAllocator allocator,
+      int initialSize,
+      int maxSize,
+      boolean plainData,
+      boolean opportunisticDispose) {
+    this.name = name;
+    this.allocator = allocator;
+    this.byteBuf = byteBuf.orElse(null);
+    this.maxSize = maxSize;
+    this.plainData = plainData;
+    this.opportunisticDispose = opportunisticDispose;
+    this.lastSize = byteBuf.map(ByteBuf::capacity).orElse(initialSize);
+  }
+
+  public void prepare() {
+    if (buffer == null) {
+      byteBuf = allocator.allocate(lastSize);
+      buffer = byteBuf.asNIO();
+    }
+  }
+
+  public boolean release() {
+    if (opportunisticDispose && buffer.position() == 0) {
+      return dispose();
+    } else {
+      return false;
+    }
+  }
+
+  public boolean dispose() {
+    if (buffer != null) {
+      allocator.free(byteBuf);
+      buffer = null;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public void resize(int newCapacity) {
+    if (newCapacity > maxSize)
+      throw new IllegalArgumentException(
+          format(
+              "new capacity (%s) bigger than absolute max size (%s)", newCapacity, maxSize));
+    if (logger.isTraceEnabled()) {
+      logger.trace(format(
+              "resizing buffer %s, increasing from %s to %s (manual sizing)",
+              name,
+              buffer.capacity(),
+              newCapacity));
+    }
+    resizeImpl(newCapacity);
+  }
+
+  public void enlarge() {
+    if (buffer.capacity() >= maxSize) {
+      throw new IllegalStateException(
+          format(
+              "%s buffer insufficient despite having capacity of %d", name, buffer.capacity()));
+    }
+    int newCapacity = Math.min(buffer.capacity() * 2, maxSize);
+    if (logger.isTraceEnabled()) {
+      logger.trace(format(
+              "enlarging buffer %s, increasing from %s to %s (automatic enlarge)",
+              name,
+              buffer.capacity(),
+              newCapacity));
+    }
+    resizeImpl(newCapacity);
+  }
+
+  private void resizeImpl(int newCapacity) {
+    ByteBuf newByteBuf = allocator.allocate(newCapacity);
+    ByteBuffer newBuffer = newByteBuf.asNIO();
+    buffer.flip();
+    newBuffer.put(buffer);
+    if (plainData) {
+      zero();
+    }
+    allocator.free(byteBuf);
+    byteBuf = newByteBuf;
+    buffer = newBuffer;
+    lastSize = newCapacity;
+  }
+
+  /**
+   * Fill with zeros the remaining of the supplied buffer. This method does not change the buffer
+   * position.
+   *
+   * <p>Typically used for security reasons, with buffers that contains now-unused plaintext.
+   */
+  public void zeroRemaining() {
+    buffer.mark();
+    buffer.put(zeros, 0, buffer.remaining());
+    buffer.reset();
+  }
+
+  /**
+   * Fill the buffer with zeros. This method does not change the buffer position.
+   *
+   * <p>Typically used for security reasons, with buffers that contains now-unused plaintext.
+   */
+  public void zero() {
+    buffer.mark();
+    buffer.position(0);
+    buffer.put(zeros, 0, buffer.remaining());
+    buffer.reset();
+  }
+
+  public boolean nullOrEmpty() {
+    return buffer == null || buffer.position() == 0;
+  }
+
+  private static int roundUpToNextHighestPowerOfTwo(final int size) {
+    int v = size;
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v++;
+    return v;
+  }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/TrackingByteBufAllocator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/TrackingByteBufAllocator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel.mongo;
+
+import com.mongodb.internal.connection.tlschannel.BufferAllocator;
+import com.mongodb.internal.connection.tlschannel.mongo.ByteBufAllocator;
+import org.bson.ByteBuf;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+
+/** A decorating {@link BufferAllocator} that keeps statistics. */
+public class TrackingByteBufAllocator implements ByteBufAllocator {
+
+  private ByteBufAllocator impl;
+
+  private LongAdder bytesAllocatedAdder = new LongAdder();
+  private LongAdder bytesDeallocatedAdder = new LongAdder();
+  private AtomicLong currentAllocationSize = new AtomicLong();
+  private LongAccumulator maxAllocationSizeAcc = new LongAccumulator(Math::max, 0);
+
+  private LongAdder buffersAllocatedAdder = new LongAdder();
+  private LongAdder buffersDeallocatedAdder = new LongAdder();
+
+  public TrackingByteBufAllocator(ByteBufAllocator impl) {
+    this.impl = impl;
+  }
+
+  public ByteBuf allocate(int size) {
+    bytesAllocatedAdder.add(size);
+    currentAllocationSize.addAndGet(size);
+    buffersAllocatedAdder.increment();
+    return impl.allocate(size);
+  }
+
+  public void free(ByteBuf buffer) {
+    int size = buffer.capacity();
+    bytesDeallocatedAdder.add(size);
+    maxAllocationSizeAcc.accumulate(currentAllocationSize.longValue());
+    currentAllocationSize.addAndGet(-size);
+    buffersDeallocatedAdder.increment();
+    impl.free(buffer);
+  }
+
+  public long bytesAllocated() {
+    return bytesAllocatedAdder.longValue();
+  }
+
+  public long bytesDeallocated() {
+    return bytesDeallocatedAdder.longValue();
+  }
+
+  public long currentAllocation() {
+    return currentAllocationSize.longValue();
+  }
+
+  public long maxAllocation() {
+    return maxAllocationSizeAcc.longValue();
+  }
+
+  public long buffersAllocated() {
+    return buffersAllocatedAdder.longValue();
+  }
+
+  public long buffersDeallocated() {
+    return buffersDeallocatedAdder.longValue();
+  }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/package-info.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/mongo/package-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+/**
+ * This package contains the adaptation classes used so this library can work with ByteBufs and free used resources correctly.
+ *
+ * The changes are as follows:
+ *
+ *   - AsynchronousTlsChannelAdapter - originally from this package the AsynchronousTlsChannel was moved out to support other usecases, this
+ *                                     is a simple proxy class, used by the TlsChannelStreamFactoryFactory.
+ *   - ByteBufAllocator - This replaces the tls-channels BufferAllocator class, so that we can free any ByteBufs once used.
+ *   - ByteBufHolder - This replaces the tls-channels BufferHolder class, and manages the ByteBuf correctly so it can be freed once used
+ *   - TrackingByteBufAllocator - This replaces the tls-channels TrackingBufferAllocator class and is a tracking proxy for the Allocator class.
+ *
+ *  The tls-channel library is then updated to use the new counter parts instead of the originals. Any changes to the originals should be
+ *  included in these classes.
+ *
+ *  The final change required is to update the logger code
+ */
+package com.mongodb.internal.connection.tlschannel.mongo;

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/package-info.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/package-info.java
@@ -17,29 +17,14 @@
  * https://github.com/marianobarrios/tls-channel
  */
 
-package com.mongodb.internal.connection.tlschannel;
-
-import java.nio.ByteBuffer;
-
 /**
- * A factory for {@link ByteBuffer}s. Implementations are free to return heap or direct buffers, or
- * to do any kind of pooling. They are also expected to be thread-safe.
+ * TLS Channel is a library that implements a ByteChannel interface to a TLS (Transport Layer
+ * Security) connection. The library delegates all cryptographic operations to the standard Java TLS
+ * implementation: SSLEngine; effectively hiding it behind an easy-to-use streaming API, that allows
+ * to securitize JVM applications with minimal added complexity.
+ *
+ * <p>In other words, a simple library that allows the programmer to have TLS using the same
+ * standard socket API used for plaintext, just like OpenSSL does for C, only for Java, filling a
+ * specially painful missing feature of the standard Java library.
  */
-public interface BufferAllocator {
-
-  /**
-   * Allocate a {@link ByteBuffer} with the given initial capacity.
-   *
-   * @param size the size to allocate
-   * @return the newly created buffer
-   */
-  ByteBuffer allocate(int size);
-
-  /**
-   * Deallocate the given {@link ByteBuffer}.
-   *
-   * @param buffer the buffer to deallocate, that should have been allocated using the same {@link
-   *     BufferAllocator} instance
-   */
-  void free(ByteBuffer buffer);
-}
+package com.mongodb.internal.connection.tlschannel;

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/DirectBufferDeallocator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/DirectBufferDeallocator.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
+ * https://github.com/marianobarrios/tls-channel
+ */
+
+package com.mongodb.internal.connection.tlschannel.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+/**
+ * Access to NIO sun.misc.Cleaner, allowing caller to deterministically deallocate a given
+ * sun.nio.ch.DirectBuffer.
+ */
+public class DirectBufferDeallocator {
+
+  private static Logger logger = LoggerFactory.getLogger(DirectBufferDeallocator.class);
+
+  private interface Deallocator {
+    void free(ByteBuffer bb);
+  }
+
+  private static class Java8Deallocator implements Deallocator {
+
+    /*
+     * Getting instance of cleaner from buffer (sun.misc.Cleaner)
+     */
+
+    final Method cleanerAccessor;
+    final Method clean;
+
+    Java8Deallocator() {
+      try {
+        cleanerAccessor =
+            Class.forName("sun.nio.ch.DirectBuffer").getMethod("cleaner", (Class<?>[]) null);
+        clean = Class.forName("sun.misc.Cleaner").getMethod("clean");
+      } catch (NoSuchMethodException | ClassNotFoundException t) {
+        throw new RuntimeException(t);
+      }
+    }
+
+    @Override
+    public void free(ByteBuffer bb) {
+      try {
+        clean.invoke(cleanerAccessor.invoke(bb));
+      } catch (IllegalAccessException | InvocationTargetException t) {
+        throw new RuntimeException(t);
+      }
+    }
+  }
+
+  private static class Java9Deallocator implements Deallocator {
+
+    /*
+     * Clean is of type jdk.internal.ref.Cleaner, but this type is not accessible, as it is not exported by default.
+     * Using workaround through sun.misc.Unsafe.
+     */
+
+    final Object unsafe;
+    final Method invokeCleaner;
+
+    Java9Deallocator() {
+      try {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        // avoiding getUnsafe methods, as it is explicitly filtered out from reflection API
+        Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+        theUnsafe.setAccessible(true);
+        unsafe = theUnsafe.get(null);
+        invokeCleaner = unsafeClass.getMethod("invokeCleaner", ByteBuffer.class);
+      } catch (NoSuchMethodException
+          | ClassNotFoundException
+          | IllegalAccessException
+          | NoSuchFieldException t) {
+        throw new RuntimeException(t);
+      }
+    }
+
+    @Override
+    public void free(ByteBuffer bb) {
+      try {
+        invokeCleaner.invoke(unsafe, bb);
+      } catch (IllegalAccessException | InvocationTargetException t) {
+        throw new RuntimeException(t);
+      }
+    }
+  }
+
+  private final Deallocator deallocator;
+
+  public DirectBufferDeallocator() {
+    if (Util.getJavaMajorVersion() >= 9) {
+      deallocator = new Java9Deallocator();
+      logger.debug("initialized direct buffer deallocator for java >= 9");
+    } else {
+      deallocator = new Java8Deallocator();
+      logger.debug("initialized direct buffer deallocator for java < 9");
+    }
+  }
+
+  public void deallocate(ByteBuffer buffer) {
+    deallocator.free(buffer);
+  }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
@@ -19,14 +19,9 @@
 
 package com.mongodb.internal.connection.tlschannel.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.net.ssl.SSLEngineResult;
 
 public class Util {
-
-  private static final Logger logger = LoggerFactory.getLogger(Util.class);
 
   public static void assertTrue(boolean condition) {
     if (!condition) throw new AssertionError();

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
@@ -13,29 +13,51 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Original Work: MIT License, Copyright (c) [2015-2018] all contributors
+ * Original Work: MIT License, Copyright (c) [2015-2020] all contributors
  * https://github.com/marianobarrios/tls-channel
  */
 
 package com.mongodb.internal.connection.tlschannel.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.net.ssl.SSLEngineResult;
 
 public class Util {
 
-    public static void assertTrue(final boolean condition) {
-        if (!condition) {
-            throw new AssertionError();
-        }
-    }
+  private static final Logger logger = LoggerFactory.getLogger(Util.class);
 
-    /**
-     * Convert a {@link SSLEngineResult} into a {@link String}, this is needed
-     * because the supplied method includes a log-breaking newline.
-     */
-    public static String resultToString(final SSLEngineResult result) {
-        return String.format("status=%s,handshakeStatus=%s,bytesConsumed=%d,bytesConsumed=%d", result.getStatus(),
-                result.getHandshakeStatus(), result.bytesProduced(), result.bytesConsumed());
-    }
+  public static void assertTrue(boolean condition) {
+    if (!condition) throw new AssertionError();
+  }
 
+  /**
+   * Convert a {@link SSLEngineResult} into a {@link String}, this is needed because the supplied
+   * method includes a log-breaking newline.
+   *
+   * @param result the SSLEngineResult
+   * @return the resulting string
+   */
+  public static String resultToString(SSLEngineResult result) {
+    return String.format(
+        "status=%s,handshakeStatus=%s,bytesConsumed=%d,bytesConsumed=%d",
+        result.getStatus(),
+        result.getHandshakeStatus(),
+        result.bytesProduced(),
+        result.bytesConsumed());
+  }
+
+  public static int getJavaMajorVersion() {
+    String version = System.getProperty("java.version");
+    if (version.startsWith("1.")) {
+      version = version.substring(2, 3);
+    } else {
+      int dot = version.indexOf(".");
+      if (dot != -1) {
+        version = version.substring(0, dot);
+      }
+    }
+    return Integer.parseInt(version);
+  }
 }


### PR DESCRIPTION
Two commits to make the process simpler in the future:

 * Revendoring the tls code - as is.
 * Added a mongo package to hold the specific tls changes needed. And refactored the core tls code  to support the mongo mainly to support ByteBufs. See [package-info](https://github.com/rozza/mongo-java-driver/pull/383/files#diff-4075e5d9973949a089266591d1bcd541)


https://evergreen.mongodb.com/version/5eb29180e3c3310f36bbf8bb