### PR TITLE
Simplify CommandBatchCursor and AsyncCommandBatchCursor

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -45,7 +45,6 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.CommandReadTra
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
-import static com.mongodb.internal.operation.OperationHelper.createCommandCursorResult;
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryableRead;
@@ -223,21 +222,19 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
 
     private CommandReadTransformer<BsonDocument, CommandBatchCursor<T>> transformer() {
         return (result, source, connection) -> {
-            CommandCursorResult<T> commandCursorResult = createCommandCursorResult(result, connection.getDescription().getServerAddress());
             // TODO (CSOT) JAVA-4058
             long maxAwaitTimeMS = timeoutSettings.getMaxAwaitTimeMS();
-            return new CommandBatchCursor<>(commandCursorResult, 0, batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder, comment,
-                    source, connection, result);
+            return new CommandBatchCursor<>(connection.getDescription().getServerAddress(), result, 0, batchSize != null ? batchSize : 0,
+                    maxAwaitTimeMS, decoder, comment, source, connection);
         };
     }
 
     private CommandReadTransformerAsync<BsonDocument, AsyncBatchCursor<T>> asyncTransformer() {
         return (result, source, connection) -> {
-            CommandCursorResult<T> commandCursorResult = createCommandCursorResult(result, connection.getDescription().getServerAddress());
             // TODO (CSOT) JAVA-4058
             long maxAwaitTimeMS = timeoutSettings.getMaxAwaitTimeMS();
-            return new AsyncCommandBatchCursor<>(commandCursorResult, 0, batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder,
-                    comment, source, connection, result);
+            return new AsyncCommandBatchCursor<>(connection.getDescription().getServerAddress(), result, 0,
+                    batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder, comment, source, connection);
         };
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -224,8 +224,8 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
         return (result, source, connection) -> {
             // TODO (CSOT) JAVA-4058
             long maxAwaitTimeMS = timeoutSettings.getMaxAwaitTimeMS();
-            return new CommandBatchCursor<>(connection.getDescription().getServerAddress(), result, 0, batchSize != null ? batchSize : 0,
-                    maxAwaitTimeMS, decoder, comment, source, connection);
+            return new CommandBatchCursor<>(result, 0, batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder,
+                    comment, source, connection);
         };
     }
 
@@ -233,8 +233,8 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
         return (result, source, connection) -> {
             // TODO (CSOT) JAVA-4058
             long maxAwaitTimeMS = timeoutSettings.getMaxAwaitTimeMS();
-            return new AsyncCommandBatchCursor<>(connection.getDescription().getServerAddress(), result, 0,
-                    batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder, comment, source, connection);
+            return new AsyncCommandBatchCursor<>(result, 0, batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder,
+                    comment, source, connection);
         };
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateResponseBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateResponseBatchCursor.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
 
@@ -27,8 +28,10 @@ import org.bson.BsonTimestamp;
  */
 @NotThreadSafe
 public interface AggregateResponseBatchCursor<T> extends BatchCursor<T> {
+    @Nullable
     BsonDocument getPostBatchResumeToken();
 
+    @Nullable
     BsonTimestamp getOperationTime();
 
     boolean isFirstBatchEmpty();

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
@@ -96,7 +96,6 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
     private volatile boolean isClosePending = false;
 
     AsyncCommandBatchCursor(
-            final ServerAddress serverAddress,
             final BsonDocument commandCursorDocument,
             final int limit, final int batchSize, final long maxTimeMS,
             final Decoder<T> decoder,
@@ -105,7 +104,8 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
             final AsyncConnection connection) {
         isTrueArgument("maxTimeMS >= 0", maxTimeMS >= 0);
         this.cursor = new AtomicReference<>();
-        this.initialCommandCursorResult = initFromCommandCursorDocument(serverAddress, FIRST_BATCH, commandCursorDocument);
+        this.initialCommandCursorResult = initFromCommandCursorDocument(connection.getDescription().getServerAddress(),
+                FIRST_BATCH, commandCursorDocument);
         this.namespace = initialCommandCursorResult.getNamespace();
         this.limit = limit;
         this.batchSize = batchSize;

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
 import com.mongodb.ServerCursor;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerType;
@@ -55,36 +56,37 @@ import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.Locks.withLock;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.CommandBatchCursorHelper.FIRST_BATCH;
+import static com.mongodb.internal.operation.CommandBatchCursorHelper.NEXT_BATCH;
 import static com.mongodb.internal.operation.CursorHelper.getNumberToReturn;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.QueryHelper.translateCommandException;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotFour;
-import static com.mongodb.internal.operation.SyncOperationHelper.getMoreDocumentToCommandCursorResult;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
 class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
     private static final Logger LOGGER = Loggers.getLogger("operation");
     private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
-    private static final String CURSOR = "cursor";
-    private static final String POST_BATCH_RESUME_TOKEN = "postBatchResumeToken";
-    private static final String OPERATION_TIME = "operationTime";
 
     private final MongoNamespace namespace;
     private final int limit;
     private final Decoder<T> decoder;
     private final long maxTimeMS;
-    private volatile AsyncConnectionSource connectionSource;
-    private volatile AsyncConnection pinnedConnection;
-    private final AtomicReference<ServerCursor> cursor;
-    private volatile CommandCursorResult<T> firstBatch;
-    private volatile int batchSize;
-    private final AtomicInteger count = new AtomicInteger();
-    private volatile BsonDocument postBatchResumeToken;
-    private final BsonTimestamp operationTime;
+    @Nullable
     private final BsonValue comment;
+    private final BsonTimestamp operationTime;
     private final boolean firstBatchEmpty;
     private final int maxWireVersion;
+
+    private final AtomicReference<ServerCursor> cursor;
+    private final AtomicInteger count = new AtomicInteger();
+
+    private volatile AsyncConnectionSource connectionSource;
+    private volatile AsyncConnection pinnedConnection;
+    private volatile CommandCursorResult<T> initialCommandCursorResult;
+    private volatile int batchSize;
+    private volatile BsonDocument postBatchResumeToken;
 
     private final Lock lock = new ReentrantLock();
     /* protected by `lock` */
@@ -93,33 +95,27 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
     /* protected by `lock` */
     private volatile boolean isClosePending = false;
 
-    AsyncCommandBatchCursor(final CommandCursorResult<T> firstBatch, final int limit, final int batchSize, final long maxTimeMS,
-            final Decoder<T> decoder, final BsonValue comment, final AsyncConnectionSource connectionSource,
+    AsyncCommandBatchCursor(
+            final ServerAddress serverAddress,
+            final BsonDocument commandCursorDocument,
+            final int limit, final int batchSize, final long maxTimeMS,
+            final Decoder<T> decoder,
+            @Nullable final BsonValue comment,
+            final AsyncConnectionSource connectionSource,
             final AsyncConnection connection) {
-        this(firstBatch, limit, batchSize, maxTimeMS, decoder, comment, connectionSource, connection, null);
-    }
-
-    AsyncCommandBatchCursor(final CommandCursorResult<T> firstBatch, final int limit, final int batchSize, final long maxTimeMS,
-            final Decoder<T> decoder, final BsonValue comment, final AsyncConnectionSource connectionSource,
-            @Nullable final AsyncConnection connection, @Nullable final BsonDocument result) {
         isTrueArgument("maxTimeMS >= 0", maxTimeMS >= 0);
-        this.maxTimeMS = maxTimeMS;
-        this.namespace = firstBatch.getNamespace();
-        this.firstBatch = firstBatch;
+        this.cursor = new AtomicReference<>();
+        this.initialCommandCursorResult = initFromCommandCursorDocument(serverAddress, FIRST_BATCH, commandCursorDocument);
+        this.namespace = initialCommandCursorResult.getNamespace();
         this.limit = limit;
         this.batchSize = batchSize;
+        this.maxTimeMS = maxTimeMS;
         this.decoder = decoder;
         this.comment = comment;
-        this.cursor = new AtomicReference<>(firstBatch.getServerCursor());
-        this.count.addAndGet(firstBatch.getResults().size());
-        if (result != null) {
-            this.operationTime = result.getTimestamp(OPERATION_TIME, null);
-            this.postBatchResumeToken = getPostBatchResumeTokenFromResponse(result);
-        } else {
-            this.operationTime = null;
-        }
+        this.maxWireVersion = connection.getDescription().getMaxWireVersion();
+        this.firstBatchEmpty = initialCommandCursorResult.getResults().isEmpty();
 
-        firstBatchEmpty = firstBatch.getResults().isEmpty();
+        this.operationTime = initialCommandCursorResult.getOperationTime();
         if (cursor.get() != null) {
             this.connectionSource = notNull("connectionSource", connectionSource).retain();
             assertNotNull(connection);
@@ -132,8 +128,7 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
                 }
             }
         }
-        this.maxWireVersion = connection == null ? 0 : connection.getDescription().getMaxWireVersion();
-        logQueryResult(firstBatch);
+        logQueryResult(initialCommandCursorResult);
     }
 
     /**
@@ -167,10 +162,10 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
     public void next(final SingleResultCallback<List<T>> callback) {
         if (isClosed()) {
             callback.onResult(null, new MongoException("next() called after the cursor was closed."));
-        } else if (firstBatch != null && (!firstBatch.getResults().isEmpty())) {
+        } else if (initialCommandCursorResult != null && !firstBatchEmpty) {
             // May be empty for a tailable cursor
-            List<T> results = firstBatch.getResults();
-            firstBatch = null;
+            List<T> results = initialCommandCursorResult.getResults();
+            initialCommandCursorResult = null;
             if (getServerCursor() == null) {
                 close();
             }
@@ -344,7 +339,6 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
         } else if (result.getResults().isEmpty() && result.getServerCursor() != null) {
             getMore(connection, assertNotNull(result.getServerCursor()), callback);
         } else {
-            count.addAndGet(result.getResults().size());
             if (limitReached()) {
                 killCursor(connection);
                 connection.release();
@@ -362,6 +356,21 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
                 callback.onResult(result.getResults(), null);
             }
         }
+    }
+
+    private CommandCursorResult<T> initFromCommandCursorDocument(
+            final ServerAddress serverAddress,
+            final String fieldNameContainingBatch,
+            final BsonDocument commandCursorDocument) {
+        CommandCursorResult<T> cursorResult = new CommandCursorResult<>(serverAddress, fieldNameContainingBatch, commandCursorDocument);
+        cursor.set(cursorResult.getServerCursor());
+        count.addAndGet(cursorResult.getResults().size());
+        postBatchResumeToken = cursorResult.getPostBatchResumeToken();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(format("Received batch of %d documents with cursorId %d from server %s", cursorResult.getResults().size(),
+                    cursorResult.getCursorId(), cursorResult.getServerAddress()));
+        }
+        return cursorResult;
     }
 
     private void logQueryResult(final CommandCursorResult<T> result) {
@@ -392,10 +401,8 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
                 callback.onResult(null, translatedException);
             } else {
                 assertNotNull(result);
-                CommandCursorResult<T> commandCursorResult = getMoreDocumentToCommandCursorResult(result,
-                        connection.getDescription().getServerAddress());
-                postBatchResumeToken = getPostBatchResumeTokenFromResponse(result);
-                handleGetMoreQueryResult(connection, callback, commandCursorResult);
+                handleGetMoreQueryResult(connection, callback,
+                        initFromCommandCursorDocument(connection.getDescription().getServerAddress(), NEXT_BATCH, result));
             }
         }
     }
@@ -403,14 +410,5 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
     @Nullable
     ServerCursor getServerCursor() {
         return cursor.get();
-    }
-
-    @Nullable
-    private BsonDocument getPostBatchResumeTokenFromResponse(final BsonDocument result) {
-        BsonDocument cursor = result.getDocument(CURSOR, null);
-        if (cursor != null) {
-            return cursor.getDocument(POST_BATCH_RESUME_TOKEN, null);
-        }
-        return null;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -335,7 +335,7 @@ final class AsyncOperationHelper {
 
     static <T> AsyncBatchCursor<T> cursorDocumentToAsyncBatchCursor(final BsonDocument cursorDocument, final Decoder<T> decoder,
             final BsonValue comment, final AsyncConnectionSource source, final AsyncConnection connection, final int batchSize) {
-        return new AsyncCommandBatchCursor<>(source.getServerDescription().getAddress(), cursorDocument, 0, batchSize, 0, decoder,
+        return new AsyncCommandBatchCursor<>(cursorDocument, 0, batchSize, 0, decoder,
                 comment, source, connection);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -53,7 +53,6 @@ import static com.mongodb.internal.operation.CommandOperationHelper.initialRetry
 import static com.mongodb.internal.operation.CommandOperationHelper.isRetryWritesEnabled;
 import static com.mongodb.internal.operation.CommandOperationHelper.logRetryExecute;
 import static com.mongodb.internal.operation.CommandOperationHelper.transformWriteException;
-import static com.mongodb.internal.operation.OperationHelper.createCommandCursorResult;
 import static com.mongodb.internal.operation.WriteConcernHelper.throwOnWriteConcernError;
 
 final class AsyncOperationHelper {
@@ -336,9 +335,8 @@ final class AsyncOperationHelper {
 
     static <T> AsyncBatchCursor<T> cursorDocumentToAsyncBatchCursor(final BsonDocument cursorDocument, final Decoder<T> decoder,
             final BsonValue comment, final AsyncConnectionSource source, final AsyncConnection connection, final int batchSize) {
-        return new AsyncCommandBatchCursor<>(createCommandCursorResult(cursorDocument,
-                source.getServerDescription().getAddress()),
-                0, batchSize, 0, decoder, comment, source, connection, cursorDocument);
+        return new AsyncCommandBatchCursor<>(source.getServerDescription().getAddress(), cursorDocument, 0, batchSize, 0, decoder,
+                comment, source, connection);
     }
 
     static <T> SingleResultCallback<T> releasingCallback(final SingleResultCallback<T> wrapped, final AsyncConnection connection) {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
@@ -83,14 +83,14 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
     private final ResourceManager resourceManager;
 
     CommandBatchCursor(
-            final ServerAddress serverAddress,
             final BsonDocument commandCursorDocument,
             final int limit, final int batchSize, final long maxTimeMS,
             final Decoder<T> decoder,
             @Nullable final BsonValue comment,
             final ConnectionSource connectionSource,
             final Connection connection) {
-        this.commandCursorResult = initFromCommandCursorDocument(serverAddress, FIRST_BATCH, commandCursorDocument);
+        this.commandCursorResult = initFromCommandCursorDocument(connection.getDescription().getServerAddress(),
+                FIRST_BATCH, commandCursorDocument);
         this.namespace = commandCursorResult.getNamespace();
         this.limit = limit;
         this.batchSize = batchSize;

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
@@ -24,7 +24,6 @@ import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerCursor;
 import com.mongodb.annotations.ThreadSafe;
-import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerType;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.connection.Connection;
@@ -34,7 +33,6 @@ import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonTimestamp;
@@ -45,7 +43,6 @@ import org.bson.codecs.Decoder;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
@@ -55,92 +52,65 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.assertNull;
 import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.fail;
-import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.Locks.withLock;
-import static com.mongodb.internal.operation.CursorHelper.getNumberToReturn;
-import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
+import static com.mongodb.internal.operation.CommandBatchCursorHelper.FIRST_BATCH;
+import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_CURSOR;
+import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_ITERATOR;
+import static com.mongodb.internal.operation.CommandBatchCursorHelper.NEXT_BATCH;
+import static com.mongodb.internal.operation.CommandBatchCursorHelper.getMoreCommandDocument;
 import static com.mongodb.internal.operation.QueryHelper.translateCommandException;
-import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotFour;
-import static com.mongodb.internal.operation.SyncOperationHelper.getMoreDocumentToCommandCursorResult;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
 class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
     private static final Logger LOGGER = Loggers.getLogger("operation");
     private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
-    private static final String CURSOR = "cursor";
-    private static final String POST_BATCH_RESUME_TOKEN = "postBatchResumeToken";
-    private static final String OPERATION_TIME = "operationTime";
-    private static final String MESSAGE_IF_CLOSED_AS_CURSOR = "Cursor has been closed";
-    private static final String MESSAGE_IF_CLOSED_AS_ITERATOR = "Iterator has been closed";
 
     private final MongoNamespace namespace;
-    private final ServerAddress serverAddress;
     private final int limit;
     private final Decoder<T> decoder;
     private final long maxTimeMS;
     private int batchSize;
+    @Nullable
     private final BsonValue comment;
+    private CommandCursorResult<T> commandCursorResult;
+    @Nullable
     private List<T> nextBatch;
     private int count;
-    private BsonDocument postBatchResumeToken;
-    private BsonTimestamp operationTime;
     private final boolean firstBatchEmpty;
-    private int maxWireVersion = 0;
+    private final int maxWireVersion;
     private final ResourceManager resourceManager;
 
-    CommandBatchCursor(final CommandCursorResult<T> firstCommandCursorResult, final int limit, final int batchSize, final Decoder<T> decoder) {
-        this(firstCommandCursorResult, limit, batchSize, decoder, null, null);
-    }
-
-    CommandBatchCursor(final CommandCursorResult<T> firstCommandCursorResult, final int limit, final int batchSize, final Decoder<T> decoder,
-            @Nullable final BsonValue comment, @Nullable final ConnectionSource connectionSource) {
-        this(firstCommandCursorResult, limit, batchSize, 0, decoder, comment, connectionSource, null, null);
-    }
-
-    CommandBatchCursor(final CommandCursorResult<T> firstCommandCursorResult, final int limit, final int batchSize, final long maxTimeMS,
-            final Decoder<T> decoder, @Nullable final BsonValue comment, @Nullable final ConnectionSource connectionSource,
-            @Nullable final Connection connection) {
-        this(firstCommandCursorResult, limit, batchSize, maxTimeMS, decoder, comment, connectionSource, connection, null);
-    }
-
-    CommandBatchCursor(final CommandCursorResult<T> firstCommandCursorResult, final int limit, final int batchSize, final long maxTimeMS,
-            final Decoder<T> decoder, @Nullable final BsonValue comment, @Nullable final ConnectionSource connectionSource,
-            @Nullable final Connection connection, @Nullable final BsonDocument result) {
-        isTrueArgument("maxTimeMS >= 0", maxTimeMS >= 0);
-        this.maxTimeMS = maxTimeMS;
-        this.namespace = firstCommandCursorResult.getNamespace();
-        this.serverAddress = firstCommandCursorResult.getServerAddress();
+    CommandBatchCursor(
+            final ServerAddress serverAddress,
+            final BsonDocument commandCursorDocument,
+            final int limit, final int batchSize, final long maxTimeMS,
+            final Decoder<T> decoder,
+            @Nullable final BsonValue comment,
+            final ConnectionSource connectionSource,
+            final Connection connection) {
+        this.commandCursorResult = initFromCommandCursorDocument(serverAddress, FIRST_BATCH, commandCursorDocument);
+        this.namespace = commandCursorResult.getNamespace();
         this.limit = limit;
-        this.comment = comment;
         this.batchSize = batchSize;
+        this.maxTimeMS = maxTimeMS;
         this.decoder = notNull("decoder", decoder);
-        if (result != null) {
-            this.operationTime = result.getTimestamp(OPERATION_TIME, null);
-            this.postBatchResumeToken = getPostBatchResumeTokenFromResponse(result);
-        }
-        ServerCursor serverCursor = initCommandCursorResult(firstCommandCursorResult);
-        if (serverCursor != null) {
-            notNull("connectionSource", connectionSource);
-        }
-        firstBatchEmpty = firstCommandCursorResult.getResults().isEmpty();
+        this.comment = comment;
+        this.maxWireVersion = connection.getDescription().getMaxWireVersion();
+        this.firstBatchEmpty = commandCursorResult.getResults().isEmpty();
+
         Connection connectionToPin = null;
         boolean releaseServerAndResources = false;
-        if (connection != null) {
-            this.maxWireVersion = connection.getDescription().getMaxWireVersion();
-            if (limitReached()) {
-                releaseServerAndResources = true;
-            } else {
-                assertNotNull(connectionSource);
-                if (connectionSource.getServerDescription().getType() == ServerType.LOAD_BALANCER) {
-                    connectionToPin = connection;
-                }
-            }
+        if (limitReached()) {
+            releaseServerAndResources = true;
+        } else if (connectionSource.getServerDescription().getType() == ServerType.LOAD_BALANCER) {
+            connectionToPin = connection;
         }
-        resourceManager = new ResourceManager(connectionSource, connectionToPin, serverCursor);
+
+        resourceManager = new ResourceManager(connectionSource, connectionToPin, commandCursorResult.getServerCursor());
         if (releaseServerAndResources) {
-            resourceManager.releaseServerAndClientResources(assertNotNull(connection));
+            resourceManager.releaseServerAndClientResources(connection);
         }
     }
 
@@ -181,6 +151,7 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
         return !resourceManager.operable() || nextBatch == null ? 0 : nextBatch.size();
     }
 
+    @Nullable
     private List<T> doNext() {
         if (!doHasNext()) {
             throw new NoSuchElementException();
@@ -254,17 +225,17 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
             throw new IllegalStateException(MESSAGE_IF_CLOSED_AS_ITERATOR);
         }
 
-        return serverAddress;
+        return commandCursorResult.getServerAddress();
     }
 
     @Override
     public BsonDocument getPostBatchResumeToken() {
-        return postBatchResumeToken;
+        return commandCursorResult.getPostBatchResumeToken();
     }
 
     @Override
     public BsonTimestamp getOperationTime() {
-        return operationTime;
+        return commandCursorResult.getOperationTime();
     }
 
     @Override
@@ -282,12 +253,16 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
         resourceManager.executeWithConnection(connection -> {
             ServerCursor nextServerCursor;
             try {
-                nextServerCursor = initFromCommandResult(Objects.requireNonNull(connection.command(namespace.getDatabaseName(),
-                        asGetMoreCommandDocument(serverCursor.getId(), connection.getDescription()),
-                        NO_OP_FIELD_NAME_VALIDATOR,
-                        ReadPreference.primary(),
-                        CommandResultDocumentCodec.create(decoder, "nextBatch"),
-                        assertNotNull(resourceManager.connectionSource).getOperationContext())));
+                initFromCommandCursorDocument(connection.getDescription().getServerAddress(), NEXT_BATCH,
+                        assertNotNull(
+                                connection.command(namespace.getDatabaseName(),
+                                        getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace,
+                                                limit, batchSize, count, maxTimeMS, comment),
+                                        NO_OP_FIELD_NAME_VALIDATOR,
+                                        ReadPreference.primary(),
+                                        CommandResultDocumentCodec.create(decoder, NEXT_BATCH),
+                                        assertNotNull(resourceManager.connectionSource).getOperationContext())));
+                nextServerCursor = commandCursorResult.getServerCursor();
             } catch (MongoCommandException e) {
                 throw translateCommandException(e, serverCursor);
             }
@@ -298,51 +273,20 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
         });
     }
 
-    private BsonDocument asGetMoreCommandDocument(final long cursorId, final ConnectionDescription connectionDescription) {
-        BsonDocument document = new BsonDocument("getMore", new BsonInt64(cursorId))
-                                .append("collection", new BsonString(namespace.getCollectionName()));
-
-        int batchSizeForGetMoreCommand = Math.abs(getNumberToReturn(limit, this.batchSize, count));
-        if (batchSizeForGetMoreCommand != 0) {
-            document.append("batchSize", new BsonInt32(batchSizeForGetMoreCommand));
+    private CommandCursorResult<T> initFromCommandCursorDocument(final ServerAddress serverAddress, final String fieldNameContainingBatch,
+            final BsonDocument commandCursorDocument) {
+        this.commandCursorResult = new CommandCursorResult<>(serverAddress, fieldNameContainingBatch, commandCursorDocument);
+        this.nextBatch = commandCursorResult.getResults().isEmpty() ? null : commandCursorResult.getResults();
+        this.count += commandCursorResult.getResults().size();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(format("Received batch of %d documents with cursorId %d from server %s", commandCursorResult.getResults().size(),
+                    commandCursorResult.getCursorId(), commandCursorResult.getServerAddress()));
         }
-        if (maxTimeMS != 0) {
-            document.append("maxTimeMS", new BsonInt64(maxTimeMS));
-        }
-        if (serverIsAtLeastVersionFourDotFour(connectionDescription)) {
-            putIfNotNull(document, "comment", comment);
-        }
-        return document;
-    }
-
-    @Nullable
-    private ServerCursor initCommandCursorResult(final CommandCursorResult<T> commandCursorResult) {
-        nextBatch = commandCursorResult.getResults().isEmpty() ? null : commandCursorResult.getResults();
-        count += commandCursorResult.getResults().size();
-        LOGGER.debug(format("Received batch of %d documents with cursorId %d from server %s", commandCursorResult.getResults().size(),
-                commandCursorResult.getCursorId(), commandCursorResult.getServerAddress()));
-        return commandCursorResult.getServerCursor();
-    }
-
-    @Nullable
-    private ServerCursor initFromCommandResult(final BsonDocument getMoreCommandResultDocument) {
-        CommandCursorResult<T> commandCursorResult = getMoreDocumentToCommandCursorResult(getMoreCommandResultDocument, serverAddress);
-        postBatchResumeToken = getPostBatchResumeTokenFromResponse(getMoreCommandResultDocument);
-        operationTime = getMoreCommandResultDocument.getTimestamp(OPERATION_TIME, null);
-        return initCommandCursorResult(commandCursorResult);
+        return commandCursorResult;
     }
 
     private boolean limitReached() {
         return Math.abs(limit) != 0 && count >= Math.abs(limit);
-    }
-
-    @Nullable
-    private BsonDocument getPostBatchResumeTokenFromResponse(final BsonDocument result) {
-        BsonDocument cursor = result.getDocument(CURSOR, null);
-        if (cursor != null) {
-            return cursor.getDocument(POST_BATCH_RESUME_TOKEN, null);
-        }
-        return null;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursorHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursorHelper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoCursorNotFoundException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.MongoQueryException;
+import com.mongodb.ServerCursor;
+import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.validator.NoOpFieldNameValidator;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.FieldNameValidator;
+
+import static com.mongodb.internal.operation.CursorHelper.getNumberToReturn;
+import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotFour;
+
+final class CommandBatchCursorHelper {
+
+    static final String FIRST_BATCH = "firstBatch";
+    static final String NEXT_BATCH = "nextBatch";
+    static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
+    static final String MESSAGE_IF_CLOSED_AS_CURSOR = "Cursor has been closed";
+    static final String MESSAGE_IF_CLOSED_AS_ITERATOR = "Iterator has been closed";
+
+    static final String MESSAGE_IF_CONCURRENT_OPERATION = "Another operation is currently in progress, concurrent operations are not "
+            + "supported";
+
+    static BsonDocument getMoreCommandDocument(
+            final long cursorId, final ConnectionDescription connectionDescription, final MongoNamespace namespace, final int limit,
+            final int batchSize, final int count, final long maxTimeMS, @Nullable final BsonValue comment) {
+        BsonDocument document = new BsonDocument("getMore", new BsonInt64(cursorId))
+                .append("collection", new BsonString(namespace.getCollectionName()));
+
+        int batchSizeForGetMoreCommand = Math.abs(getNumberToReturn(limit, batchSize, count));
+        if (batchSizeForGetMoreCommand != 0) {
+            document.append("batchSize", new BsonInt32(batchSizeForGetMoreCommand));
+        }
+        if (maxTimeMS != 0) {
+            document.append("maxTimeMS", new BsonInt64(maxTimeMS));
+        }
+        if (serverIsAtLeastVersionFourDotFour(connectionDescription)) {
+            putIfNotNull(document, "comment", comment);
+        }
+        return document;
+    }
+
+    static MongoQueryException translateCommandException(final MongoCommandException commandException, final ServerCursor cursor) {
+        if (commandException.getErrorCode() == 43) {
+            return new MongoCursorNotFoundException(cursor.getId(), commandException.getResponse(), cursor.getAddress());
+        } else {
+            return new MongoQueryException(commandException.getResponse(), commandException.getServerAddress());
+        }
+    }
+
+    private CommandBatchCursorHelper() {
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -456,8 +456,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
 
     private CommandReadTransformer<BsonDocument, CommandBatchCursor<T>> transformer() {
         return (result, source, connection) ->
-                new CommandBatchCursor<>(connection.getDescription().getServerAddress(), result, limit, batchSize, getMaxTimeForCursor(),
-                    decoder, comment, source, connection);
+                new CommandBatchCursor<>(result, limit, batchSize, getMaxTimeForCursor(), decoder, comment, source, connection);
     }
 
     // TODO - CSOT JAVA-4058
@@ -467,7 +466,6 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
 
     private CommandReadTransformerAsync<BsonDocument, AsyncBatchCursor<T>> asyncTransformer() {
         return (result, source, connection) ->
-            new AsyncCommandBatchCursor<>(connection.getDescription().getServerAddress(), result, limit, batchSize, getMaxTimeForCursor(),
-                    decoder, comment, source, connection);
+            new AsyncCommandBatchCursor<>(result, limit, batchSize, getMaxTimeForCursor(), decoder, comment, source, connection);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -54,7 +54,6 @@ import static com.mongodb.internal.operation.DocumentHelper.putIfNotNullOrEmpty;
 import static com.mongodb.internal.operation.ExplainHelper.asExplainCommand;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
-import static com.mongodb.internal.operation.OperationHelper.createCommandCursorResult;
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSION;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
@@ -456,11 +455,9 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     }
 
     private CommandReadTransformer<BsonDocument, CommandBatchCursor<T>> transformer() {
-        return (result, source, connection) -> {
-            CommandCursorResult<T> commandCursorResult = createCommandCursorResult(result, connection.getDescription().getServerAddress());
-            return new CommandBatchCursor<>(commandCursorResult, limit, batchSize, getMaxTimeForCursor(), decoder, comment, source,
-                    connection, result);
-        };
+        return (result, source, connection) ->
+                new CommandBatchCursor<>(connection.getDescription().getServerAddress(), result, limit, batchSize, getMaxTimeForCursor(),
+                    decoder, comment, source, connection);
     }
 
     // TODO - CSOT JAVA-4058
@@ -469,10 +466,8 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     }
 
     private CommandReadTransformerAsync<BsonDocument, AsyncBatchCursor<T>> asyncTransformer() {
-        return (result, source, connection) -> {
-            CommandCursorResult<T> commandCursorResult = createCommandCursorResult(result, connection.getDescription().getServerAddress());
-            return new AsyncCommandBatchCursor<>(commandCursorResult, limit, batchSize, getMaxTimeForCursor(), decoder, comment, source,
-                    connection, result);
-        };
+        return (result, source, connection) ->
+            new AsyncCommandBatchCursor<>(connection.getDescription().getServerAddress(), result, limit, batchSize, getMaxTimeForCursor(),
+                    decoder, comment, source, connection);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoClientException;
-import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
@@ -194,15 +193,6 @@ final class OperationHelper {
             return false;
         }
         return true;
-    }
-
-    static <T> CommandCursorResult<T> createCommandCursorResult(final BsonDocument cursorDocument, final ServerAddress serverAddress) {
-        return createCommandCursorResult(cursorDocument, serverAddress, "firstBatch");
-    }
-
-    static <T> CommandCursorResult<T> createCommandCursorResult(final BsonDocument cursorDocument, final ServerAddress serverAddress,
-            final String fieldNameContainingBatch) {
-        return new CommandCursorResult<>(serverAddress, fieldNameContainingBatch, cursorDocument);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -331,8 +331,7 @@ final class SyncOperationHelper {
 
     static <T> BatchCursor<T> cursorDocumentToBatchCursor(final BsonDocument cursorDocument, final Decoder<T> decoder,
             final BsonValue comment, final ConnectionSource source, final Connection connection, final int batchSize) {
-        return new CommandBatchCursor<>(connection.getDescription().getServerAddress(), cursorDocument,
-                0, batchSize, 0, decoder, comment, source, connection);
+        return new CommandBatchCursor<>(cursorDocument, 0, batchSize, 0, decoder, comment, source, connection);
     }
 
     private SyncOperationHelper() {

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
-import com.mongodb.ServerAddress;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackBiFunction;
@@ -56,7 +55,6 @@ import static com.mongodb.internal.operation.CommandOperationHelper.logRetryExec
 import static com.mongodb.internal.operation.OperationHelper.ResourceSupplierInternalException;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
 import static com.mongodb.internal.operation.OperationHelper.canRetryWrite;
-import static com.mongodb.internal.operation.OperationHelper.createCommandCursorResult;
 import static com.mongodb.internal.operation.WriteConcernHelper.throwOnWriteConcernError;
 
 final class SyncOperationHelper {
@@ -333,13 +331,8 @@ final class SyncOperationHelper {
 
     static <T> BatchCursor<T> cursorDocumentToBatchCursor(final BsonDocument cursorDocument, final Decoder<T> decoder,
             final BsonValue comment, final ConnectionSource source, final Connection connection, final int batchSize) {
-        return new CommandBatchCursor<>(createCommandCursorResult(cursorDocument, source.getServerDescription().getAddress()),
+        return new CommandBatchCursor<>(connection.getDescription().getServerAddress(), cursorDocument,
                 0, batchSize, 0, decoder, comment, source, connection);
-    }
-
-    static <T> CommandCursorResult<T> getMoreDocumentToCommandCursorResult(final BsonDocument cursorDocument,
-            final ServerAddress serverAddress) {
-        return OperationHelper.createCommandCursorResult(cursorDocument, serverAddress, "nextBatch");
     }
 
     private SyncOperationHelper() {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalSpecification.groovy
@@ -20,7 +20,6 @@ import com.mongodb.MongoCursorNotFoundException
 import com.mongodb.MongoTimeoutException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadPreference
-import com.mongodb.ServerAddress
 import com.mongodb.ServerCursor
 import com.mongodb.WriteConcern
 import com.mongodb.client.model.CreateCollectionOptions
@@ -80,10 +79,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'server cursor should not be null'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(2)
+        def commandCursorResult = executeFindCommand(2)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 0, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -92,10 +91,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'test server address'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand()
+        def commandCursorResult = executeFindCommand()
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 0, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
         then:
         cursor.getServerAddress() != null
@@ -103,9 +102,9 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'should get Exceptions for operations on the cursor after closing'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand()
+        def commandCursorResult = executeFindCommand()
 
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 0, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -133,9 +132,9 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'should throw an Exception when going off the end'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(1)
+        def commandCursorResult = executeFindCommand(1)
 
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 2, 0, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 2, 0, 0, CODEC,
                 null, connectionSource, connection)
         when:
         cursor.next()
@@ -148,10 +147,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'test normal exhaustion'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand()
+        def commandCursorResult = executeFindCommand()
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 0, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -160,11 +159,11 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'test limit exhaustion'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(limit, batchSize)
+        def commandCursorResult = executeFindCommand(limit, batchSize)
         def connection = connectionSource.getConnection()
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, limit, batchSize, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, limit, batchSize, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -187,9 +186,9 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'test remove'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand()
+        def commandCursorResult = executeFindCommand()
 
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 0, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -206,11 +205,11 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
         def connection = connectionSource.getConnection()
         collectionHelper.create(collectionName, new CreateCollectionOptions().capped(true).sizeInBytes(1000))
         collectionHelper.insertDocuments(CODEC, new Document('_id', 1).append('ts', new BsonTimestamp(5, 0)))
-        def (serverAddress, commandCursorResult) = executeFindCommand(
+        def commandCursorResult = executeFindCommand(
                 new BsonDocument('ts', new BsonDocument('$gte', new BsonTimestamp(5, 0))), 0, 2, true, awaitData)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, maxTimeMS, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, maxTimeMS, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -254,12 +253,12 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
     def 'test try next with tailable'() {
         collectionHelper.create(collectionName, new CreateCollectionOptions().capped(true).sizeInBytes(1000))
         collectionHelper.insertDocuments(CODEC, new Document('_id', 1).append('ts', new BsonTimestamp(5, 0)))
-        def (serverAddress, commandCursorResult) = executeFindCommand(
+        def commandCursorResult = executeFindCommand(
                 new BsonDocument('ts', new BsonDocument('$gte', new BsonTimestamp(5, 0))), 0, 2, true, true)
 
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -282,9 +281,9 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
         Connection conn = connectionSource.getConnection()
         collectionHelper.create(collectionName, new CreateCollectionOptions().capped(true).sizeInBytes(1000))
         collectionHelper.insertDocuments(CODEC, new Document('_id', 1).append('ts', new BsonTimestamp(5, 0)))
-        def (serverAddress, commandCursorResult) = executeFindCommand(
+        def commandCursorResult = executeFindCommand(
                 new BsonDocument('ts', new BsonDocument('$gte', new BsonTimestamp(5, 0))), 0, 2, true, true)
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, 0, CODEC,
                 null, connectionSource, conn)
         cursor.next()
         def closeCompleted = new CountDownLatch(1)
@@ -313,12 +312,12 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
     def 'test maxTimeMS'() {
         collectionHelper.create(collectionName, new CreateCollectionOptions().capped(true).sizeInBytes(1000))
         collectionHelper.insertDocuments(CODEC, new Document('_id', 1).append('ts', new BsonTimestamp(5, 0)))
-        def (serverAddress, commandCursorResult) = executeFindCommand(
+        def commandCursorResult = executeFindCommand(
                 new BsonDocument('ts', new BsonDocument('$gte', new BsonTimestamp(5, 0))), 0, 2, true, true)
 
         def connection = connectionSource.getConnection()
         def maxTimeMS = 10
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, maxTimeMS, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, maxTimeMS, CODEC,
                 null, connectionSource, connection)
         cursor.tryNext()
         long startTime = System.currentTimeMillis()
@@ -341,10 +340,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
         collectionHelper.create(collectionName, new CreateCollectionOptions().capped(true).sizeInBytes(1000))
         collectionHelper.insertDocuments(CODEC, new Document('_id', 1))
 
-        def (serverAddress, commandCursorResult) = executeFindCommand(new BsonDocument(), 0, 2, true, true)
+        def commandCursorResult = executeFindCommand(new BsonDocument(), 0, 2, true, true)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, 0, CODEC,
                 null, connectionSource, connection)
 
         CountDownLatch latch = new CountDownLatch(1)
@@ -373,8 +372,8 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
     @IgnoreIf({ isSharded() })
     def 'should kill cursor if limit is reached on initial query'() throws InterruptedException {
         given:
-        def (serverAddress, commandResult) = executeFindCommand(5)
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandResult, 5, 0, 0, new DocumentCodec(),
+        def commandResult = executeFindCommand(5)
+        cursor = new CommandBatchCursor<Document>(commandResult, 5, 0, 0, new DocumentCodec(),
                 null, connectionSource, connection)
 
         when:
@@ -389,9 +388,9 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
     @Slow
     def 'should kill cursor if limit is reached on get more'() throws InterruptedException {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(3)
+        def commandCursorResult = executeFindCommand(3)
 
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 5, 3,  0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 5, 3,  0, CODEC,
                 null, connectionSource, connection)
         ServerCursor serverCursor = cursor.getServerCursor()
 
@@ -408,11 +407,11 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'should release connection source if limit is reached on initial query'() throws InterruptedException {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(5)
+        def commandCursorResult = executeFindCommand(5)
         def connection = connectionSource.getConnection()
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 5, 0, 0, CODEC, null, connectionSource, connection)
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 5, 0, 0, CODEC, null, connectionSource, connection)
 
         then:
         checkReferenceCountReachesTarget(connectionSource, 1)
@@ -423,9 +422,9 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'should release connection source if limit is reached on get more'() throws InterruptedException {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(3)
+        def commandCursorResult = executeFindCommand(3)
 
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 5, 3, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 5, 3, 0, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -438,10 +437,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'test limit with get more'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(2)
+        def commandCursorResult = executeFindCommand(2)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 5, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 5, 2, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -458,10 +457,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
         String bigString = new String(array)
 
         (11..1000).each { collectionHelper.insertDocuments(CODEC, new Document('_id', it).append('s', bigString)) }
-        def (serverAddress, commandCursorResult) = executeFindCommand(300, 0)
+        def commandCursorResult = executeFindCommand(300, 0)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 300, 0, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 300, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -470,10 +469,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'should respect batch size'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(2)
+        def commandCursorResult = executeFindCommand(2)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -508,10 +507,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'test normal loop with get more'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(2)
+        def commandCursorResult = executeFindCommand(2)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, 0, CODEC,
                 null, connectionSource, connection)
         def results = cursor.iterator().collectMany { it*.get('_id') }
 
@@ -522,10 +521,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'test next without has next with get more'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(2)
+        def commandCursorResult = executeFindCommand(2)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -544,10 +543,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
     @IgnoreIf({ isSharded() })
     def 'should throw cursor not found exception'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(2)
+        def commandCursorResult = executeFindCommand(2)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, 0, CODEC,
                 null, connectionSource, connection)
         def serverCursor = cursor.getServerCursor()
         def connection = connectionSource.getConnection()
@@ -571,10 +570,10 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
 
     def 'should report available documents'() {
         given:
-        def (serverAddress, commandCursorResult) = executeFindCommand(3)
+        def commandCursorResult = executeFindCommand(3)
 
         when:
-        cursor = new CommandBatchCursor<Document>(serverAddress, commandCursorResult, 0, 2, 0, CODEC,
+        cursor = new CommandBatchCursor<Document>(commandCursorResult, 0, 2, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -617,28 +616,28 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
         cursor.available() == 0
     }
 
-     private Tuple2<ServerAddress, BsonDocument> executeFindCommand() {
+     private BsonDocument executeFindCommand() {
         executeFindCommand(0)
     }
 
-     private Tuple2<ServerAddress, BsonDocument> executeFindCommand(int batchSize) {
+     private BsonDocument executeFindCommand(int batchSize) {
         executeFindCommand(batchSize, ReadPreference.primary())
     }
 
-     private Tuple2<ServerAddress, BsonDocument> executeFindCommand(int batchSize, ReadPreference readPreference) {
+     private BsonDocument executeFindCommand(int batchSize, ReadPreference readPreference) {
         executeFindCommand(new BsonDocument(), 0, batchSize, false, false, readPreference)
     }
 
-     private Tuple2<ServerAddress, BsonDocument> executeFindCommand(int limit, int batchSize) {
+     private BsonDocument executeFindCommand(int limit, int batchSize) {
         executeFindCommand(new BsonDocument(), limit, batchSize, false, false, ReadPreference.primary())
     }
 
-     private Tuple2<ServerAddress, BsonDocument> executeFindCommand(BsonDocument filter, int limit, int batchSize, boolean tailable,
+     private BsonDocument executeFindCommand(BsonDocument filter, int limit, int batchSize, boolean tailable,
             boolean awaitData) {
         executeFindCommand(filter, limit, batchSize, tailable, awaitData, ReadPreference.primary())
     }
 
-     private Tuple2<ServerAddress, BsonDocument> executeFindCommand(BsonDocument filter, int limit, int batchSize, boolean tailable,
+     private BsonDocument executeFindCommand(BsonDocument filter, int limit, int batchSize, boolean tailable,
             boolean awaitData, ReadPreference readPreference) {
         def connection = connectionSource.getConnection()
         try {
@@ -657,9 +656,9 @@ class CommandBatchCursorFunctionalSpecification extends OperationFunctionalSpeci
                 }
             }
 
-            new Tuple2(connection.getDescription().getServerAddress(), connection.command(getDatabaseName(), findCommand,
+            connection.command(getDatabaseName(), findCommand,
                     NO_OP_FIELD_NAME_VALIDATOR, readPreference, CommandResultDocumentCodec.create(CODEC, FIRST_BATCH),
-                    connectionSource.getOperationContext()))
+                    connectionSource.getOperationContext())
         } finally {
             connection.release()
         }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncCommandBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncCommandBatchCursorSpecification.groovy
@@ -50,7 +50,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connection = referenceCountedAsyncConnection()
         def connectionSource = getAsyncConnectionSource(connection)
 
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, createCommandResult([], 42), 0, batchSize, maxTimeMS, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(createCommandResult([], 42), 0, batchSize, maxTimeMS, CODEC,
                 null, connectionSource, connection)
         def expectedCommand = new BsonDocument('getMore': new BsonInt64(CURSOR_ID))
                 .append('collection', new BsonString(NAMESPACE.getCollectionName()))
@@ -94,7 +94,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def serverVersion = new ServerVersion([3, 6, 0])
         def connection = referenceCountedAsyncConnection(serverVersion)
         def connectionSource = getAsyncConnectionSource(connection)
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -121,7 +121,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connectionSource = getAsyncConnectionSource(connection)
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, createCommandResult(FIRST_BATCH, 0), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(createCommandResult(FIRST_BATCH, 0), 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -153,7 +153,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def thirdBatch = [new Document('_id', 7)]
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, createCommandResult(firstBatch, 42), 7, 3, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(createCommandResult(firstBatch, 42), 7, 3, 0, CODEC,
                 null, connectionSource, connectionA)
         def batch = nextBatch(cursor)
 
@@ -203,7 +203,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 1, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 1, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -228,7 +228,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult([], CURSOR_ID)
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 3, 0, 0, CODEC, null, connectionSource, connection)
+        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 3, 0, 0, CODEC, null, connectionSource, connection)
         def batch = nextBatch(cursor)
 
         then:
@@ -270,7 +270,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 3, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 3, 0, 0, CODEC,
                 null, connectionSource, connection)
         def batch = nextBatch(cursor)
 
@@ -313,7 +313,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connectionSource = getAsyncConnectionSource(serverType, connectionA, connectionB)
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, createCommandResult(FIRST_BATCH, 42), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(createCommandResult(FIRST_BATCH, 42), 0, 0, 0, CODEC,
                 null, connectionSource, connectionA)
         def batch = nextBatch(cursor)
 
@@ -357,7 +357,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connectionA)
         def batch = nextBatch(cursor)
 
@@ -395,7 +395,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connection = referenceCountedAsyncConnection()
         def connectionSource = getAsyncConnectionSourceWithResult(ServerType.STANDALONE) { [null, MONGO_EXCEPTION] }
         def firstBatch = createCommandResult()
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -414,7 +414,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult()
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -440,7 +440,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult()
-        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connectionA)
 
         then:
@@ -526,6 +526,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def mock = Mock(AsyncConnection, name: name) {
             _ * getDescription() >> Stub(ConnectionDescription) {
                 getMaxWireVersion() >> getMaxWireVersionForServerVersion(serverVersion.getVersionList())
+                getServerAddress() >> SERVER_ADDRESS
             }
         }
         mock.retain() >> {

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncCommandBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncCommandBatchCursorSpecification.groovy
@@ -50,7 +50,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connection = referenceCountedAsyncConnection()
         def connectionSource = getAsyncConnectionSource(connection)
 
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult([], 42), 0, batchSize, maxTimeMS, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, createCommandResult([], 42), 0, batchSize, maxTimeMS, CODEC,
                 null, connectionSource, connection)
         def expectedCommand = new BsonDocument('getMore': new BsonInt64(CURSOR_ID))
                 .append('collection', new BsonString(NAMESPACE.getCollectionName()))
@@ -94,7 +94,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def serverVersion = new ServerVersion([3, 6, 0])
         def connection = referenceCountedAsyncConnection(serverVersion)
         def connectionSource = getAsyncConnectionSource(connection)
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -121,8 +121,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connectionSource = getAsyncConnectionSource(connection)
 
         when:
-        def firstBatch = createCommandResult(FIRST_BATCH, 0)
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, createCommandResult(FIRST_BATCH, 0), 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -154,7 +153,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def thirdBatch = [new Document('_id', 7)]
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch, 42), 7, 3, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, createCommandResult(firstBatch, 42), 7, 3, 0, CODEC,
                 null, connectionSource, connectionA)
         def batch = nextBatch(cursor)
 
@@ -204,7 +203,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch), 1, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 1, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -228,8 +227,8 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connectionSource = getAsyncConnectionSource(connection)
 
         when:
-        def firstBatch = createCommandCursorResult([], CURSOR_ID)
-        def cursor = new AsyncCommandBatchCursor<Document>(firstBatch, 3, 0, 0, CODEC, null, connectionSource, connection)
+        def firstBatch = createCommandResult([], CURSOR_ID)
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 3, 0, 0, CODEC, null, connectionSource, connection)
         def batch = nextBatch(cursor)
 
         then:
@@ -271,7 +270,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch), 3, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 3, 0, 0, CODEC,
                 null, connectionSource, connection)
         def batch = nextBatch(cursor)
 
@@ -314,7 +313,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connectionSource = getAsyncConnectionSource(serverType, connectionA, connectionB)
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(FIRST_BATCH, 42), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, createCommandResult(FIRST_BATCH, 42), 0, 0, 0, CODEC,
                 null, connectionSource, connectionA)
         def batch = nextBatch(cursor)
 
@@ -358,7 +357,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connectionA)
         def batch = nextBatch(cursor)
 
@@ -396,7 +395,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connection = referenceCountedAsyncConnection()
         def connectionSource = getAsyncConnectionSourceWithResult(ServerType.STANDALONE) { [null, MONGO_EXCEPTION] }
         def firstBatch = createCommandResult()
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -415,7 +414,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult()
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connection)
 
         then:
@@ -441,7 +440,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult()
-        def cursor = new AsyncCommandBatchCursor<Document>(createCommandCursorResult(firstBatch), 0, 0, 0, CODEC,
+        def cursor = new AsyncCommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 0, 0, CODEC,
                 null, connectionSource, connectionA)
 
         then:
@@ -501,17 +500,6 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
     private static BsonDocument getMoreResponse(results, cursorId = CURSOR_ID) {
         createCommandResult(results, cursorId, "nextBatch")
-    }
-
-    private static CommandCursorResult createCommandCursorResult(final List<?> results, final Long cursorId,
-            final String fieldNameContainingBatch = "firstBatch", final ServerAddress serverAddress = SERVER_ADDRESS) {
-        createCommandCursorResult(createCommandResult(results, cursorId, fieldNameContainingBatch), fieldNameContainingBatch, serverAddress)
-    }
-
-    private static CommandCursorResult createCommandCursorResult(final BsonDocument commandResult,
-            final String fieldNameContainingBatch = "firstBatch",
-            final ServerAddress serverAddress = SERVER_ADDRESS) {
-        new CommandCursorResult(serverAddress, fieldNameContainingBatch, commandResult)
     }
 
     private static BsonDocument createCommandResult(List<?> results = FIRST_BATCH, Long cursorId = CURSOR_ID,

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommandBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommandBatchCursorSpecification.groovy
@@ -49,6 +49,7 @@ class CommandBatchCursorSpecification extends Specification {
         given:
         def connection = Mock(Connection) {
             _ * getDescription() >> Stub(ConnectionDescription) {
+                getServerAddress() >> SERVER_ADDRESS
                 getMaxWireVersion() >> 4
             }
         }
@@ -61,7 +62,7 @@ class CommandBatchCursorSpecification extends Specification {
         def cursorId = 42
 
         def result = createCommandResult([], cursorId)
-        def cursor = new CommandBatchCursor<Document>(SERVER_ADDRESS, result, 0, batchSize, maxTimeMS, CODEC,
+        def cursor = new CommandBatchCursor<Document>(result, 0, batchSize, maxTimeMS, CODEC,
                 null, connectionSource, connection)
         def expectedCommand = new BsonDocument('getMore': new BsonInt64(cursorId))
                 .append('collection', new BsonString(NAMESPACE.getCollectionName()))
@@ -94,6 +95,7 @@ class CommandBatchCursorSpecification extends Specification {
         given:
         def connection = Mock(Connection) {
             _ * getDescription() >> Stub(ConnectionDescription) {
+                getServerAddress() >> SERVER_ADDRESS
                 getMaxWireVersion() >> 4
             }
             _ * command(*_) >> { throw new MongoSocketException('No MongoD', SERVER_ADDRESS) }
@@ -105,7 +107,7 @@ class CommandBatchCursorSpecification extends Specification {
         connectionSource.retain() >> connectionSource
 
         def firstBatch = createCommandResult([], 42)
-        def cursor = new CommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 2, 100, CODEC,
+        def cursor = new CommandBatchCursor<Document>(firstBatch, 0, 2, 100, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -125,6 +127,7 @@ class CommandBatchCursorSpecification extends Specification {
         given:
         def connection = Mock(Connection) {
             _ * getDescription() >> Stub(ConnectionDescription) {
+                getServerAddress() >> SERVER_ADDRESS
                 getMaxWireVersion() >> 4
             }
         }
@@ -135,7 +138,7 @@ class CommandBatchCursorSpecification extends Specification {
         connectionSource.retain() >> connectionSource
 
         def firstBatch = createCommandResult([], 42)
-        def cursor = new CommandBatchCursor<Document>(SERVER_ADDRESS, firstBatch, 0, 2, 100, CODEC,
+        def cursor = new CommandBatchCursor<Document>(firstBatch, 0, 2, 100, CODEC,
                 null, connectionSource, connection)
 
         when:
@@ -165,7 +168,7 @@ class CommandBatchCursorSpecification extends Specification {
         Object getMoreResponse = emptyGetMoreCommandResponse(getMoreResponseHasCursor ? 42 : 0)
 
         when:
-        CommandBatchCursor<Document> cursor = new CommandBatchCursor<>(SERVER_ADDRESS, commandResult, 0, 0, 0, CODEC,
+        CommandBatchCursor<Document> cursor = new CommandBatchCursor<>(commandResult, 0, 0, 0, CODEC,
                 null, connSource, conn)
         List<Document> batch = cursor.next()
 
@@ -227,7 +230,7 @@ class CommandBatchCursorSpecification extends Specification {
         String exceptionMessage = 'test'
 
         when:
-        CommandBatchCursor<Document> cursor = new CommandBatchCursor<>(SERVER_ADDRESS, initialResult, 0, 0, 0, CODEC,
+        CommandBatchCursor<Document> cursor = new CommandBatchCursor<>(initialResult, 0, 0, 0, CODEC,
                 null, connSource, conn)
         List<Document> batch = cursor.next()
 
@@ -279,6 +282,7 @@ class CommandBatchCursorSpecification extends Specification {
         Connection mockConn = Mock(Connection) {
             getDescription() >> Stub(ConnectionDescription) {
                 getMaxWireVersion() >> getMaxWireVersionForServerVersion(serverVersion.getVersionList())
+                getServerAddress() >> SERVER_ADDRESS
             }
         }
         mockConn.retain() >> {


### PR DESCRIPTION
Just pass the command result (BsonDocument) to the cursor.

Part of a wider Command Cursor refactoring

JAVA-5159