### PR TITLE
Attempt to simplify the internal abstraction for ClientSideOperationTimeout

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/ClientSideOperationTimeout.java
+++ b/driver-core/src/main/com/mongodb/internal/ClientSideOperationTimeout.java
@@ -37,6 +37,10 @@ public class ClientSideOperationTimeout {
     @Nullable
     private Timeout timeout;
 
+    public static ClientSideOperationTimeout create(@Nullable final Long timeoutMS) {
+        return new ClientSideOperationTimeout(timeoutMS, 0, 0, 0);
+    }
+
     public ClientSideOperationTimeout(@Nullable final Long timeoutMS,
                                       final long maxAwaitTimeMS,
                                       final long maxTimeMS,

--- a/driver-core/src/main/com/mongodb/internal/operation/BaseWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BaseWriteOperation.java
@@ -169,7 +169,7 @@ public abstract class BaseWriteOperation implements AsyncWriteOperation<WriteCon
     }
 
     private MixedBulkWriteOperation getMixedBulkOperation() {
-        return new MixedBulkWriteOperation(clientSideOperationTimeoutFactory, namespace, getWriteRequests(), ordered, writeConcern,
+        return new MixedBulkWriteOperation(clientSideOperationTimeoutFactory.create(), namespace, getWriteRequests(), ordered, writeConcern,
                 retryWrites).bypassDocumentValidation(bypassDocumentValidation);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -43,6 +43,7 @@ import com.mongodb.client.model.UpdateManyModel;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.ClientSideOperationTimeoutFactory;
 import com.mongodb.internal.bulk.DeleteRequest;
 import com.mongodb.internal.bulk.IndexRequest;
@@ -345,56 +346,56 @@ public final class Operations<TDocument> {
     }
 
 
-    public MixedBulkWriteOperation insertOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation insertOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                              final TDocument document, final InsertOneOptions options) {
-        return bulkWrite(clientSideOperationTimeoutFactory, singletonList(new InsertOneModel<TDocument>(document)),
+        return bulkWrite(clientSideOperationTimeout, singletonList(new InsertOneModel<TDocument>(document)),
                 new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()));
     }
 
 
-    public MixedBulkWriteOperation replaceOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation replaceOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                               final Bson filter, final TDocument replacement, final ReplaceOptions options) {
-        return bulkWrite(clientSideOperationTimeoutFactory, singletonList(new ReplaceOneModel<TDocument>(filter, replacement, options)),
+        return bulkWrite(clientSideOperationTimeout, singletonList(new ReplaceOneModel<TDocument>(filter, replacement, options)),
                 new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()));
     }
 
-    public MixedBulkWriteOperation deleteOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation deleteOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                              final Bson filter, final DeleteOptions options) {
-        return bulkWrite(clientSideOperationTimeoutFactory, singletonList(new DeleteOneModel<TDocument>(filter, options)),
+        return bulkWrite(clientSideOperationTimeout, singletonList(new DeleteOneModel<TDocument>(filter, options)),
                 new BulkWriteOptions());
     }
 
-    public MixedBulkWriteOperation deleteMany(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation deleteMany(final ClientSideOperationTimeout clientSideOperationTimeout,
                                               final Bson filter, final DeleteOptions options) {
-        return bulkWrite(clientSideOperationTimeoutFactory, singletonList(new DeleteManyModel<TDocument>(filter, options)),
+        return bulkWrite(clientSideOperationTimeout, singletonList(new DeleteManyModel<TDocument>(filter, options)),
                 new BulkWriteOptions());
     }
 
-    public MixedBulkWriteOperation updateOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation updateOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                              final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return bulkWrite(clientSideOperationTimeoutFactory, singletonList(new UpdateOneModel<TDocument>(filter, update, updateOptions)),
+        return bulkWrite(clientSideOperationTimeout, singletonList(new UpdateOneModel<TDocument>(filter, update, updateOptions)),
                 new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
     }
 
-    public MixedBulkWriteOperation updateOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation updateOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                              final Bson filter, final List<? extends Bson> update, final UpdateOptions updateOptions) {
-        return bulkWrite(clientSideOperationTimeoutFactory, singletonList(new UpdateOneModel<TDocument>(filter, update, updateOptions)),
+        return bulkWrite(clientSideOperationTimeout, singletonList(new UpdateOneModel<TDocument>(filter, update, updateOptions)),
                 new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
     }
 
-    public MixedBulkWriteOperation updateMany(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation updateMany(final ClientSideOperationTimeout clientSideOperationTimeout,
                                               final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return bulkWrite(clientSideOperationTimeoutFactory, singletonList(new UpdateManyModel<TDocument>(filter, update, updateOptions)),
+        return bulkWrite(clientSideOperationTimeout, singletonList(new UpdateManyModel<TDocument>(filter, update, updateOptions)),
                 new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
     }
 
-    public MixedBulkWriteOperation updateMany(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation updateMany(final ClientSideOperationTimeout clientSideOperationTimeout,
                                               final Bson filter, final List<? extends Bson> update, final UpdateOptions updateOptions) {
-        return bulkWrite(clientSideOperationTimeoutFactory, singletonList(new UpdateManyModel<TDocument>(filter, update, updateOptions)),
+        return bulkWrite(clientSideOperationTimeout, singletonList(new UpdateManyModel<TDocument>(filter, update, updateOptions)),
                 new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
     }
 
-    public MixedBulkWriteOperation insertMany(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation insertMany(final ClientSideOperationTimeout clientSideOperationTimeout,
                                               final List<? extends TDocument> documents,
                                               final InsertManyOptions options) {
         notNull("documents", documents);
@@ -409,12 +410,12 @@ public final class Operations<TDocument> {
             requests.add(new InsertRequest(documentToBsonDocument(document)));
         }
 
-        return new MixedBulkWriteOperation(clientSideOperationTimeoutFactory, namespace, requests, options.isOrdered(), writeConcern,
+        return new MixedBulkWriteOperation(clientSideOperationTimeout, namespace, requests, options.isOrdered(), writeConcern,
                 retryWrites).bypassDocumentValidation(options.getBypassDocumentValidation());
     }
 
     @SuppressWarnings("unchecked")
-    public MixedBulkWriteOperation bulkWrite(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public MixedBulkWriteOperation bulkWrite(final ClientSideOperationTimeout clientSideOperationTimeout,
                                              final List<? extends WriteModel<? extends TDocument>> requests,
                                              final BulkWriteOptions options) {
         notNull("requests", requests);
@@ -477,7 +478,7 @@ public final class Operations<TDocument> {
             }
             writeRequests.add(writeRequest);
         }
-        return new MixedBulkWriteOperation(clientSideOperationTimeoutFactory, namespace, writeRequests, options.isOrdered(), writeConcern,
+        return new MixedBulkWriteOperation(clientSideOperationTimeout, namespace, writeRequests, options.isOrdered(), writeConcern,
                 retryWrites).bypassDocumentValidation(options.getBypassDocumentValidation());
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -37,6 +37,7 @@ import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.ClientSideOperationTimeoutFactory;
 import com.mongodb.internal.client.model.AggregationLevel;
 import com.mongodb.internal.client.model.FindOptions;
@@ -168,59 +169,59 @@ public final class SyncOperations<TDocument> {
         return operations.findOneAndUpdate(clientSideOperationTimeoutFactory, filter, update, options);
     }
 
-    public WriteOperation<BulkWriteResult> insertOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> insertOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                      final TDocument document, final InsertOneOptions options) {
-        return operations.insertOne(clientSideOperationTimeoutFactory, document, options);
+        return operations.insertOne(clientSideOperationTimeout, document, options);
     }
 
 
-    public WriteOperation<BulkWriteResult> replaceOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> replaceOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                       final Bson filter, final TDocument replacement, final ReplaceOptions options) {
-        return operations.replaceOne(clientSideOperationTimeoutFactory, filter, replacement, options);
+        return operations.replaceOne(clientSideOperationTimeout, filter, replacement, options);
     }
 
-    public WriteOperation<BulkWriteResult> deleteOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> deleteOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                      final Bson filter, final DeleteOptions options) {
-        return operations.deleteOne(clientSideOperationTimeoutFactory, filter, options);
+        return operations.deleteOne(clientSideOperationTimeout, filter, options);
     }
 
-    public WriteOperation<BulkWriteResult> deleteMany(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> deleteMany(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                       final Bson filter, final DeleteOptions options) {
-        return operations.deleteMany(clientSideOperationTimeoutFactory, filter, options);
+        return operations.deleteMany(clientSideOperationTimeout, filter, options);
     }
 
-    public WriteOperation<BulkWriteResult> updateOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> updateOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                      final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return operations.updateOne(clientSideOperationTimeoutFactory, filter, update, updateOptions);
+        return operations.updateOne(clientSideOperationTimeout, filter, update, updateOptions);
     }
 
-    public WriteOperation<BulkWriteResult> updateOne(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> updateOne(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                      final Bson filter, final List<? extends Bson> update,
                                                      final UpdateOptions updateOptions) {
-        return operations.updateOne(clientSideOperationTimeoutFactory, filter, update, updateOptions);
+        return operations.updateOne(clientSideOperationTimeout, filter, update, updateOptions);
     }
 
-    public WriteOperation<BulkWriteResult> updateMany(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> updateMany(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                       final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return operations.updateMany(clientSideOperationTimeoutFactory, filter, update, updateOptions);
+        return operations.updateMany(clientSideOperationTimeout, filter, update, updateOptions);
     }
 
-    public WriteOperation<BulkWriteResult> updateMany(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> updateMany(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                       final Bson filter, final List<? extends Bson> update,
                                                       final UpdateOptions updateOptions) {
-        return operations.updateMany(clientSideOperationTimeoutFactory, filter, update, updateOptions);
+        return operations.updateMany(clientSideOperationTimeout, filter, update, updateOptions);
     }
 
-    public WriteOperation<BulkWriteResult> insertMany(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> insertMany(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                       final List<? extends TDocument> documents, final InsertManyOptions options) {
-        return operations.insertMany(clientSideOperationTimeoutFactory, documents, options);
+        return operations.insertMany(clientSideOperationTimeout, documents, options);
     }
 
     @SuppressWarnings("unchecked")
-    public WriteOperation<BulkWriteResult> bulkWrite(final ClientSideOperationTimeoutFactory clientSideOperationTimeoutFactory,
+    public WriteOperation<BulkWriteResult> bulkWrite(final ClientSideOperationTimeout clientSideOperationTimeout,
                                                      final List<? extends WriteModel<? extends TDocument>> requests,
                                                      final BulkWriteOptions options) {
-        return operations.bulkWrite(clientSideOperationTimeoutFactory, requests, options);
+        return operations.bulkWrite(clientSideOperationTimeout, requests, options);
     }
 
 

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -252,7 +252,7 @@ public final class CollectionHelper<T> {
     }
 
     public void updateOne(final Bson filter, final Bson update, final boolean isUpsert) {
-        new MixedBulkWriteOperation(DEFAULT_CSOT_FACTORY, namespace,
+        new MixedBulkWriteOperation(DEFAULT_CSOT_FACTORY.create(), namespace,
                                     singletonList(new UpdateRequest(filter.toBsonDocument(Document.class, registry),
                                                                     update.toBsonDocument(Document.class, registry),
                                                                     WriteRequest.Type.UPDATE)
@@ -262,7 +262,7 @@ public final class CollectionHelper<T> {
     }
 
     public void replaceOne(final Bson filter, final Bson update, final boolean isUpsert) {
-        new MixedBulkWriteOperation(DEFAULT_CSOT_FACTORY, namespace,
+        new MixedBulkWriteOperation(DEFAULT_CSOT_FACTORY.create(), namespace,
                 singletonList(new UpdateRequest(filter.toBsonDocument(Document.class, registry),
                         update.toBsonDocument(Document.class, registry),
                         WriteRequest.Type.REPLACE)
@@ -272,7 +272,7 @@ public final class CollectionHelper<T> {
     }
 
     public void deleteOne(final Bson filter) {
-        new MixedBulkWriteOperation(DEFAULT_CSOT_FACTORY, namespace,
+        new MixedBulkWriteOperation(DEFAULT_CSOT_FACTORY.create(), namespace,
                 singletonList(new DeleteRequest(filter.toBsonDocument(Document.class, registry))),
                 true, WriteConcern.ACKNOWLEDGED, false)
                 .execute(getBinding());

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -27,6 +27,7 @@ import com.mongodb.client.model.DBCollectionFindOptions;
 import com.mongodb.client.model.DBCollectionRemoveOptions;
 import com.mongodb.client.model.DBCollectionUpdateOptions;
 import com.mongodb.connection.BufferProvider;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.ClientSideOperationTimeoutFactories;
 import com.mongodb.internal.ClientSideOperationTimeoutFactory;
 import com.mongodb.internal.bulk.DeleteRequest;
@@ -2095,7 +2096,7 @@ public class DBCollection {
                                               final WriteConcern writeConcern) {
         try {
             return translateBulkWriteResult(executor.execute(new MixedBulkWriteOperation(
-                    ClientSideOperationTimeoutFactories.create(getTimeout(MILLISECONDS)),
+                    ClientSideOperationTimeout.create(getTimeout(MILLISECONDS)),
                     getNamespace(), translateWriteRequestsToNew(writeRequests), ordered, writeConcern, false)
                     .bypassDocumentValidation(bypassDocumentValidation), getReadConcern()), getObjectCodec());
         } catch (MongoBulkWriteException e) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
@@ -53,6 +53,7 @@ import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertManyResult;
 import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.ClientSideOperationTimeoutFactories;
 import com.mongodb.internal.ClientSideOperationTimeoutFactory;
 import com.mongodb.internal.async.SingleResultCallback;
@@ -317,13 +318,13 @@ public final class MongoOperationPublisher<T> {
             @Nullable final ClientSession clientSession,
             final List<? extends WriteModel<? extends T>> requests, final BulkWriteOptions options) {
         return createWriteOperationMono(() -> operations.bulkWrite(
-                getClientSideOperationTimeoutFactory(), notNull("requests", requests),
+                ClientSideOperationTimeout.create(timeoutMS), notNull("requests", requests),
                 notNull("options", options)), clientSession);
     }
 
     Publisher<InsertOneResult> insertOne(@Nullable final ClientSession clientSession, final T document, final InsertOneOptions options) {
         return createSingleWriteRequestMono(() -> operations.insertOne(
-                getClientSideOperationTimeoutFactory(), notNull("document", document),
+                ClientSideOperationTimeout.create(timeoutMS), notNull("document", document),
                 notNull("options", options)), clientSession, WriteRequest.Type.INSERT)
                 .map(INSERT_ONE_RESULT_MAPPER);
     }
@@ -332,21 +333,21 @@ public final class MongoOperationPublisher<T> {
             @Nullable final ClientSession clientSession, final List<? extends T> documents,
             final InsertManyOptions options) {
         return createWriteOperationMono(() -> operations.insertMany(
-                getClientSideOperationTimeoutFactory(),
+                ClientSideOperationTimeout.create(timeoutMS),
                 notNull("documents", documents), notNull("options", options)), clientSession)
                 .map(INSERT_MANY_RESULT_MAPPER);
     }
 
     Publisher<DeleteResult> deleteOne(@Nullable final ClientSession clientSession, final Bson filter, final DeleteOptions options) {
         return createSingleWriteRequestMono(() -> operations.deleteOne(
-                getClientSideOperationTimeoutFactory(),
+                ClientSideOperationTimeout.create(timeoutMS),
                 notNull("filter", filter), notNull("options", options)), clientSession, WriteRequest.Type.DELETE)
                 .map(DELETE_RESULT_MAPPER);
     }
 
     Publisher<DeleteResult> deleteMany(@Nullable final ClientSession clientSession, final Bson filter, final DeleteOptions options) {
         return createSingleWriteRequestMono(() -> operations.deleteMany(
-                getClientSideOperationTimeoutFactory(),
+                ClientSideOperationTimeout.create(timeoutMS),
                 notNull("filter", filter), notNull("options", options)), clientSession, WriteRequest.Type.DELETE)
                 .map(DELETE_RESULT_MAPPER);
     }
@@ -355,7 +356,7 @@ public final class MongoOperationPublisher<T> {
             @Nullable final ClientSession clientSession, final Bson filter, final T replacement,
             final ReplaceOptions options) {
         return createSingleWriteRequestMono(() -> operations.replaceOne(
-                getClientSideOperationTimeoutFactory(),
+                ClientSideOperationTimeout.create(timeoutMS),
                 notNull("filter", filter), notNull("replacement", replacement), notNull("options", options)),
                 clientSession, WriteRequest.Type.REPLACE)
                 .map(UPDATE_RESULT_MAPPER);
@@ -365,7 +366,7 @@ public final class MongoOperationPublisher<T> {
             @Nullable final ClientSession clientSession, final Bson filter, final Bson update,
             final UpdateOptions options) {
         return createSingleWriteRequestMono(() -> operations.updateOne(
-                getClientSideOperationTimeoutFactory(),
+                ClientSideOperationTimeout.create(timeoutMS),
                 notNull("filter", filter), notNull("update", update), notNull("options", options)),
                 clientSession, WriteRequest.Type.UPDATE)
                 .map(UPDATE_RESULT_MAPPER);
@@ -375,7 +376,7 @@ public final class MongoOperationPublisher<T> {
             @Nullable final ClientSession clientSession, final Bson filter, final List<? extends Bson> update,
             final UpdateOptions options) {
         return createSingleWriteRequestMono(() -> operations.updateOne(
-                getClientSideOperationTimeoutFactory(),
+                ClientSideOperationTimeout.create(timeoutMS),
                 notNull("filter", filter), notNull("update", update), notNull("options", options)),
                 clientSession, WriteRequest.Type.UPDATE)
                 .map(UPDATE_RESULT_MAPPER);
@@ -385,7 +386,7 @@ public final class MongoOperationPublisher<T> {
             @Nullable final ClientSession clientSession, final Bson filter, final Bson update,
             final UpdateOptions options) {
         return createSingleWriteRequestMono(() -> operations.updateMany(
-                getClientSideOperationTimeoutFactory(),
+                ClientSideOperationTimeout.create(timeoutMS),
                 notNull("filter", filter), notNull("update", update), notNull("options", options)),
                 clientSession, WriteRequest.Type.UPDATE)
                 .map(UPDATE_RESULT_MAPPER);
@@ -395,7 +396,7 @@ public final class MongoOperationPublisher<T> {
             @Nullable final ClientSession clientSession, final Bson filter, final List<? extends Bson> update,
             final UpdateOptions options) {
         return createSingleWriteRequestMono(() -> operations.updateMany(
-                getClientSideOperationTimeoutFactory(),
+                ClientSideOperationTimeout.create(timeoutMS),
                 notNull("filter", filter), notNull("update", update), notNull("options", options)),
                 clientSession, WriteRequest.Type.UPDATE)
                 .map(UPDATE_RESULT_MAPPER);

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -57,6 +57,7 @@ import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertManyResult;
 import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.ClientSideOperationTimeoutFactories;
 import com.mongodb.internal.bulk.WriteRequest;
 import com.mongodb.internal.client.model.AggregationLevel;
@@ -462,7 +463,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                              final List<? extends WriteModel<? extends TDocument>> requests,
                                              final BulkWriteOptions options) {
         notNull("requests", requests);
-        return executor.execute(operations.bulkWrite(ClientSideOperationTimeoutFactories.create(timeoutMS), requests, options),
+        return executor.execute(operations.bulkWrite(ClientSideOperationTimeout.create(timeoutMS), requests, options),
                 readConcern, clientSession);
     }
 
@@ -492,7 +493,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private InsertOneResult executeInsertOne(@Nullable final ClientSession clientSession, final TDocument document,
                                              final InsertOneOptions options) {
         return toInsertOneResult(executeSingleWriteRequest(clientSession,
-                operations.insertOne(ClientSideOperationTimeoutFactories.create(timeoutMS), document, options), INSERT));
+                operations.insertOne(ClientSideOperationTimeout.create(timeoutMS), document, options), INSERT));
     }
 
     @Override
@@ -520,7 +521,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private InsertManyResult executeInsertMany(@Nullable final ClientSession clientSession, final List<? extends TDocument> documents,
                                    final InsertManyOptions options) {
-        return toInsertManyResult(executor.execute(operations.insertMany(ClientSideOperationTimeoutFactories.create(timeoutMS), documents,
+        return toInsertManyResult(executor.execute(operations.insertMany(ClientSideOperationTimeout.create(timeoutMS), documents,
                                                                          options), readConcern, clientSession));
     }
 
@@ -591,7 +592,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private UpdateResult executeReplaceOne(@Nullable final ClientSession clientSession, final Bson filter, final TDocument replacement,
                                            final ReplaceOptions replaceOptions) {
         return toUpdateResult(executeSingleWriteRequest(clientSession, operations.replaceOne(
-                ClientSideOperationTimeoutFactories.create(timeoutMS), filter, replacement, replaceOptions), REPLACE));
+                ClientSideOperationTimeout.create(timeoutMS), filter, replacement, replaceOptions), REPLACE));
     }
 
     @Override
@@ -1019,8 +1020,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private DeleteResult executeDelete(@Nullable final ClientSession clientSession, final Bson filter, final DeleteOptions deleteOptions,
                                        final boolean multi) {
         com.mongodb.bulk.BulkWriteResult result = executeSingleWriteRequest(clientSession,
-                multi ? operations.deleteMany(ClientSideOperationTimeoutFactories.create(timeoutMS), filter, deleteOptions)
-                        : operations.deleteOne(ClientSideOperationTimeoutFactories.create(timeoutMS), filter, deleteOptions),
+                multi ? operations.deleteMany(ClientSideOperationTimeout.create(timeoutMS), filter, deleteOptions)
+                        : operations.deleteOne(ClientSideOperationTimeout.create(timeoutMS), filter, deleteOptions),
                 DELETE);
         if (result.wasAcknowledged()) {
             return DeleteResult.acknowledged(result.getDeletedCount());
@@ -1032,16 +1033,16 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private UpdateResult executeUpdate(@Nullable final ClientSession clientSession, final Bson filter, final Bson update,
                                        final UpdateOptions updateOptions, final boolean multi) {
         return toUpdateResult(executeSingleWriteRequest(clientSession,
-                multi ? operations.updateMany(ClientSideOperationTimeoutFactories.create(timeoutMS), filter, update, updateOptions)
-                        : operations.updateOne(ClientSideOperationTimeoutFactories.create(timeoutMS), filter, update, updateOptions),
+                multi ? operations.updateMany(ClientSideOperationTimeout.create(timeoutMS), filter, update, updateOptions)
+                        : operations.updateOne(ClientSideOperationTimeout.create(timeoutMS), filter, update, updateOptions),
                 UPDATE));
     }
 
     private UpdateResult executeUpdate(@Nullable final ClientSession clientSession, final Bson filter,
                                        final List<? extends Bson> update, final UpdateOptions updateOptions, final boolean multi) {
         return toUpdateResult(executeSingleWriteRequest(clientSession,
-                multi ? operations.updateMany(ClientSideOperationTimeoutFactories.create(timeoutMS), filter, update, updateOptions)
-                        : operations.updateOne(ClientSideOperationTimeoutFactories.create(timeoutMS), filter, update, updateOptions),
+                multi ? operations.updateMany(ClientSideOperationTimeout.create(timeoutMS), filter, update, updateOptions)
+                        : operations.updateOne(ClientSideOperationTimeout.create(timeoutMS), filter, update, updateOptions),
                 UPDATE));
     }
 


### PR DESCRIPTION
Given that most/all the places that need to create a ClientSideOperationTimeout already are aware
of timeoutMS, I'm not sure how valuable the two layers of factories are to the abstraction.

This is an attempt to show how it might be simplified.  If you agree that this is a good simplification, it would need to be expanded to the rest of the operations.  I just did it for MixedBulkWriteOperation here.
