### PR TITLE
Fix PojoCodec cache concurrency issue.

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/LazyPojoCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/LazyPojoCodec.java
@@ -31,7 +31,7 @@ class LazyPojoCodec<T> extends PojoCodec<T> {
     private final PropertyCodecRegistry propertyCodecRegistry;
     private final DiscriminatorLookup discriminatorLookup;
     private final ConcurrentMap<ClassModel<?>, Codec<?>> codecCache;
-    private volatile PojoCodecImpl<T> pojoCodec;
+    private PojoCodecImpl<T> pojoCodec;
 
     LazyPojoCodec(final ClassModel<T> classModel, final CodecRegistry registry, final PropertyCodecRegistry propertyCodecRegistry,
                   final DiscriminatorLookup discriminatorLookup, final ConcurrentMap<ClassModel<?>, Codec<?>> codecCache) {
@@ -57,7 +57,7 @@ class LazyPojoCodec<T> extends PojoCodec<T> {
         return getPojoCodec().decode(reader, decoderContext);
     }
 
-    private Codec<T> getPojoCodec() {
+    private synchronized Codec<T> getPojoCodec() {
         if (pojoCodec == null) {
             pojoCodec = new PojoCodecImpl<T>(classModel, registry, propertyCodecRegistry, discriminatorLookup, codecCache, true);
         }

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -132,6 +132,7 @@ public final class PojoRoundTripTest extends PojoTestCase {
     @Test
     public void test() {
         roundTrip(builder, model, json);
+        threadedRoundTrip(builder, model, json);
     }
 
     private static List<TestData> testCases() {

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
@@ -68,12 +68,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.pojo.Conventions.DEFAULT_CONVENTIONS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 abstract class PojoTestCase {
 
@@ -88,6 +93,38 @@ abstract class PojoTestCase {
     <T> void roundTrip(final PojoCodecProvider.Builder builder, final T value, final String json) {
         encodesTo(getCodecRegistry(builder), value, json);
         decodesTo(getCodecRegistry(builder), json, value);
+    }
+
+    <T> void threadedRoundTrip(final PojoCodecProvider.Builder builder, final T value, final String json) {
+        int numberOfThreads = 5;
+        ExecutorService service = null;
+        try {
+            service = Executors.newFixedThreadPool(10);
+            CountDownLatch latch = new CountDownLatch(numberOfThreads);
+            List<String> errors = new ArrayList<>();
+            CodecRegistry codecRegistry = getCodecRegistry(builder);
+            for (int i = 0; i < numberOfThreads; i++) {
+                service.submit(() -> {
+                    try {
+                        encodesTo(codecRegistry, value, json);
+                        decodesTo(codecRegistry, json, value);
+                    } catch (Exception e) {
+                        errors.add(e instanceof  NullPointerException ? "NPE: " + e.getStackTrace()[0] : e.getMessage());
+                    }
+                    latch.countDown();
+                });
+            }
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+            assertTrue(format("Errors encountered: [%s]", String.join(",", errors)), errors.isEmpty());
+        } finally {
+            if (service != null) {
+                service.shutdown();
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Only add to cache once the properties have been cached
Ensure other threads don't overwrite existing property model cached
codecs

JAVA-3775

https://spruce.mongodb.com/version/5f07351bc9ec446a93a00807/tasks